### PR TITLE
fix(ci): use cross for linux-arm64, fix openssl-sys build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,20 +16,25 @@ jobs:
   # Build CLI + server binaries for 4 targets
   binaries:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             suffix: linux-amd64
+            use-cross: false
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             suffix: linux-arm64
+            use-cross: true
           - target: x86_64-apple-darwin
             os: macos-latest
             suffix: darwin-amd64
+            use-cross: false
           - target: aarch64-apple-darwin
             os: macos-14
             suffix: darwin-arm64
+            use-cross: false
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -39,12 +44,9 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Install cross-compilation tools (Linux ARM64)
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          echo 'CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc' >> "$GITHUB_ENV"
+      - name: Install cross
+        if: matrix.use-cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
 
       - name: Cache cargo
         uses: actions/cache@v4
@@ -55,8 +57,13 @@ jobs:
             target
           key: ${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Build
+      - name: Build (native)
+        if: "!matrix.use-cross"
         run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Build (cross)
+        if: matrix.use-cross
+        run: cross build --release --target ${{ matrix.target }}
 
       - name: Package binaries
         run: |
@@ -81,6 +88,7 @@ jobs:
   # Build multi-arch Docker images
   images:
     strategy:
+      fail-fast: false
       matrix:
         image:
           - name: control-plane


### PR DESCRIPTION
The linux-arm64 binary build failed because openssl-sys needs cross-compiled headers. Uses `cross` tool instead of bare cargo for ARM64 Linux builds. Also adds `fail-fast: false` so one build failure doesn't cancel everything.