### PR TITLE
docs: open source ready — README, LICENSE, CONTRIBUTING, deploy guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing to Nemo
+
+Nemo is open source under Apache 2.0. Contributions are welcome.
+
+## Getting started
+
+```bash
+git clone https://github.com/tinkrtailor/nemo.git
+cd nemo
+cargo build --workspace
+cargo test --workspace
+```
+
+### Prerequisites
+
+- Rust (edition 2024, 1.85+)
+- Docker with buildx (for image builds)
+- Postgres (for integration tests, or use the in-memory store)
+
+### Project layout
+
+```
+control-plane/     Rust library + binary (API server + loop engine)
+cli/               Rust binary (nemo CLI)
+images/            Dockerfiles (control-plane, agent-base, sidecar)
+terraform/         Hetzner + k3s provisioning
+.nemo/prompts/     Agent prompt templates
+```
+
+## Development workflow
+
+1. Create a branch: `git checkout -b feat/your-feature`
+2. Make changes
+3. Run checks:
+   ```bash
+   cargo clippy --workspace -- -D warnings
+   cargo test --workspace
+   ```
+4. Commit with [conventional commits](https://www.conventionalcommits.org/): `feat(api): add endpoint`
+5. Push and open a PR against `main`
+
+## Code standards
+
+- **Clippy clean**: `cargo clippy --workspace -- -D warnings` must pass with zero warnings
+- **Tests pass**: `cargo test --workspace` must pass
+- **Conventional commits**: all commit messages follow the format `type(scope): description`
+- **No secrets**: never commit credentials, API keys, or private keys
+- **Complete implementations**: no TODOs, no stubs, no placeholders. If you can't finish it, don't start it.
+
+## Architecture decisions
+
+- **Rust** for control plane and CLI (performance, type safety, single binary)
+- **axum** for the API server
+- **sqlx** with Postgres for state (compile-time query checking where possible)
+- **kube-rs** for Kubernetes API interaction
+- **thiserror** for error types (no `unwrap()` in library code)
+- **Trait-based mocking** for tests (no mocking frameworks)
+
+## Testing
+
+- Unit tests: inline `#[cfg(test)]` modules
+- Integration tests: `tests/` directory in each crate
+- State store tests use `MemoryStateStore` (no Postgres required)
+- K8s tests use `k8s-openapi` fixtures
+
+## What we look for in PRs
+
+- Does it solve a real problem?
+- Is the implementation complete (not partial)?
+- Are edge cases handled?
+- Do tests cover the new behavior?
+- Is the commit history clean and conventional?
+
+## Reporting issues
+
+Open an issue on GitHub. Include:
+- What you expected to happen
+- What actually happened
+- Steps to reproduce
+- Nemo version (`nemo --version`)
+- Relevant logs (`nemo logs <loop_id>`)
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the Apache 2.0 License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2025-2026 Gunnar Gylfason
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,147 +1,77 @@
 # Nemo
 
-A convergent, multi-model adversarial build system. Push a spec, get a clean PR.
+**Push a spec, get a clean PR.** Nemo is a convergent loop that pits AI models against each other until your code is right.
 
-```
-nemo start spec.md       # implement, create PR
+Claude implements. OpenAI reviews. If the reviewer finds issues, the implementer fixes them. The loop runs until the reviewer finds nothing wrong. Then you get a PR.
+
+Different models have different blind spots. Claude never reviews its own work.
+
+```bash
+nemo start spec.md       # implement + PR
 nemo ship spec.md        # implement + auto-merge
-nemo harden spec.md      # harden spec, merge spec PR
+nemo harden spec.md      # harden the spec itself
 ```
 
-## What it does
+## The loop
 
-You write a spec. Nemo runs a convergent loop: **Claude implements**, **OpenAI reviews**. If the reviewer finds issues, the implementer fixes them. The loop runs until the reviewer finds nothing wrong. Then you get a PR.
+```
+Round 1: Claude implements  -->  tests run  -->  OpenAI reviews  -->  3 issues
+Round 2: Claude fixes       -->  tests run  -->  OpenAI reviews  -->  1 issue
+Round 3: Claude fixes       -->  tests run  -->  OpenAI reviews  -->  clean
+--> PR created
+```
 
-Your agents keep working when you stop.
+The exit condition is quality, not iteration count. If it takes 2 rounds, great. If it takes 12, that's fine too. The reviewer decides when the code is ready.
 
 ## How it works
 
 ```
-Engineer's Mac                    Hetzner k3s Cluster
-┌──────────┐                      ┌─────────────────────────────┐
-│ nemo CLI │──── HTTPS ──────────>│ API Server (axum)           │
-│          │                      │ Loop Engine (reconciler)    │
-│ nemo start spec.md              │ Postgres                    │
-│ nemo status                     │                             │
-│ nemo ship spec.md               │ ┌─────────┐ ┌─────────┐    │
-│                                 │ │Implement│ │ Review  │    │
-│                                 │ │  Job    │ │  Job    │    │
-│                                 │ │(Claude) │ │(OpenAI) │    │
-│                                 │ └─────────┘ └─────────┘    │
-└──────────┘                      └─────────────────────────────┘
+Your machine                         Your cluster (k3s)
++----------+                         +-----------------------------+
+| nemo CLI | -------- HTTPS -------> | API Server                  |
+|          |                         | Loop Engine                 |
++----------+                         | Postgres                    |
+                                     |                             |
+                                     |  +----------+ +----------+  |
+                                     |  |Implement | | Review   |  |
+                                     |  |  (Claude)| | (OpenAI) |  |
+                                     |  +----------+ +----------+  |
+                                     +-----------------------------+
 ```
 
-The convergent loop:
+Your agents keep working when you close your laptop. The control plane runs on a VPS, dispatches agent jobs as K8s pods, and watches them until convergence.
 
+## Quick start
+
+```bash
+# Deploy (once)
+./build-images.sh --tag 0.1.0
+cd terraform && op run --env-file=.env.1password -- terraform apply
+
+# Set up your repo (once)
+cd ~/your-repo
+nemo init                    # generates nemo.toml
+nemo auth                    # pushes Claude + OpenAI + SSH credentials
+
+# Use it (daily)
+nemo start spec.md           # PR appears when it converges
+nemo status                  # watch progress
+nemo logs <id>               # stream agent output
 ```
-Round 1: Claude implements → tests run → OpenAI reviews → issues found
-Round 2: Claude fixes issues → tests run → OpenAI reviews → issues found
-Round 3: Claude fixes issues → tests run → OpenAI reviews → CLEAN
-→ PR created
-```
 
-Cross-model adversarial review: Claude never reviews its own work. A different model (OpenAI) does the review. Different models have different blind spots. This catches more bugs than single-model review.
-
-## Architecture
-
-- **Control plane** (Rust): API server + loop engine, deployed as two k3s Deployments
-- **CLI** (Rust): `nemo` binary, runs on your machine
-- **Agent jobs** (K8s Jobs): each stage runs as a separate pod with an auth sidecar
-- **Auth sidecar** (Go): proxies model API calls (injects auth), proxies git push (SSH key), logs all egress
-- **Terraform**: provisions Hetzner VPS, k3s, Postgres, control plane, bare repo
+See [docs/deploy.md](docs/deploy.md) for full deployment guide.
 
 ## Three verbs
 
-| Command | What happens | Terminal state |
-|---------|-------------|----------------|
-| `nemo harden spec.md` | Adversarial spec review loop | HARDENED |
-| `nemo start spec.md` | Implement → test → review loop, PR | CONVERGED |
-| `nemo ship spec.md` | Same loop + auto-merge on convergence | SHIPPED |
+| Command | What happens | Result |
+|---------|-------------|--------|
+| `nemo harden spec.md` | OpenAI audits the spec, Claude revises. Loop until clean. | Hardened spec merged |
+| `nemo start spec.md` | Claude implements, tests run, OpenAI reviews. Loop until clean. | PR created |
+| `nemo ship spec.md` | Same as start + auto-merge when the loop converges | Code shipped |
 
-Add `--harden` to `start` or `ship` to run spec hardening first.
-
-## Prerequisites
-
-- [1Password CLI](https://developer.1password.com/docs/cli) (`op`) — all secrets managed via 1Password
-- [Terraform](https://developer.hashicorp.com/terraform/install) >= 1.5
-- [Docker](https://docs.docker.com/get-docker/) with buildx
-- A "Nemo" vault in 1Password with these items:
-
-| 1Password Item | Fields | Purpose |
-|----------------|--------|---------|
-| `hetzner-cloud` | `credential` | Hetzner Cloud API token |
-| `nemo-domain` | `domain`, `email` | Control plane domain + ACME email |
-| `nemo-repo` | `ssh_url` | Git repo URL (SSH format) |
-| `github-pat` | `credential` | GitHub PAT for PR creation/merge |
-| `nemo-deploy-key` | `private_key` | SSH deploy key for repo access |
-| `github-registry` | `username`, `pat` | GHCR credentials for image push/pull |
-| `ssh-public-key` | `public_key` | SSH public key for server access |
-
-## Deploy
-
-### 1. Build and push images
-
-```bash
-./build-images.sh --tag 0.1.0
-```
-
-Builds 3 images (control-plane, agent-base, sidecar), pushes to GHCR. Authenticates via 1Password automatically.
-
-Options: `--no-push` (local only), `--only control-plane` (single image), `--platform linux/arm64` (override arch).
-
-### 2. Provision the cluster
-
-```bash
-cd terraform
-op run --env-file=.env.1password -- terraform init
-op run --env-file=.env.1password -- terraform apply
-```
-
-This provisions a Hetzner VPS, installs k3s with Traefik, deploys Postgres, the control plane (API + loop engine), and initializes the bare repo. Takes ~5 minutes on first run.
-
-### 3. Set up each engineer
-
-```bash
-cd ~/your-monorepo
-nemo init                    # generates nemo.toml
-nemo auth                    # pushes credentials (Claude, OpenAI, SSH) to cluster
-```
-
-### 4. Use it
-
-```bash
-nemo start spec.md           # PR appears when done
-nemo ship spec.md            # implement + auto-merge on convergence
-nemo harden spec.md          # harden spec before implementing
-nemo status                  # check progress
-nemo logs <loop_id>          # stream job logs
-```
-
-### Teardown (save money)
-
-```bash
-cd terraform
-op run --env-file=.env.1password -- terraform destroy
-```
-
-Destroys the server but keeps the Hetzner volume (Postgres data persists). Next `terraform apply` reattaches the same volume — no data loss.
-
-### Update (new images)
-
-```bash
-./build-images.sh --tag 0.2.0
-cd terraform
-op run --env-file=.env.1password -- terraform apply \
-  -var="control_plane_image=ghcr.io/tinkrtailor/nemo-control-plane:0.2.0" \
-  -var="agent_base_image=ghcr.io/tinkrtailor/nemo-agent-base:0.2.0" \
-  -var="sidecar_image=ghcr.io/tinkrtailor/nemo-sidecar:0.2.0"
-```
-
-All three images must be updated together to avoid version skew. The build script enforces this by only tagging `:latest` when building all images (not with `--only`).
+Add `--harden` to `start` or `ship` to harden the spec before implementing.
 
 ## Configuration
-
-Three layers, each overriding the previous:
 
 ```toml
 # nemo.toml (repo root, checked in)
@@ -150,8 +80,8 @@ name = "my-project"
 default_branch = "main"
 
 [models]
-implementor = "claude-opus-4"
-reviewer = "gpt-5.4"
+implementor = "claude-opus-4"    # who writes the code
+reviewer = "gpt-5.4"            # who reviews it
 
 [services.api]
 path = "api/"
@@ -164,66 +94,78 @@ test = "cd web && npm test"
 
 ```toml
 # ~/.nemo/config.toml (per engineer)
+server_url = "https://nemo.yourdomain.com"
+api_key = "your-api-key"
+
 [identity]
 name = "Alice"
 email = "alice@example.com"
-
-server_url = "https://nemo.internal"
-api_key = "your-api-key"
 ```
 
-## Security
+## Security model
 
-- **Auth sidecar**: model credentials and SSH keys never touch the agent container
-- **Egress logging**: all outbound traffic from agent pods is logged
-- **Read-only reviewer**: review stage mounts the worktree read-only
-- **Per-engineer credentials**: each engineer's subscriptions are scoped to their jobs
+Agent containers get open internet but **no secrets**. Model API auth and git push go through a localhost sidecar that injects credentials at the network level. Secrets never touch the agent filesystem.
 
-## Convergence data
+- **Auth sidecar** proxies all model API calls and git pushes
+- **Read-only reviewer** mounts the worktree read-only in review stage
+- **Per-engineer credentials** scoped to each engineer's jobs
+- **Egress logging** on all outbound traffic from agent pods
 
-Built through the exact process it automates:
+## Architecture
 
-| Lane | Rounds | Findings | Spec hardening |
-|------|--------|----------|----------------|
-| A (core loop) | 28 | 124 | 2 rounds |
-| B (infrastructure) | 25 | 88 | 11 rounds |
-| C (agent runtime) | 21 | 107 | 11 rounds |
-| Integration | 7 | 12 | — |
-| **Total** | **81** | **331** | — |
-
-331 production bugs caught by cross-model adversarial review. The exit condition is quality, not iteration count.
-
-## Project structure
+- **Control plane** (Rust): API server (axum) + loop engine, two k3s Deployments
+- **CLI** (Rust): `nemo` binary on your machine
+- **Agent jobs** (K8s pods): each stage runs as a separate pod
+- **Auth sidecar** (Go): credential injection + egress proxy
+- **Terraform**: provisions Hetzner VPS, k3s, Postgres, Traefik, cert-manager
 
 ```
 control-plane/          Rust: API server + loop engine
   src/api/              REST endpoints (axum)
   src/loop_engine/      Convergent loop driver + reconciler
-  src/state/            Postgres state store
-  src/git/              Git operations (worktrees, branches, PRs)
-  src/k8s/              K8s job builder + client
-  src/config/           Three-layer config loading
+  src/state/            Postgres state store (sqlx)
+  src/git/              Git operations (bare repo, worktrees)
+  src/k8s/              Job builder + K8s client (kube-rs)
+  src/config/           Three-layer config (cluster, repo, engineer)
   migrations/           SQL migrations
 
-cli/                    Rust: nemo CLI binary
-  src/commands/         start, ship, harden, status, auth, init, etc.
+cli/                    Rust: nemo CLI
+  src/commands/         start, ship, harden, status, logs, auth, init
 
 images/
-  base/                 Agent base Docker image + entrypoint
-  sidecar/              Auth sidecar (Go)
+  base/                 Agent base image (Claude Code + OpenCode + tools)
+  sidecar/              Auth sidecar (Go, ~10MB static binary)
+  control-plane/        Control plane image (Rust, multi-stage build)
 
-terraform/              Hetzner + k3s + Postgres + control plane
-
-.nemo/prompts/          Default prompt templates (implement, review, etc.)
-
-specs/                  Hardened specs (Lane A, B, C, V2 DAG)
-docs/                   Design doc, architecture diagrams, convergence learnings
+terraform/              Hetzner + k3s + Traefik + Postgres + control plane
+.nemo/prompts/          Agent prompt templates
 ```
+
+## Built with Nemo
+
+Nemo was built through the exact process it automates. Three parallel implementation lanes, each hardened by cross-model adversarial review:
+
+| Lane | What | Rounds | Findings |
+|------|------|--------|----------|
+| A | Core loop engine | 28 | 124 |
+| B | Infrastructure (k8s, terraform) | 25 | 88 |
+| C | Agent runtime (sidecar, entrypoint) | 21 | 107 |
+| Integration | Cross-lane compatibility | 7 | 12 |
+| **Total** | | **81 rounds** | **331 findings** |
+
+331 production bugs caught by cross-model review before first deploy.
+
+## Documentation
+
+- [Deployment guide](docs/deploy.md) -- full setup with 1Password or env vars
+- [Architecture](docs/architecture.md) -- system design and component interaction
+- [Design document](docs/design.md) -- product decisions and rationale
+- [Convergence data](docs/convergence-learnings.md) -- what we learned from 81 rounds
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md). TL;DR: conventional commits, clippy clean, tests pass, no placeholders.
 
 ## License
 
-Apache 2.0
-
-## Status
-
-V1 — built, adversarially reviewed (331 findings, 81 rounds), ready for deployment.
+[Apache 2.0](LICENSE)

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,117 @@
+# Deploying Nemo
+
+## Prerequisites
+
+- [1Password CLI](https://developer.1password.com/docs/cli) (`op`) for secrets management (or set `TF_VAR_*` env vars manually)
+- [Terraform](https://developer.hashicorp.com/terraform/install) >= 1.5
+- [Docker](https://docs.docker.com/get-docker/) with buildx
+- A Hetzner Cloud account
+- A domain with DNS you control
+- GitHub PAT with repo + PR permissions
+- SSH deploy key for your repo
+
+## Option A: 1Password (recommended)
+
+Create a "Nemo" vault in 1Password with these items:
+
+| 1Password Item | Fields | Purpose |
+|----------------|--------|---------|
+| `hetzner-cloud` | `credential` | Hetzner Cloud API token |
+| `nemo-domain` | `domain`, `email` | Control plane domain + ACME email |
+| `nemo-repo` | `ssh_url` | Git repo URL (SSH format) |
+| `github-pat` | `credential` | GitHub PAT for PR creation/merge |
+| `nemo-deploy-key` | `private_key` | SSH deploy key for repo access |
+| `github-registry` | `username`, `pat` | GHCR credentials for image push/pull |
+| `ssh-public-key` | `public_key` | SSH public key for server access |
+
+Then use `op run` to inject secrets:
+
+```bash
+cd terraform
+op run --env-file=.env.1password -- terraform init
+op run --env-file=.env.1password -- terraform apply
+```
+
+## Option B: Environment variables
+
+Set `TF_VAR_*` variables directly:
+
+```bash
+export TF_VAR_hetzner_api_token="your-token"
+export TF_VAR_domain="nemo.yourdomain.com"
+export TF_VAR_acme_email="you@example.com"
+export TF_VAR_git_repo_url="git@github.com:you/repo.git"
+export TF_VAR_git_host_token="ghp_..."
+export TF_VAR_repo_ssh_private_key="$(cat ~/.ssh/nemo_deploy_key)"
+export TF_VAR_ssh_public_keys='["ssh-ed25519 AAAA..."]'
+
+cd terraform
+terraform init
+terraform apply
+```
+
+## Build and push images
+
+```bash
+./build-images.sh --tag 0.1.0
+```
+
+Builds 3 images (control-plane, agent-base, sidecar), pushes to GHCR.
+
+Options:
+- `--no-push` — build locally, don't push
+- `--only control-plane` — build a single image
+- `--platform linux/arm64` — override platform (default: linux/amd64)
+
+## Provision the cluster
+
+```bash
+cd terraform
+op run --env-file=.env.1password -- terraform init
+op run --env-file=.env.1password -- terraform apply
+```
+
+This provisions a Hetzner VPS, installs k3s with Traefik, deploys Postgres, the control plane (API + loop engine), and initializes the bare repo. Takes ~5 minutes on first run.
+
+## Set up engineers
+
+Each engineer runs once:
+
+```bash
+cd ~/your-monorepo
+nemo init                    # generates nemo.toml
+nemo auth                    # pushes credentials (Claude, OpenAI, SSH) to cluster
+```
+
+## Teardown (save money)
+
+```bash
+cd terraform
+op run --env-file=.env.1password -- terraform destroy
+```
+
+Destroys the server but keeps the Hetzner volume (Postgres data persists). Next `terraform apply` reattaches the same volume, no data loss.
+
+## Update (new images)
+
+```bash
+./build-images.sh --tag 0.2.0
+cd terraform
+op run --env-file=.env.1password -- terraform apply \
+  -var="control_plane_image=ghcr.io/tinkrtailor/nemo-control-plane:0.2.0" \
+  -var="agent_base_image=ghcr.io/tinkrtailor/nemo-agent-base:0.2.0" \
+  -var="sidecar_image=ghcr.io/tinkrtailor/nemo-sidecar:0.2.0"
+```
+
+All three images must be updated together to avoid version skew.
+
+## Bring your own Kubernetes
+
+If you already have a k8s cluster, you don't need the Hetzner terraform. Deploy the control plane images directly:
+
+1. Build images: `./build-images.sh --tag 0.1.0`
+2. Create a Postgres database
+3. Deploy the control plane (API server + loop engine) with the images
+4. Point the CLI at your server: `server_url` in `~/.nemo/config.toml`
+
+The terraform in this repo is a reference deployment, not a requirement.


### PR DESCRIPTION
## Summary

- Rewrite README as the hero page (value prop first, loop visualization, quick start)
- Move deployment ops to docs/deploy.md (1Password + env var options + BYOK8s)
- Apache 2.0 LICENSE file
- CONTRIBUTING.md (dev workflow, code standards, what we look for in PRs)

Open core model: Apache 2.0 + future Nemo Cloud hosted offering.