### PR TITLE
fix(www): change hero CTA to nemo start

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -53,12 +53,12 @@
 
         <div class="hero-cta">
           <span class="dollar">$</span>
-          <code>terraform apply</code>
-          <button class="copy-btn" data-copy="terraform apply" aria-label="Copy command">
+          <code>nemo start spec.md</code>
+          <button class="copy-btn" data-copy="nemo start spec.md" aria-label="Copy command">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="5" y="2" width="9" height="9" rx="1.5"/><path d="M2 6v7.5A1.5 1.5 0 003.5 15H11"/></svg>
           </button>
         </div>
-        <p class="hero-cta-sub">Four required variables. One command. <a href="#deploy">See the deploy guide</a></p>
+        <p class="hero-cta-sub">Push a spec. Get a clean PR. <a href="#deploy">Deploy in 5 minutes</a></p>
 
         <div class="verb-badges">
           <span class="verb-badge">nemo harden</span>


### PR DESCRIPTION
Hero CTA now shows `nemo start spec.md` instead of `terraform apply`. The product action is nemo, not terraform.