### PR TITLE
chore: release 0.1.1 — multi-arch images

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -57,9 +57,9 @@ module "nautiloop" {
   acme_email = "me@mydomain.com"     # required if domain is set
 
   # Optional: images (defaults to latest public GHCR)
-  control_plane_image = "ghcr.io/tinkrtailor/nemo-control-plane:0.1.0"
-  agent_base_image    = "ghcr.io/tinkrtailor/nemo-agent-base:0.1.0"
-  sidecar_image       = "ghcr.io/tinkrtailor/nemo-sidecar:0.1.0"
+  control_plane_image = "ghcr.io/tinkrtailor/nemo-control-plane:0.1.1"
+  agent_base_image    = "ghcr.io/tinkrtailor/nemo-agent-base:0.1.1"
+  sidecar_image       = "ghcr.io/tinkrtailor/nemo-sidecar:0.1.1"
 }
 ```
 
@@ -75,9 +75,9 @@ module "nautiloop" {
 | `repo_ssh_private_key` | no | auto-generated | SSH deploy key. If null, generates ED25519 |
 | `domain` | no | `null` | Domain for TLS. null = HTTP on raw IP:8080 |
 | `acme_email` | no | `null` | Let's Encrypt email. Required if domain is set |
-| `control_plane_image` | no | `ghcr.io/tinkrtailor/nemo-control-plane:0.1.0` | Control plane image |
-| `agent_base_image` | no | `ghcr.io/tinkrtailor/nemo-agent-base:0.1.0` | Agent base image |
-| `sidecar_image` | no | `ghcr.io/tinkrtailor/nemo-sidecar:0.1.0` | Auth sidecar image |
+| `control_plane_image` | no | `ghcr.io/tinkrtailor/nemo-control-plane:0.1.1` | Control plane image |
+| `agent_base_image` | no | `ghcr.io/tinkrtailor/nemo-agent-base:0.1.1` | Agent base image |
+| `sidecar_image` | no | `ghcr.io/tinkrtailor/nemo-sidecar:0.1.1` | Auth sidecar image |
 | `k3s_version` | no | `v1.32.13+k3s1` | k3s version (v1.32+ required) |
 | `postgres_password` | no | auto-generated | Postgres password |
 | `postgres_volume_size` | no | `20` | Postgres volume size (Gi) |
@@ -150,7 +150,7 @@ Set `domain = "nemo.mydomain.com"` and `acme_email = "you@example.com"`. The mod
 ## Build and push images
 
 ```bash
-./build-images.sh --tag 0.1.0
+./build-images.sh --tag 0.1.1
 ```
 
 Builds 3 images (control-plane, agent-base, sidecar), pushes to GHCR.

--- a/terraform/examples/existing-server/variables.tf
+++ b/terraform/examples/existing-server/variables.tf
@@ -50,17 +50,17 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nemo-control-plane:0.1.0"
+  default     = "ghcr.io/tinkrtailor/nemo-control-plane:0.1.1"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nemo-agent-base:0.1.0"
+  default     = "ghcr.io/tinkrtailor/nemo-agent-base:0.1.1"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nemo-sidecar:0.1.0"
+  default     = "ghcr.io/tinkrtailor/nemo-sidecar:0.1.1"
 }

--- a/terraform/examples/hetzner/variables.tf
+++ b/terraform/examples/hetzner/variables.tf
@@ -77,19 +77,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nemo-control-plane:0.1.0"
+  default     = "ghcr.io/tinkrtailor/nemo-control-plane:0.1.1"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nemo-agent-base:0.1.0"
+  default     = "ghcr.io/tinkrtailor/nemo-agent-base:0.1.1"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nemo-sidecar:0.1.0"
+  default     = "ghcr.io/tinkrtailor/nemo-sidecar:0.1.1"
 }
 
 variable "k3s_version" {

--- a/terraform/modules/nautiloop/variables.tf
+++ b/terraform/modules/nautiloop/variables.tf
@@ -79,19 +79,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nemo-control-plane:0.1.0"
+  default     = "ghcr.io/tinkrtailor/nemo-control-plane:0.1.1"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nemo-agent-base:0.1.0"
+  default     = "ghcr.io/tinkrtailor/nemo-agent-base:0.1.1"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nemo-sidecar:0.1.0"
+  default     = "ghcr.io/tinkrtailor/nemo-sidecar:0.1.1"
 }
 
 # --- Optional: tuning ---

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -71,19 +71,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nemo-control-plane:0.1.0"
+  default     = "ghcr.io/tinkrtailor/nemo-control-plane:0.1.1"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nemo-agent-base:0.1.0"
+  default     = "ghcr.io/tinkrtailor/nemo-agent-base:0.1.1"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nemo-sidecar:0.1.0"
+  default     = "ghcr.io/tinkrtailor/nemo-sidecar:0.1.1"
 }
 
 variable "k3s_version" {


### PR DESCRIPTION
## Summary

Bump default image tags from 0.1.0 to 0.1.1 across the module, examples, and docs.

## What changed in 0.1.1

- Multi-arch images: `linux/amd64` + `linux/arm64` (fixes ARM servers like Hetzner CCX/CAX)
- GHCR packages set to public (fixes 401 on anonymous pull)
- Removed platform-specific SHA digest pins from Dockerfiles

## After merge

Tag the release:
```bash
git tag v0.1.1
git push origin v0.1.1
```