### PR TITLE
fix(ci): switch reqwest to rustls, drop openssl system dep

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,22 +44,12 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Install cross-compilation deps (Linux ARM64)
+      - name: Install cross-compilation toolchain (Linux ARM64)
         if: matrix.cross-compile
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-          sudo dpkg --add-architecture arm64
-          # Add arm64 package sources
-          echo 'deb [arch=arm64] http://ports.ubuntu.com/ noble main restricted universe' | sudo tee /etc/apt/sources.list.d/arm64.list
-          sudo apt-get update
-          sudo apt-get install -y libssl-dev:arm64 pkg-config
+          sudo apt-get install -y gcc-aarch64-linux-gnu
           echo 'CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc' >> "$GITHUB_ENV"
-          echo 'PKG_CONFIG_SYSROOT_DIR=/usr/aarch64-linux-gnu' >> "$GITHUB_ENV"
-          echo 'PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig' >> "$GITHUB_ENV"
-          echo 'OPENSSL_DIR=/usr/aarch64-linux-gnu' >> "$GITHUB_ENV"
-          echo 'OPENSSL_INCLUDE_DIR=/usr/include/aarch64-linux-gnu' >> "$GITHUB_ENV"
-          echo 'OPENSSL_LIB_DIR=/usr/lib/aarch64-linux-gnu' >> "$GITHUB_ENV"
 
       - name: Cache cargo
         uses: actions/cache@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ tower = { version = "0.5" }
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 
 # HTTP client
-reqwest = { version = "0.12", features = ["json", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
 
 # CLI
 clap = { version = "4", features = ["derive"] }


### PR DESCRIPTION
Root cause: reqwest defaulted to native-tls (OpenSSL), which needs cross-compiled system headers for ARM64. Switching to rustls makes TLS pure Rust — no system deps, clean cross-compilation.