### PR TITLE
ci(pages): add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: [main]
     paths: ['www/**']
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` to the Pages workflow so it can be triggered manually
- Needed for initial deployment since Pages was just enabled and there's no recent push to `www/`

## Test plan
- [x] Workflow YAML is valid
- [ ] After merge, run `gh workflow run pages.yml` to trigger first deploy