### PR TITLE
fix(jobs): move agent HOME outside /work mount

### DIFF
--- a/control-plane/src/k8s/job_builder.rs
+++ b/control-plane/src/k8s/job_builder.rs
@@ -230,10 +230,17 @@ fn build_agent_env_vars(ctx: &LoopContext, stage: &StageConfig, is_test: bool) -
         env_var("ROUND", &ctx.round.to_string()),
         env_var("MAX_ROUNDS", &ctx.max_rounds.to_string()),
         env_var("LOOP_ID", &ctx.loop_id.to_string()),
-        // FR-27: Writable path env vars
-        env_var("HOME", "/work/home"),
-        env_var("XDG_CONFIG_HOME", "/work/home/.config"),
-        env_var("XDG_CACHE_HOME", "/work/home/.cache"),
+        // FR-27: Writable path env vars.
+        // HOME lives at /home/agent (NOT inside /work) so the home EmptyDir
+        // mount doesn't need to be created inside the worktree mount. For
+        // REVIEW/AUDIT stages /work is mounted read-only (FR-6), and a
+        // sub-mount inside a read-only mount fails at pod start with:
+        //   mkdirat .../rootfs/work/home: read-only file system
+        // because containerd cannot create the mountpoint inside the
+        // read-only worktree.
+        env_var("HOME", "/home/agent"),
+        env_var("XDG_CONFIG_HOME", "/home/agent/.config"),
+        env_var("XDG_CACHE_HOME", "/home/agent/.cache"),
         env_var("TMPDIR", "/tmp"),
         // FR-8: Proxy env vars for outbound traffic through sidecar egress logger
         env_var("HTTP_PROXY", "http://localhost:9092"),
@@ -428,7 +435,7 @@ fn build_agent_mounts(
         },
         VolumeMount {
             name: "home".to_string(),
-            mount_path: "/work/home".to_string(),
+            mount_path: "/home/agent".to_string(),
             ..Default::default()
         },
     ];
@@ -437,7 +444,7 @@ fn build_agent_mounts(
     if is_implement_or_revise {
         mounts.push(VolumeMount {
             name: "claude-session".to_string(),
-            mount_path: "/work/home/.claude".to_string(),
+            mount_path: "/home/agent/.claude".to_string(),
             read_only: Some(true),
             ..Default::default()
         });
@@ -712,7 +719,7 @@ mod tests {
         assert_eq!(find_env("ROUND").unwrap(), "2");
         assert_eq!(find_env("MAX_ROUNDS").unwrap(), "15");
         assert_eq!(find_env("LOOP_ID").unwrap(), ctx.loop_id.to_string());
-        assert_eq!(find_env("HOME").unwrap(), "/work/home");
+        assert_eq!(find_env("HOME").unwrap(), "/home/agent");
         assert_eq!(find_env("TMPDIR").unwrap(), "/tmp");
 
         // FR-8: Proxy env vars
@@ -900,7 +907,7 @@ mod tests {
         let job = build_job(&ctx, &stage, &cfg);
         let agent = &job.spec.unwrap().template.spec.unwrap().containers[0];
         let mounts = agent.volume_mounts.as_ref().unwrap();
-        let claude_mount = mounts.iter().find(|m| m.mount_path == "/work/home/.claude");
+        let claude_mount = mounts.iter().find(|m| m.mount_path == "/home/agent/.claude");
         assert!(
             claude_mount.is_some(),
             "Claude session should be mounted for implement"
@@ -927,7 +934,7 @@ mod tests {
         let job = build_job(&ctx, &stage, &cfg);
         let agent = &job.spec.unwrap().template.spec.unwrap().containers[0];
         let mounts = agent.volume_mounts.as_ref().unwrap();
-        assert!(mounts.iter().all(|m| m.mount_path != "/work/home/.claude"));
+        assert!(mounts.iter().all(|m| m.mount_path != "/home/agent/.claude"));
     }
 
     #[test]

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -48,17 +48,25 @@ RUN chmod +x /usr/local/bin/nautiloop-agent-entry
 # Prompts are embedded in the image as fallback defaults.
 COPY .nautiloop/prompts/ /etc/nautiloop/prompts/
 
-# Create agent user (UID 1000) for non-root execution (FR-25)
+# Create agent user (UID 1000) for non-root execution (FR-25).
 # node:22-bookworm-slim has UID/GID 1000 as 'node'. Reuse it.
-RUN mkdir -p /work/home && \
-    cp -a /home/node/. /work/home/ 2>/dev/null || true && \
-    usermod -l agent -d /work/home -s /bin/bash node && \
+#
+# HOME deliberately lives at /home/agent and NOT inside /work. /work is
+# mounted from the worktree at runtime (read-only for REVIEW/AUDIT, FR-6),
+# and a sub-mount inside a read-only mount fails at pod start because
+# containerd cannot create the mountpoint inside the read-only rootfs.
+RUN mkdir -p /home/agent && \
+    cp -a /home/node/. /home/agent/ 2>/dev/null || true && \
+    usermod -l agent -d /home/agent -s /bin/bash node && \
     groupmod -n agent node && \
-    chown -R agent:agent /work/home
+    chown -R agent:agent /home/agent
 
-# Writable directories that will be emptyDir mounts at runtime
-RUN mkdir -p /work /work/home /output /sessions /tmp/shared && \
-    chown -R agent:agent /work /output /sessions /tmp/shared
+# Writable directories that will be emptyDir mounts at runtime.
+# These must exist in the image because the agent container runs with
+# read_only_root_filesystem: true — containerd cannot create mountpoints
+# in a read-only rootfs.
+RUN mkdir -p /work /output /sessions /tmp/shared && \
+    chown -R agent:agent /work /output /sessions /tmp/shared /home/agent
 
 USER agent
 WORKDIR /work


### PR DESCRIPTION
## Summary

Agent Job pods can't start on REVIEW/AUDIT stages because the home EmptyDir is mounted *inside* the read-only worktree mount. Verified live against a fresh v0.2.3 install.

This is the next blocker after #43. Together with #40 and #43, this is the third \"fresh install can't run a single loop end-to-end\" fix.

## Repro

\`\`\`bash
$ nemo harden specs/foo.md
Started loop 97972880-…
$ kubectl -n nautiloop-jobs describe pod nautiloop-97972880-audit-r1-t2-...
Events:
  Normal   Created  Created container: init-iptables
  Normal   Started  Started container init-iptables
  Normal   Pulled   Container image \"...nautiloop-agent-base:0.2.3\" already present
  Normal   Created  Created container: agent
  Warning  Failed   Error: failed to create containerd task: failed to create shim task:
                    OCI runtime create failed: runc create failed: unable to start container
                    process: error during container init: error mounting
                    \".../volumes/kubernetes.io~empty-dir/home\" to rootfs at \"/work/home\":
                    create mountpoint for /work/home mount: make mountpoint \"/work/home\":
                    mkdirat .../rootfs/work/home: read-only file system
\`\`\`

\`nemo logs <loop-id>\` is empty because the agent never ran. Loop FAILS as \`BackoffLimitExceeded\`.

## Why it fails

\`build_agent_mounts\` produced this layout:

| Volume | Mount path | Notes |
|---|---|---|
| \`worktree\` | \`/work\` (subPath) | **read-only** for REVIEW/AUDIT (FR-6) |
| \`home\` | \`/work/home\` | EmptyDir, sub-mount inside read-only \`/work\` |
| \`claude-session\` | \`/work/home/.claude\` | implement/revise only |

Containerd has to create the \`/work/home\` mountpoint inside the rootfs to mount the home EmptyDir there. The rootfs at that path is the worktree, which is read-only. \`mkdirat\` fails. Agent container fails to start. Job retries 2x, hits BackoffLimitExceeded, loop FAILS.

The agent container also has \`read_only_root_filesystem: true\`, so even on stages where \`/work\` is *not* read-only, any mountpoint that needs to live in the rootfs has to already exist in the image — you can't \`mkdir\` it at runtime.

## Fix

Move HOME out of \`/work\` entirely, to \`/home/agent\`. Also conventional — there's no good reason for the agent's home directory to live inside the source tree.

\`\`\`diff
- env_var(\"HOME\", \"/work/home\"),
- env_var(\"XDG_CONFIG_HOME\", \"/work/home/.config\"),
- env_var(\"XDG_CACHE_HOME\", \"/work/home/.cache\"),
+ env_var(\"HOME\", \"/home/agent\"),
+ env_var(\"XDG_CONFIG_HOME\", \"/home/agent/.config\"),
+ env_var(\"XDG_CACHE_HOME\", \"/home/agent/.cache\"),

  VolumeMount {
      name: \"home\".to_string(),
-     mount_path: \"/work/home\".to_string(),
+     mount_path: \"/home/agent\".to_string(),
  },

  // claude-session for implement/revise
- mount_path: \"/work/home/.claude\".to_string(),
+ mount_path: \"/home/agent/.claude\".to_string(),
\`\`\`

The agent base image's Dockerfile needs to match — \`/home/agent\` must exist in the rootfs because of \`read_only_root_filesystem: true\`. Updated:

\`\`\`diff
- RUN mkdir -p /work/home && \\
-     cp -a /home/node/. /work/home/ 2>/dev/null || true && \\
-     usermod -l agent -d /work/home -s /bin/bash node && \\
+ RUN mkdir -p /home/agent && \\
+     cp -a /home/node/. /home/agent/ 2>/dev/null || true && \\
+     usermod -l agent -d /home/agent -s /bin/bash node && \\
      groupmod -n agent node && \\
-     chown -R agent:agent /work/home
+     chown -R agent:agent /home/agent

- RUN mkdir -p /work /work/home /output /sessions /tmp/shared && \\
-     chown -R agent:agent /work /output /sessions /tmp/shared
+ RUN mkdir -p /work /output /sessions /tmp/shared && \\
+     chown -R agent:agent /work /output /sessions /tmp/shared /home/agent
\`\`\`

## Test plan

- [x] \`cargo test -p nautiloop-control-plane\` — 106/106 pass (3 tests asserting on \`/work/home\` paths updated to match)
- [x] Manually reproduced StartError on a fresh v0.2.3 install
- [ ] End-to-end on the v0.2.4 install: agent container starts, audit stage runs, \`nemo logs <id>\` shows agent output (will run after merge + tag)

## Compat / migration

Both the control-plane binary and the agent base image must ship together. The control-plane env / mount path change references \`/home/agent\`, which only exists in the new image. Cutting a coordinated v0.2.4 (or whatever) is the cleanest path; mismatched versions will break.

## Suggested release

Cut \`v0.2.4\` after merge.