### PR TITLE
fix(images): enable multi-arch builds (amd64 + arm64)

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -63,7 +63,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --tag, -t <version>   Image tag (required)"
             echo "  --no-push             Build locally, don't push to GHCR"
             echo "  --only <image>        Build only: control-plane, agent-base, or sidecar"
-            echo "  --platform <plat>     Override platform (default: linux/amd64)"
+            echo "  --platform <plat>     Override platform (default: linux/amd64,linux/arm64)"
             echo "  -h, --help            Show this help"
             exit 0
             ;;
@@ -123,8 +123,8 @@ else
     docker buildx use "$BUILDER_NAME"
 fi
 
-# Hetzner runs amd64
-PLATFORM="${PLATFORM_OVERRIDE:-linux/amd64}"
+# Multi-arch: support both amd64 (most clouds) and arm64 (Hetzner CAX/CCX, Graviton)
+PLATFORM="${PLATFORM_OVERRIDE:-linux/amd64,linux/arm64}"
 
 info "Building images with tag: $IMAGE_TAG"
 info "Platform: $PLATFORM"
@@ -163,7 +163,12 @@ build_image() {
     if [ "$PUSH" = true ]; then
         build_cmd+=(--push)
     else
-        build_cmd+=(--load)
+        # --load only works with single-platform builds
+        if [[ "$PLATFORM" == *","* ]]; then
+            warn "Multi-platform build without --push: images stay in buildx cache only (use --no-push --platform linux/amd64 to load locally)"
+        else
+            build_cmd+=(--load)
+        fi
     fi
 
     build_cmd+=("$context")

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -3,14 +3,14 @@
 # NFR-1: Target < 2 GB compressed via multi-stage build
 
 # Stage 1: Install tools that need compilation
-FROM python:3.12-slim@sha256:6294405dc2a6612366092848c41c2ec7f9ba7368b618ee707dcf7f75c1d07830 AS python-tools
+FROM python:3.12-slim AS python-tools
 RUN pip install --no-cache-dir yq
 
 # Stage 2: Get opencode binary from published image
-FROM ghcr.io/anomalyco/opencode:latest@sha256:f19f2c5902ae1b20667b707d495dfc80d4c30761b52f4d8a66ed4f7778693d74 AS opencode-src
+FROM ghcr.io/anomalyco/opencode:latest AS opencode-src
 
 # Stage 3: Final image
-FROM node:22-bookworm-slim@sha256:263e93fe2e7f5edc1e0f6647fcc679aa88e7cdd25d93bccf65f97ab68eacb93b
+FROM node:22-bookworm-slim
 
 # FR-1: System packages
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/images/control-plane/Dockerfile
+++ b/images/control-plane/Dockerfile
@@ -2,7 +2,7 @@
 # Produces a minimal image with the nemo-server binary.
 # Same binary runs as API server or loop engine based on args.
 
-FROM rust:1.88-bookworm@sha256:8aa70d1416cf5b1cff4b95ec6c57f1c5e4e649a3b53d616a26695cda6fbb46bc AS builder
+FROM rust:1.88-bookworm AS builder
 
 WORKDIR /build
 
@@ -26,7 +26,7 @@ RUN touch control-plane/src/main.rs control-plane/src/lib.rs && \
     cargo build --release --package nemo-control-plane
 
 # Runtime image: minimal Debian with TLS certs
-FROM debian:bookworm-slim@sha256:ee5473f786ff8a4e03409277c276b459b29afa55a84268bef55342c4f705b7ad
+FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/images/sidecar/Dockerfile
+++ b/images/sidecar/Dockerfile
@@ -2,7 +2,7 @@
 # FR-14: Single static binary (~10 MB)
 # NFR-2: Under 15 MB
 
-FROM golang:1.22-alpine@sha256:7030196c59858ca8942e85aa2f68599240d58282ee35eb795609738a1e242c1f AS builder
+FROM golang:1.22-alpine AS builder
 
 WORKDIR /build
 COPY go.mod go.sum* ./


### PR DESCRIPTION
## Summary

- Default build platform changed from `linux/amd64` to `linux/amd64,linux/arm64`
- Removed platform-specific SHA digest pins from all Dockerfiles (pinned digests only resolve to one arch)
- Handles `--load` incompatibility with multi-platform builds

## Context

Reitun team reported ImagePullBackOff on their Hetzner CCX23 (ARM) server. Two issues:
1. GHCR packages were private (fixed: now public)
2. Images were built for amd64 only (fixed: this PR)

## After merge

Rebuild and push images:
```bash
./build-images.sh --tag 0.1.1
```