### PR TITLE
fix: control plane git fetch — enum decode panic + missing SSH mounts

### DIFF
--- a/control-plane/src/state/postgres.rs
+++ b/control-plane/src/state/postgres.rs
@@ -9,7 +9,7 @@ use tokio::sync::Mutex;
 use uuid::Uuid;
 
 use super::{LoopFlag, StateStore};
-use crate::error::{NautiloopError, Result};
+use crate::error::Result;
 use crate::types::{
     EngineerCredential, LogEvent, LoopKind, LoopRecord, LoopState, RoundRecord, SubState,
 };
@@ -38,49 +38,6 @@ impl PgStateStore {
     /// Run database migrations.
     pub async fn run_migrations(&self) -> std::result::Result<(), sqlx::migrate::MigrateError> {
         sqlx::migrate!("./migrations").run(&self.pool).await
-    }
-}
-
-/// Helper to parse LoopState from a string. Returns error on unknown values (Finding #12).
-fn parse_loop_state(s: &str) -> Result<LoopState> {
-    match s {
-        "PENDING" => Ok(LoopState::Pending),
-        "HARDENING" => Ok(LoopState::Hardening),
-        "AWAITING_APPROVAL" => Ok(LoopState::AwaitingApproval),
-        "IMPLEMENTING" => Ok(LoopState::Implementing),
-        "TESTING" => Ok(LoopState::Testing),
-        "REVIEWING" => Ok(LoopState::Reviewing),
-        "CONVERGED" => Ok(LoopState::Converged),
-        "FAILED" => Ok(LoopState::Failed),
-        "CANCELLED" => Ok(LoopState::Cancelled),
-        "PAUSED" => Ok(LoopState::Paused),
-        "AWAITING_REAUTH" => Ok(LoopState::AwaitingReauth),
-        "HARDENED" => Ok(LoopState::Hardened),
-        "SHIPPED" => Ok(LoopState::Shipped),
-        unknown => Err(NautiloopError::Internal(format!(
-            "Corrupt DB: unknown loop_state '{unknown}'"
-        ))),
-    }
-}
-
-fn parse_sub_state(s: &str) -> Result<SubState> {
-    match s {
-        "DISPATCHED" => Ok(SubState::Dispatched),
-        "RUNNING" => Ok(SubState::Running),
-        "COMPLETED" => Ok(SubState::Completed),
-        unknown => Err(NautiloopError::Internal(format!(
-            "Corrupt DB: unknown sub_state '{unknown}'"
-        ))),
-    }
-}
-
-fn parse_loop_kind(s: &str) -> Result<LoopKind> {
-    match s {
-        "harden" => Ok(LoopKind::Harden),
-        "implement" => Ok(LoopKind::Implement),
-        unknown => Err(NautiloopError::Internal(format!(
-            "Corrupt DB: unknown loop_kind '{unknown}'"
-        ))),
     }
 }
 
@@ -124,12 +81,13 @@ fn row_to_loop_record(row: &PgRow) -> Result<LoopRecord> {
         spec_path: row.get("spec_path"),
         spec_content_hash: row.get("spec_content_hash"),
         branch: row.get("branch"),
-        kind: parse_loop_kind(row.get::<String, _>("kind").as_str())?,
-        state: parse_loop_state(row.get::<String, _>("state").as_str())?,
-        sub_state: row
-            .get::<Option<String>, _>("sub_state")
-            .map(|s| parse_sub_state(&s))
-            .transpose()?,
+        // Postgres enum columns (loop_kind, loop_state, sub_state) decode
+        // through the sqlx::Type derives on LoopKind/LoopState/SubState in
+        // crate::types. Decoding them as `String` panics with
+        // "mismatched types ... is not compatible with SQL type `loop_kind`".
+        kind: row.get::<LoopKind, _>("kind"),
+        state: row.get::<LoopState, _>("state"),
+        sub_state: row.get::<Option<SubState>, _>("sub_state"),
         round: row.get("round"),
         max_rounds: row.get("max_rounds"),
         harden: row.get("harden"),
@@ -138,14 +96,8 @@ fn row_to_loop_record(row: &PgRow) -> Result<LoopRecord> {
         cancel_requested: row.get("cancel_requested"),
         approve_requested: row.get("approve_requested"),
         resume_requested: row.get("resume_requested"),
-        paused_from_state: row
-            .get::<Option<String>, _>("paused_from_state")
-            .map(|s| parse_loop_state(&s))
-            .transpose()?,
-        reauth_from_state: row
-            .get::<Option<String>, _>("reauth_from_state")
-            .map(|s| parse_loop_state(&s))
-            .transpose()?,
+        paused_from_state: row.get::<Option<LoopState>, _>("paused_from_state"),
+        reauth_from_state: row.get::<Option<LoopState>, _>("reauth_from_state"),
         failure_reason: row.get("failure_reason"),
         current_sha: row.get("current_sha"),
         session_id: row.get("session_id"),

--- a/terraform/modules/nautiloop/control-plane.tf
+++ b/terraform/modules/nautiloop/control-plane.tf
@@ -134,6 +134,14 @@ spec:
                   key: GIT_HOST_TOKEN
             - name: BARE_REPO_PATH
               value: /bare-repo
+            # The api-server shells out to `git fetch` against the upstream
+            # remote (which is configured as git@github.com:owner/repo.git in
+            # the bare repo). Without this, ssh has no key, no known_hosts,
+            # and falls over with "Host key verification failed". The repo-init
+            # job sets these up for the initial clone but the long-running
+            # control-plane pods need them too.
+            - name: GIT_SSH_COMMAND
+              value: "ssh -i /etc/git-ssh/id_ed25519 -o UserKnownHostsFile=/etc/git-ssh-known-hosts/known_hosts -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes"
           resources:
             requests:
               cpu: 100m
@@ -146,6 +154,12 @@ spec:
               mountPath: /bare-repo
             - name: nautiloop-config
               mountPath: /etc/nautiloop
+              readOnly: true
+            - name: git-ssh-key
+              mountPath: /etc/git-ssh
+              readOnly: true
+            - name: git-ssh-known-hosts
+              mountPath: /etc/git-ssh-known-hosts
               readOnly: true
           startupProbe:
             httpGet:
@@ -172,6 +186,13 @@ spec:
         - name: nautiloop-config
           configMap:
             name: nautiloop-config
+        - name: git-ssh-key
+          secret:
+            secretName: nautiloop-repo-ssh-key
+            defaultMode: 0400
+        - name: git-ssh-known-hosts
+          configMap:
+            name: nautiloop-ssh-known-hosts
 ---
 apiVersion: v1
 kind: Service
@@ -229,11 +250,22 @@ spec:
               value: /bare-repo
             - name: AGENT_IMAGE
               value: ${var.agent_base_image}
+            # See api-server above — the loop-engine also reconciles state by
+            # invoking `git fetch` against the SSH remote. Without this it
+            # crashes the same way.
+            - name: GIT_SSH_COMMAND
+              value: "ssh -i /etc/git-ssh/id_ed25519 -o UserKnownHostsFile=/etc/git-ssh-known-hosts/known_hosts -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes"
           volumeMounts:
             - name: bare-repo
               mountPath: /bare-repo
             - name: nautiloop-config
               mountPath: /etc/nautiloop
+              readOnly: true
+            - name: git-ssh-key
+              mountPath: /etc/git-ssh
+              readOnly: true
+            - name: git-ssh-known-hosts
+              mountPath: /etc/git-ssh-known-hosts
               readOnly: true
           resources:
             requests:
@@ -255,6 +287,13 @@ spec:
         - name: nautiloop-config
           configMap:
             name: nautiloop-config
+        - name: git-ssh-key
+          secret:
+            secretName: nautiloop-repo-ssh-key
+            defaultMode: 0400
+        - name: git-ssh-known-hosts
+          configMap:
+            name: nautiloop-ssh-known-hosts
 YAML
 }
 


### PR DESCRIPTION
## Summary

Two unrelated bugs that combine to make `nemo harden` totally unusable on a fresh nautiloop install. Fixing both in one PR because they have the same symptom (`Internal Server Error` from the API on the first command after install) and you can't validate one without the other.

Both reproduced live against a v0.2.1 nautiloop deployed via the terraform module against a brand-new Hetzner box.

## Bug 1 — `loop_kind` enum decode panic

`row_to_loop_record` decodes the `kind`, `state`, `sub_state`, `paused_from_state`, and `reauth_from_state` columns as `String`:

\`\`\`rust
kind: parse_loop_kind(row.get::<String, _>(\"kind\").as_str())?,
state: parse_loop_state(row.get::<String, _>(\"state\").as_str())?,
\`\`\`

But all five columns are Postgres enum types (\`loop_kind\`, \`loop_state\`, \`sub_state\`), and sqlx refuses to decode an enum column as \`String\`:

\`\`\`
thread 'tokio-rt-worker' panicked at control-plane/src/state/postgres.rs:127:35:
called \`Result::unwrap()\` on an \`Err\` value: ColumnDecode {
    index: \"\\\"kind\\\"\",
    source: \"mismatched types; Rust type \`alloc::string::String\` (as SQL type \`TEXT\`) is not compatible with SQL type \`loop_kind\`\"
}
\`\`\`

The api-server hit this the first time it tried to read a loop, and once a row existed in the table the loop-engine reconciler crashed in a loop on startup (CrashLoopBackoff).

The funny part: the \`LoopKind\`, \`LoopState\`, and \`SubState\` enums in \`crate::types\` already have \`#[derive(sqlx::Type)]\` with the right \`type_name\`. They were ready to decode directly — the row decoder just wasn't using them.

**Fix:** decode each enum column through its \`sqlx::Type\` impl instead of as \`String\`. The \`parse_loop_kind\` / \`parse_loop_state\` / \`parse_sub_state\` helpers had no other callers, so they're removed.

## Bug 2 — control-plane pods missing SSH key + known_hosts

The api-server and loop-engine deployments mount the bare repo PVC and shell out to \`git fetch\` against the remote that's configured in the bare repo (\`git@github.com:owner/repo.git\`). Neither pod has any SSH state — no \`~/.ssh\`, no key, no known_hosts. So every fetch fails with:

\`\`\`
$ kubectl exec deploy/nautiloop-api-server -- sh -c 'cd /bare-repo && git ls-remote origin'
Host key verification failed.
fatal: Could not read from remote repository.
\`\`\`

And the API returns:

\`\`\`
nemo harden specs/foo.md
Error: API error (500 Internal Server Error): {\"error\":\"Git operation failed: Host key verification failed.\\r\\nfatal: Could not read from remote repository.\"}
\`\`\`

The \`nautiloop-repo-init\` Job in the same module has the SSH key + known_hosts wired up correctly for the initial clone — the long-running control-plane pods were just missed.

**Fix:** mount \`nautiloop-repo-ssh-key\` (with \`defaultMode: 0400\` so ssh accepts the key) and the \`nautiloop-ssh-known-hosts\` ConfigMap into both Deployments, and set \`GIT_SSH_COMMAND\` so git uses them with \`-o IdentitiesOnly=yes -o StrictHostKeyChecking=yes\`. Mirrors what the repo-init Job already does.

## Test plan

- [x] \`cargo build -p nemo-cli -p nautiloop-control-plane\`
- [x] \`cargo test\` — all 106 tests pass
- [x] Manually reproduced both bugs against a live v0.2.1 install (api 500 + loop-engine CrashLoopBackoff)
- [x] Hot-patched the deployments via \`kubectl patch\` with the same volume + env shape this PR adds to the module — \`git ls-remote origin HEAD\` from inside the api-server pod now succeeds against \`github.com:Reitun/virdismat-mono.git\`
- [ ] Full clean apply of the patched module against a fresh box, then \`nemo harden specs/foo.md\` end-to-end (will run after merge + tag, since the consumer pins the module by tag)

## Suggested release

Cut \`v0.2.2\` after merge — both fixes are blocking for anyone doing a fresh install today.