### PR TITLE
ci: native ARM runners for Docker builds (no QEMU)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
           name: binaries-${{ matrix.suffix }}
           path: dist/*.tar.gz
 
-  # Build multi-arch Docker images
+  # Build Docker images — native runners per platform, then merge manifests
   images:
     strategy:
       fail-fast: false
@@ -98,12 +98,16 @@ jobs:
           - name: sidecar
             dockerfile: images/sidecar/Dockerfile
             context: images/sidecar
-    runs-on: ubuntu-latest
+        platform:
+          - runner: ubuntu-latest
+            docker: linux/amd64
+            suffix: amd64
+          - runner: ubuntu-24.04-arm
+            docker: linux/arm64
+            suffix: arm64
+    runs-on: ${{ matrix.platform.runner }}
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -119,22 +123,53 @@ jobs:
         id: version
         run: echo "tag=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
-      - name: Build and push
+      - name: Build and push (single platform)
         uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.image.context }}
           file: ${{ matrix.image.dockerfile }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform.docker }}
           push: true
           tags: |
-            ${{ env.REGISTRY }}/nautiloop-${{ matrix.image.name }}:${{ steps.version.outputs.tag }}
-            ${{ env.REGISTRY }}/nautiloop-${{ matrix.image.name }}:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+            ${{ env.REGISTRY }}/nautiloop-${{ matrix.image.name }}:${{ steps.version.outputs.tag }}-${{ matrix.platform.suffix }}
+          cache-from: type=gha,scope=${{ matrix.image.name }}-${{ matrix.platform.suffix }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}-${{ matrix.platform.suffix }}
+
+  # Merge per-platform images into multi-arch manifests
+  manifests:
+    needs: [images]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: [control-plane, agent-base, sidecar]
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version
+        id: version
+        run: echo "tag=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Create multi-arch manifest
+        run: |
+          TAG=${{ steps.version.outputs.tag }}
+          IMAGE=${{ env.REGISTRY }}/nautiloop-${{ matrix.image }}
+          docker manifest create ${IMAGE}:${TAG} \
+            ${IMAGE}:${TAG}-amd64 \
+            ${IMAGE}:${TAG}-arm64
+          docker manifest push ${IMAGE}:${TAG}
+          docker manifest create ${IMAGE}:latest \
+            ${IMAGE}:${TAG}-amd64 \
+            ${IMAGE}:${TAG}-arm64
+          docker manifest push ${IMAGE}:latest
 
   # Create GitHub release with binaries
   release:
-    needs: [binaries, images]
+    needs: [binaries, manifests]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -142,6 +177,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: dist
+          pattern: binaries-*
           merge-multiple: true
 
       - name: Generate checksums


### PR DESCRIPTION
Split image builds into per-platform jobs on native runners, then merge into multi-arch manifests. No more QEMU.

| Before | After |
|--------|-------|
| 1 job per image, QEMU for ARM64 | 2 jobs per image (amd64 + arm64 native) + manifest merge |
| control-plane ARM64: ~45min via QEMU | control-plane ARM64: ~5min native |
| QEMU flaky on large Rust builds | Native compilation, reliable |

The `ubuntu-24.04-arm` runner compiles Rust natively on ARM64.