### PR TITLE
chore: release 0.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-control-plane"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-cli"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["control-plane", "cli"]
 
 [workspace.package]
-version = "0.2.4"
+version = "0.2.5"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -57,9 +57,9 @@ module "nautiloop" {
   acme_email = "me@mydomain.com"     # required if domain is set
 
   # Optional: images (defaults to latest public GHCR)
-  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.2.4"
-  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.2.4"
-  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.2.4"
+  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.2.5"
+  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.2.5"
+  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.2.5"
 }
 ```
 
@@ -75,9 +75,9 @@ module "nautiloop" {
 | `repo_ssh_private_key` | no | auto-generated | SSH deploy key. If null, generates ED25519 |
 | `domain` | no | `null` | Domain for TLS. null = HTTP on raw IP:8080 |
 | `acme_email` | no | `null` | Let's Encrypt email. Required if domain is set |
-| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.2.4` | Control plane image |
-| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.2.4` | Agent base image |
-| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.2.4` | Auth sidecar image |
+| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.2.5` | Control plane image |
+| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.2.5` | Agent base image |
+| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.2.5` | Auth sidecar image |
 | `k3s_version` | no | `v1.32.13+k3s1` | k3s version (v1.32+ required) |
 | `postgres_password` | no | auto-generated | Postgres password |
 | `postgres_volume_size` | no | `20` | Postgres volume size (Gi) |
@@ -175,9 +175,9 @@ nemo auth                    # pushes credentials (Claude, OpenAI, SSH) to clust
 ```bash
 ./build-images.sh --tag 0.2.0
 terraform apply \
-  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.2.4" \
-  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.2.4" \
-  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.2.4"
+  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.2.5" \
+  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.2.5" \
+  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.2.5"
 ```
 
 All three images must be updated together to avoid version skew.

--- a/terraform/examples/existing-server/variables.tf
+++ b/terraform/examples/existing-server/variables.tf
@@ -50,17 +50,17 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.2.4"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.2.5"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.2.4"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.2.5"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.2.4"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.2.5"
 }

--- a/terraform/examples/hetzner/variables.tf
+++ b/terraform/examples/hetzner/variables.tf
@@ -77,19 +77,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.2.4"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.2.5"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.2.4"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.2.5"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.2.4"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.2.5"
 }
 
 variable "k3s_version" {

--- a/terraform/modules/nautiloop/variables.tf
+++ b/terraform/modules/nautiloop/variables.tf
@@ -79,19 +79,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.2.4"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.2.5"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.2.4"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.2.5"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.2.4"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.2.5"
 }
 
 # --- Optional: tuning ---

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -71,19 +71,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.2.4"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.2.5"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.2.4"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.2.5"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.2.4"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.2.5"
 }
 
 variable "k3s_version" {


### PR DESCRIPTION
Bump to 0.2.5. Includes #48 (opencode glibc build + SHA256 pinning — unblocks all agent stages on fresh installs).