### PR TITLE
feat(auth): support OpenAI OAuth credentials from opencode

### DIFF
--- a/cli/src/commands/auth.rs
+++ b/cli/src/commands/auth.rs
@@ -56,12 +56,20 @@ pub async fn run(
                     .unwrap_or_else(|| candidates[0].clone())
             }
             "openai" => {
-                // OpenCode / OpenAI credential paths (checked in priority order)
+                // OpenCode / OpenAI credential paths (checked in priority order).
+                // The opencode OAuth bundle (~/.local/share/opencode/auth.json)
+                // is preferred when present so users on a ChatGPT plan don't
+                // need to mint an API key. We push the JWT access token; the
+                // control plane extracts `openai.access` from the bundle and
+                // the sidecar uses it as a Bearer token against api.openai.com.
                 let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+                let data_dir = std::env::var("XDG_DATA_HOME")
+                    .unwrap_or_else(|_| format!("{home}/.local/share"));
                 let config_dir =
                     std::env::var("XDG_CONFIG_HOME").unwrap_or_else(|_| format!("{home}/.config"));
                 let candidates = [
-                    format!("{config_dir}/opencode/credentials.json"), // opencode reviewer auth
+                    format!("{data_dir}/opencode/auth.json"), // opencode OAuth bundle
+                    format!("{config_dir}/opencode/credentials.json"), // opencode reviewer auth (raw key)
                     format!("{config_dir}/openai/credentials.json"),   // direct OpenAI
                 ];
                 candidates
@@ -82,7 +90,8 @@ pub async fn run(
             match *provider {
                 "claude" => eprintln!("  Run: claude login"),
                 "openai" => {
-                    eprintln!("  Create {cred_path} with your OpenAI API key as content")
+                    eprintln!("  Either: log in via opencode (writes ~/.local/share/opencode/auth.json),");
+                    eprintln!("  or create {cred_path} with your OpenAI API key as content");
                 }
                 "ssh" => eprintln!("  Run: ssh-keygen -t ed25519"),
                 _ => {}

--- a/control-plane/src/api/handlers.rs
+++ b/control-plane/src/api/handlers.rs
@@ -453,16 +453,31 @@ pub async fn upsert_credentials(
         // Store verbatim — not an API key
         raw_content
     } else if raw_content.starts_with('{') {
-        // Try to extract api_key / key / apiKey from JSON
+        // Try to extract api_key / key / apiKey / OAuth access token from JSON.
+        // The opencode OAuth bundle for OpenAI looks like:
+        //   { "openai": { "type": "oauth", "access": "<jwt>", "refresh": "...", "expires": ... } }
+        // For that shape we extract `openai.access` so the sidecar can use it
+        // as a Bearer token. NOTE: the access token is short-lived (~24h) and
+        // the control plane does not currently refresh it — re-run `nemo auth`
+        // when loops hit AWAITING_REAUTH.
         if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&raw_content) {
-            parsed
-                .get("api_key")
-                .or_else(|| parsed.get("key"))
-                .or_else(|| parsed.get("apiKey"))
-                .or_else(|| parsed.get("ANTHROPIC_API_KEY"))
-                .or_else(|| parsed.get("OPENAI_API_KEY"))
-                .and_then(|v| v.as_str())
+            let nested_oauth_access = parsed
+                .get("openai")
+                .and_then(|v| v.get("access"))
+                .and_then(|v| v.as_str());
+
+            nested_oauth_access
                 .map(|s| s.to_string())
+                .or_else(|| {
+                    parsed
+                        .get("api_key")
+                        .or_else(|| parsed.get("key"))
+                        .or_else(|| parsed.get("apiKey"))
+                        .or_else(|| parsed.get("ANTHROPIC_API_KEY"))
+                        .or_else(|| parsed.get("OPENAI_API_KEY"))
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string())
+                })
                 .unwrap_or(raw_content)
         } else {
             raw_content


### PR DESCRIPTION
## Summary

Lets users on a ChatGPT plan run `nemo auth --openai` **without minting an OpenAI API key**, by reading the opencode OAuth bundle at `~/.local/share/opencode/auth.json`. Mirrors how Claude OAuth credentials already work today.

Motivated by trying to use Nautiloop end-to-end without paying for an OpenAI API key on top of an existing ChatGPT subscription.

## Changes

**CLI (`cli/src/commands/auth.rs`)**
- Add `~/.local/share/opencode/auth.json` to the openai credential candidate list (also honors `XDG_DATA_HOME`). Preferred over the raw-key `~/.config/opencode/credentials.json` when present.
- Updated the missing-credential hint to mention opencode.

**Control plane (`control-plane/src/api/handlers.rs`)**
- When the credential JSON matches the opencode OAuth shape:
  ```json
  { "openai": { "type": "oauth", "access": "<jwt>", "refresh": "...", "expires": ... } }
  ```
  extract `openai.access` as the secret value. Existing extractors (`api_key`, `OPENAI_API_KEY`, etc.) remain as fallbacks.

**Sidecar:** no changes needed — the JWT access token is a valid `Bearer` token against `api.openai.com`.

## Limitation (follow-up)

The OAuth access token is short-lived (~24h). The control plane does **not** currently refresh it. When loops hit `AWAITING_REAUTH`, the user re-runs `nemo auth`. Same UX as Claude OAuth today.

A proper fix would be a server-side refresher in the control plane that watches `expires` and POSTs to OpenAI's token endpoint with the stored refresh token. Happy to do that as a follow-up PR if desired — kept this one minimal so it's easy to land.

## Test plan

- [x] `cargo build -p nemo-cli -p nautiloop-control-plane`
- [x] `cargo test -p nemo-cli -p nautiloop-control-plane` (106 passed)
- [ ] Manual: `nemo auth --openai` against a v0.2.x nautiloop install with only `~/.local/share/opencode/auth.json` present (no API key file). Verify credential is registered and a loop using gpt-5.x reviewer can hit the model.