### PR TITLE
fix(sidecar): bind /healthz to all interfaces so kubelet probes can reach it

### DIFF
--- a/images/sidecar/main.go
+++ b/images/sidecar/main.go
@@ -724,11 +724,26 @@ func main() {
 		Handler: &egressProxy{},
 	}
 
-	// FR-22: Health endpoint on :9093
+	// FR-22: Health endpoint on :9093.
+	//
+	// Bind to all interfaces (0.0.0.0), NOT 127.0.0.1. The kubelet startup
+	// probe (and any future readiness/liveness probes) connects via the pod
+	// IP, not loopback — a listener on 127.0.0.1:9093 only accepts traffic
+	// from inside the pod's loopback interface and refuses every probe with
+	// "connection refused". With native sidecars (initContainers +
+	// restartPolicy: Always) the startup probe strictly gates the agent
+	// container's start, so a permanently-failing probe means the agent
+	// never starts and the loop hangs forever in HARDENING/RUNNING.
+	//
+	// The model proxy (:9090), git SSH proxy (:9091), and egress logger
+	// (:9092) deliberately stay on 127.0.0.1 — they're only meant for the
+	// agent inside the same pod, and binding them to all interfaces would
+	// expand the attack surface for no benefit. Only /healthz needs to be
+	// reachable by the kubelet.
 	healthMux := http.NewServeMux()
 	healthMux.HandleFunc("/healthz", healthHandler)
 	healthServer := &http.Server{
-		Addr:    "127.0.0.1:9093",
+		Addr:    ":9093",
 		Handler: healthMux,
 	}
 
@@ -764,6 +779,10 @@ func main() {
 	// IMPORTANT: until `ready` is set, /healthz returns 503 — that's what
 	// gates the K8s native sidecar startupProbe and prevents the agent
 	// container from starting before every proxy port is listening.
+	// Probe loopback for the in-pod proxies and the wildcard listener for
+	// the health endpoint. These addresses must match the .Addr fields on
+	// the http.Server instances above (and the git SSH proxy listener) so
+	// the bind check is meaningful.
 	ports := []string{"127.0.0.1:9090", "127.0.0.1:9091", "127.0.0.1:9092", "127.0.0.1:9093"}
 	for _, addr := range ports {
 		bound := false


### PR DESCRIPTION
## Summary

Follow-up to #53 / v0.2.7. The native-sidecar pattern landed correctly, but the loop still hangs forever because the sidecar's health server is bound to `127.0.0.1:9093` and kubelet probes connect via the pod IP. Every probe fails with `connection refused`, the startup probe never passes, kubelet kills + restarts the sidecar in a loop, and the agent container never starts.

## Repro (against fresh v0.2.7 install)

```bash
$ nemo harden specs/foo.md
Started loop 7ee26411-...
$ kubectl -n nautiloop-jobs get pods
NAME                                   READY   STATUS     RESTARTS      AGE
nautiloop-7ee26411-audit-r1-t1-jf25n   0/2     Init:1/2   1 (28s ago)   92s
$ kubectl -n nautiloop-jobs describe pod ...
Events:
  Normal   Pulled       Container image "...nautiloop-sidecar:0.2.7" already present
  Warning  Unhealthy    Startup probe failed: Get "http://10.42.0.43:9093/healthz":
                        dial tcp 10.42.0.43:9093: connect: connection refused
                        (x25 over 101s)
  Normal   Killing      Init container auth-sidecar failed startup probe
  Normal   Created      Created container: auth-sidecar  (x2)
```

Loop sits in `HARDENING/RUNNING` until cancelled.

## Why it fails

`images/sidecar/main.go`:

```go
healthServer := &http.Server{
    Addr:    "127.0.0.1:9093",
    Handler: healthMux,
}
```

A listener on `127.0.0.1` only accepts traffic from inside the pod's loopback interface. The kubelet doesn't share the pod's network namespace — it probes via the pod IP (`10.42.0.43:9093` in the trace above), which arrives on the pod's `eth0` and gets refused because nothing on `eth0` is listening on 9093.

The sidecar's own logs prove this is purely a bind-address issue:

```
"starting auth sidecar"            2026-04-07T21:34:28.205Z
"git remote host: github.com..."   2026-04-07T21:34:28.205Z
"all ports ready, readiness file"  2026-04-07T21:34:28.207Z   <- ready=true 2ms after boot
"received shutdown signal..."      2026-04-07T21:35:28.734Z   <- killed by kubelet 60s later
"shutdown complete"                2026-04-07T21:35:28.734Z
```

By the time kubelet's first probe fires the listener has been up for >900ms. The sidecar is healthy. The probe is just talking to the wrong interface.

This was always wrong. In the pre-native-sidecar versions (≤ v0.2.6) the same `connection refused` events appeared in `kubectl describe pod` output — I noted them when filing #53 — but were tolerated long enough for the agent to do real work before the deployment-style liveness probe killed the container. v0.2.7's native sidecar pattern strictly gates the agent on the startup probe, so this latent bug becomes fatal.

## Fix

Bind the health server to `:9093` (all interfaces). The model proxy (`:9090`), git SSH proxy (`:9091`), and egress logger (`:9092`) deliberately stay on `127.0.0.1` — they're only meant for the agent inside the same pod, and binding them to all interfaces would expand the attack surface for no benefit. **Only `/healthz` needs to be reachable by the kubelet.**

```diff
- healthServer := &http.Server{
-     Addr:    "127.0.0.1:9093",
-     Handler: healthMux,
- }
+ healthServer := &http.Server{
+     Addr:    ":9093",
+     Handler: healthMux,
+ }
```

Comment block in the diff explains the asymmetry (loopback for proxies, wildcard for /healthz) so a future contributor doesn't "fix" the inconsistency back to broken.

The bind-check loop a few lines below still probes `127.0.0.1:9093`, which is fine — a `:9093` (0.0.0.0) listener accepts connections on loopback too, so the bind verification keeps working without changes.

## Test plan

- [x] Reproduced the connection-refused → startup-probe → restart loop on v0.2.7 (events captured above)
- [x] `go build` on the patched sidecar: clean
- [ ] End-to-end on v0.2.8 install: agent container actually starts, audit stage runs, loop reaches a terminal state. (Will run after merge + tag.)

## Suggested release

Cut `v0.2.8` after merge. Sidecar image rebuild only — no control plane or agent base changes.

## Followups not in this PR

- The line `{"level":"error","message":"SSH handshake failed: EOF",...}` from the very first millisecond of every sidecar boot is the kubelet (or some other prober) doing a TCP probe on the git SSH proxy `:9091`. It's harmless noise but adds confusion to every investigation. Worth filtering or downgrading to debug-level eventually — separate cosmetic issue.