### PR TITLE
fix(agent-entry): pipe prompt via stdin for opencode v1.3+

### DIFF
--- a/images/base/nautiloop-agent-entry
+++ b/images/base/nautiloop-agent-entry
@@ -107,6 +107,10 @@ check_sidecar() {
 # --- Helper: run CLI as child process, extract result, emit NAUTILOOP_RESULT: ---
 # Finding 1: exec replaces the process, preventing NAUTILOOP_RESULT emission.
 # Instead, run as child, capture output, extract final assistant payload.
+#
+# Optional env var STDIN_FILE: if set, redirect that file as the CLI's stdin.
+# Used by review/audit (opencode v1.3+ removed --prompt-file; the prompt has
+# to be piped in to avoid argv length limits on large specs/diffs).
 run_and_emit_result() {
     local stage_name="$1"
     shift
@@ -116,7 +120,11 @@ run_and_emit_result() {
 
     # Run CLI, capturing stdout and stderr separately
     set +e
-    "$@" > "$cli_stdout" 2>"$cli_stderr"
+    if [ -n "${STDIN_FILE:-}" ]; then
+        "$@" < "$STDIN_FILE" > "$cli_stdout" 2>"$cli_stderr"
+    else
+        "$@" > "$cli_stdout" 2>"$cli_stderr"
+    fi
     exit_code=$?
     set -e
 
@@ -168,12 +176,15 @@ case "$STAGE" in
     review|audit)
         # FR-6, FR-7: OpenCode for review/audit (read-only)
         export OPENCODE_PERMISSIONS='{"edit":"deny","bash":"deny","read":"allow"}'
-        # Use --prompt-file to avoid argv length limits on large specs/diffs
-        OPENCODE_ARGS=(run --format json --prompt-file "$PROMPT_FILE")
+        # opencode v1.3+ removed --prompt-file; the message is either a
+        # positional arg or piped in via stdin. We pipe via stdin to avoid
+        # argv length limits for large specs/diffs — same reasoning the
+        # original --prompt-file code had.
+        OPENCODE_ARGS=(run --format json)
         if [ -n "${SESSION_ID:-}" ]; then
             OPENCODE_ARGS+=(-s "$SESSION_ID")
         fi
-        run_and_emit_result "$STAGE" opencode "${OPENCODE_ARGS[@]}"
+        STDIN_FILE="$PROMPT_FILE" run_and_emit_result "$STAGE" opencode "${OPENCODE_ARGS[@]}"
         ;;
 
     test)


### PR DESCRIPTION
## Summary

Follow-up to #48. With the glibc opencode binary landed, the audit/review stages finally reach opencode — but they immediately exit 1 because the agent-entry script calls opencode with `--prompt-file`, a flag that no longer exists in opencode v1.3.x. opencode treats the remaining argv as a malformed invocation and prints its help text to stderr.

This is the last blocker identified so far on a fresh install. With this plus #48, the agent should actually complete its first audit round.

## Repro (against a fresh v0.2.5 install, module at `?ref=v0.2.5`)

```bash
$ nemo harden specs/foo.md
Started loop b239f5c5-...
$ kubectl -n nautiloop-jobs logs <pod> -c agent
NAUTILOOP_RESULT:{
  "stage": "audit",
  "data": {
    "exit_code": 1,
    "error": "opencode run [message..]\n\nrun opencode with a message\n\nPositionals:\n  message  message to send ...\nOptions:\n  --print-logs ... --pure ... --command ... -c, --continue ..."
  }
}
```

The error payload *is* opencode's help text — `yargs` prints help and exits 1 when it can't parse argv.

## Why it fails

[images/base/nautiloop-agent-entry](https://github.com/tinkrtailor/nautiloop/blob/main/images/base/nautiloop-agent-entry) line 172:

```bash
OPENCODE_ARGS=(run --format json --prompt-file "$PROMPT_FILE")
```

`--prompt-file` was a flag on whatever older opencode shipped by `ghcr.io/anomalyco/opencode:latest`. opencode v1.3.17 (pinned in #48) does not have it — `opencode run --help` lists only:

```
run opencode with a message

Positionals:
  message  message to send  [array] [default: []]

Options:
  --print-logs, --log-level, --pure, --command, -c/--continue,
  -s/--session, --fork, --share, -m/--model, --agent, --format,
  -f/--file, --title, --attach, -p/--password, --dir, --port,
  --variant, --thinking
```

The prompt has to be either a positional argument or piped via stdin.

## Fix

Pipe the prompt via stdin. Same intent as the original `--prompt-file` — avoids argv length limits on large specs and diffs (the whole reason the original code had it).

Two changes in `nautiloop-agent-entry`:

1. `run_and_emit_result` optionally honours a `STDIN_FILE` env var to redirect a file as the CLI's stdin. The default path (no `STDIN_FILE`) is unchanged so claude implement/revise calls behave identically.

2. The review/audit stage drops `--prompt-file` from `OPENCODE_ARGS` and prefixes the call with `STDIN_FILE="$PROMPT_FILE"`.

```diff
 review|audit)
     export OPENCODE_PERMISSIONS='{"edit":"deny","bash":"deny","read":"allow"}'
-    OPENCODE_ARGS=(run --format json --prompt-file "$PROMPT_FILE")
+    OPENCODE_ARGS=(run --format json)
     if [ -n "${SESSION_ID:-}" ]; then
         OPENCODE_ARGS+=(-s "$SESSION_ID")
     fi
-    run_and_emit_result "$STAGE" opencode "${OPENCODE_ARGS[@]}"
+    STDIN_FILE="$PROMPT_FILE" run_and_emit_result "$STAGE" opencode "${OPENCODE_ARGS[@]}"
     ;;
```

## Test plan

- [x] `bash -n` on the edited script: clean
- [x] Local bash smoke test of the `run_and_emit_result` stdin branch: redirects correctly, non-stdin path still works
- [x] In a debug pod against the exact v0.2.5 agent base rootfs:
  - `echo "..." | opencode run --format json` → streaming JSON events, clean exit
  - `opencode run --format json "..."` → same
- [x] **Bonus validation in the same debug run:** the OpenAI Platform API key credential plumbing (key → sidecar model proxy → api.openai.com) works end-to-end. The reviewer call completed with a real response. First time we've confirmed the sidecar chain actually works.
- [ ] End-to-end on v0.2.6 install: `nemo harden specs/foo.md` reaches a real terminal state (HARDENED, or a domain-level failure — not a CLI flag error)

## Notes for future-you

- Session continuation (`-s "$SESSION_ID"`) in v1.3.x expects a session ID of the form `ses_<hash>`. If the old nautiloop opencode stored session IDs in a different shape, round 2+ of multi-round loops may fail to resume. That's a separate bug we'll only see after round 1 completes cleanly.
- `OPENCODE_PERMISSIONS` env var may or may not still be honoured by v1.3.x — I didn't verify. If it isn't, the read-only sandbox for audit/review is weaker than intended (the sidecar still blocks egress and the agent has no network beyond the sidecar, but the CLI itself could edit files). Worth a follow-up but not blocking.

## Suggested release

Cut `v0.2.6` after merge. Agent-base image rebuild only; no control-plane changes.