### PR TITLE
fix(agent-base): use glibc opencode build from upstream releases

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -19,19 +19,28 @@ RUN pip install --no-cache-dir yq
 # Pulling the glibc build directly from the upstream release tarball
 # sidesteps this and gets us reproducible, pinned versions.
 FROM debian:bookworm-slim AS opencode-src
-ARG TARGETARCH
+# TARGETARCH is populated by BuildKit (docker buildx). Default to amd64 so
+# plain `docker build` still works on amd64 hosts without requiring buildx.
+ARG TARGETARCH=amd64
 ARG OPENCODE_VERSION=v1.3.17
+# Pinned SHA256 digests for the two supported arches. If upstream replaces
+# a release asset (or a MITM tampers with it), the shasum check below fails
+# the build BEFORE we execute anything from the tarball. This is the whole
+# reason we verify before running `opencode --version`.
+ARG OPENCODE_SHA256_AMD64=19e540840cfd04afebed92cfe67dce0cd6c425ed5f729ef946e8071f776205a9
+ARG OPENCODE_SHA256_ARM64=345293ed29c703cf3c4b0e696db50c3586c973a4d4ff90f1db5b6cbbbb2cee4b
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 RUN set -eux; \
     case "$TARGETARCH" in \
-      amd64) asset="opencode-linux-x64.tar.gz" ;; \
-      arm64) asset="opencode-linux-arm64.tar.gz" ;; \
+      amd64) asset="opencode-linux-x64.tar.gz";   expected_sha="$OPENCODE_SHA256_AMD64" ;; \
+      arm64) asset="opencode-linux-arm64.tar.gz"; expected_sha="$OPENCODE_SHA256_ARM64" ;; \
       *)     echo "Unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; \
     esac; \
     curl -fsSL -o /tmp/opencode.tar.gz \
       "https://github.com/sst/opencode/releases/download/${OPENCODE_VERSION}/${asset}"; \
+    echo "${expected_sha}  /tmp/opencode.tar.gz" | sha256sum -c -; \
     mkdir -p /opt/opencode; \
     tar -xzf /tmp/opencode.tar.gz -C /opt/opencode opencode; \
     chmod +x /opt/opencode/opencode; \


### PR DESCRIPTION
## Summary

The agent base image ships a broken \`opencode\` binary. Every agent stage (audit, review, implement, etc.) fails with exit 127 and \`cannot execute: required file not found\` before doing any work. Verified live against a fresh v0.2.4 install.

This is the next blocker after #46. With \`/home/agent\` fixed, the agent container finally gets past StartError — only to immediately fail the first time \`nautiloop-agent-entry\` calls \`opencode\`.

## Repro

\`\`\`bash
$ nemo harden specs/foo.md
Started loop b053e15d-...
$ kubectl -n nautiloop-jobs logs <pod> -c agent
NAUTILOOP_RESULT:{
  \"stage\": \"audit\",
  \"data\": {
    \"exit_code\": 127,
    \"error\": \"/usr/local/bin/nautiloop-agent-entry: line 119: /usr/local/bin/opencode: cannot execute: required file not found\"
  }
}
\`\`\`

## Why it fails

The Dockerfile copies \`opencode\` from \`ghcr.io/anomalyco/opencode:latest\`, which ships the **musl (Alpine)** build. The final image is based on \`node:22-bookworm-slim\` (Debian/glibc). ABI mismatch:

\`\`\`bash
$ ldd /usr/local/bin/opencode
    libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (glibc — wrong source)
    libc.musl-x86_64.so.1 => not found
    /lib/ld-musl-x86_64.so.1 => /lib64/ld-linux-x86-64.so.2
\`\`\`

The binary's PT_INTERP points at \`/lib/ld-musl-x86_64.so.1\`, which bookworm does not have. Bash then reports the misleading \"required file not found\" error (that message comes from the kernel failing to load the ELF interpreter).

I tried the \"install musl on top of glibc\" workaround — it does not work. Once you get past the loader error, opencode tries to resolve ~60 C++ symbols from its musl-built libstdc++, and the Debian glibc-built libstdc++ cannot satisfy them. Example:

\`\`\`
Error relocating /usr/local/bin/opencode: __once_proxy: symbol not found
Error relocating /usr/local/bin/opencode: _ZSt20__throw_system_errori: symbol not found
... (50+ more)
\`\`\`

Trying to ship a musl binary on a glibc base is a dead end.

## Fix

Pull the **glibc** build directly from the upstream sst/opencode release tarball. sst publishes both variants explicitly:

\`\`\`
opencode-linux-x64-musl.tar.gz      <- what anomalyco ships
opencode-linux-x64.tar.gz           <- what we actually need
opencode-linux-arm64-musl.tar.gz
opencode-linux-arm64.tar.gz         <- arm64 glibc
\`\`\`

New \`opencode-src\` stage (based on \`debian:bookworm-slim\` so it shares the target platform's curl + ca-certs) fetches the right tarball for \`TARGETARCH\`, extracts the binary, and verifies it runs at build time. The main stage copies from there.

\`\`\`diff
- FROM ghcr.io/anomalyco/opencode:latest AS opencode-src
+ FROM debian:bookworm-slim AS opencode-src
+ ARG TARGETARCH
+ ARG OPENCODE_VERSION=v1.3.17
+ RUN apt-get update && apt-get install -y --no-install-recommends \\
+     curl ca-certificates && rm -rf /var/lib/apt/lists/*
+ RUN set -eux; \\
+     case \"\$TARGETARCH\" in \\
+       amd64) asset=\"opencode-linux-x64.tar.gz\" ;; \\
+       arm64) asset=\"opencode-linux-arm64.tar.gz\" ;; \\
+       *)     echo \"Unsupported TARGETARCH: \$TARGETARCH\" >&2; exit 1 ;; \\
+     esac; \\
+     curl -fsSL -o /tmp/opencode.tar.gz \\
+       \"https://github.com/sst/opencode/releases/download/\${OPENCODE_VERSION}/\${asset}\"; \\
+     mkdir -p /opt/opencode; \\
+     tar -xzf /tmp/opencode.tar.gz -C /opt/opencode opencode; \\
+     chmod +x /opt/opencode/opencode; \\
+     /opt/opencode/opencode --version
\`\`\`

Also added a \`/usr/local/bin/opencode --version\` call on the main stage right after the COPY — that way any future regression (wrong arch, wrong libc, truncated binary) fails the image build instead of shipping a broken binary and surfacing as exit 127 inside a loop.

## Test plan

- [x] Confirmed the musl binary is broken on the v0.2.4 image (ldd output above, reproduced in a debug pod)
- [x] Confirmed the glibc tarball from sst/opencode v1.3.17 runs cleanly on the same v0.2.4 rootfs (manual curl + extract + \`opencode --version\` → \`1.3.17\`)
- [ ] CI builds the image for amd64 and arm64
- [ ] End-to-end on v0.2.5 install: agent container starts, audit stage runs opencode successfully, loop reaches a real terminal state (HARDENED / FAILED with a real reason, not exit 127) — will run after merge + tag

## Version pinning

I pinned \`OPENCODE_VERSION=v1.3.17\`, the current latest. That's deliberate — \`latest\` in the old \`FROM ghcr.io/anomalyco/opencode:latest\` is exactly what let this regression slip in silently. Bumping is now an explicit one-line change.

## Suggested release

Cut \`v0.2.5\` after merge. Rebuilds the agent-base image with the correct binary. No control-plane changes.