### PR TITLE
fix(loop-engine): resolve current_sha from git when reconciler beats handler

### DIFF
--- a/control-plane/src/loop_engine/driver.rs
+++ b/control-plane/src/loop_engine/driver.rs
@@ -1368,6 +1368,39 @@ impl ConvergentLoopDriver {
             .ensure_worktree(&record.branch, &worktree_path)
             .await?;
 
+        // Resolve current_sha. The happy path is that POST /start already
+        // set it (create_branch -> set_current_sha before returning 201).
+        // But the handler has an inherent race: the loop row is inserted
+        // with current_sha = NULL *before* create_branch and set_current_sha
+        // run, so a reconciler tick that fires in that 1-3s window picks up
+        // the PENDING loop with no SHA and — via the old
+        // `record.current_sha.clone().unwrap_or_default()` path — dispatches
+        // a job with SHA="". The agent entrypoint correctly rejects that:
+        //
+        //     NAUTILOOP_ERROR: entrypoint: missing required environment
+        //     variables: SHA
+        //
+        // Loop then fails as BackoffLimitExceeded after the K8s Job retries.
+        //
+        // Fall back to resolving the branch tip from the bare repo. By the
+        // time we get here `ensure_worktree` has already succeeded for
+        // `record.branch`, so the branch is guaranteed to exist and
+        // `get_branch_sha` returns a real SHA.
+        let current_sha = match record.current_sha.clone() {
+            Some(sha) if !sha.is_empty() => sha,
+            _ => self
+                .git
+                .get_branch_sha(&record.branch)
+                .await?
+                .ok_or_else(|| {
+                    crate::error::NautiloopError::Internal(format!(
+                        "Failed to resolve current_sha for branch {} — \
+                         branch does not exist in bare repo",
+                        record.branch
+                    ))
+                })?,
+        };
+
         Ok(LoopContext {
             loop_id: record.id,
             engineer: record.engineer.clone(),
@@ -1375,7 +1408,7 @@ impl ConvergentLoopDriver {
             engineer_email,
             spec_path: record.spec_path.clone(),
             branch: record.branch.clone(),
-            current_sha: record.current_sha.clone().unwrap_or_default(),
+            current_sha,
             round: record.round as u32,
             max_rounds: record.max_rounds as u32,
             retry_count: record.retry_count as u32,
@@ -1494,7 +1527,12 @@ mod tests {
             paused_from_state: None,
             reauth_from_state: None,
             failure_reason: None,
-            current_sha: None,
+            // Matches the real /start handler, which always calls
+            // set_current_sha after create_branch before returning 201.
+            // The race-window case (current_sha = None reaching the
+            // reconciler) is covered by its own dedicated test below:
+            // test_build_context_falls_back_to_git_sha_when_record_missing_it
+            current_sha: Some("0000000000000000000000000000000000000000".to_string()),
             session_id: None,
             active_job_name: None,
             retry_count: 0,
@@ -1634,6 +1672,43 @@ mod tests {
 
         let updated = store.get_loop(record.id).await.unwrap().unwrap();
         assert_eq!(updated.sub_state, Some(SubState::Running));
+    }
+
+    /// Regression test for the POST /start race condition: if the reconciler
+    /// wins against the handler's set_current_sha call, `build_context` must
+    /// fall back to resolving the branch tip from git instead of shipping
+    /// SHA="" to the agent. Without this fallback, the agent container
+    /// exits with NAUTILOOP_ERROR: missing required environment variables:
+    /// SHA and the loop FAILs as BackoffLimitExceeded.
+    #[tokio::test]
+    async fn test_build_context_falls_back_to_git_sha_when_record_missing_it() {
+        let store = Arc::new(MemoryStateStore::new());
+        let dispatcher = Arc::new(MockJobDispatcher::new());
+        let git = Arc::new(MockGitOperations::new());
+
+        // Simulate the state the API handler produces before it has had
+        // the chance to call set_current_sha: the branch exists in the
+        // bare repo (create_branch ran) but the loop row still has
+        // current_sha = None.
+        git.set_branch_sha("agent/alice/test-abc12345", "deadbeefcafebabe")
+            .await;
+
+        let driver =
+            ConvergentLoopDriver::new(store, dispatcher, git, NautiloopConfig::default());
+
+        let mut record = make_pending_loop(true);
+        record.current_sha = None;
+
+        let ctx = driver.build_context(&record).await.unwrap();
+        assert_eq!(
+            ctx.current_sha, "deadbeefcafebabe",
+            "build_context should fall back to the branch tip in git when \
+             the record's current_sha is None (POST /start race window)"
+        );
+        assert!(
+            !ctx.current_sha.is_empty(),
+            "current_sha must NEVER reach the agent as an empty string"
+        );
     }
 
     #[tokio::test]
@@ -1999,6 +2074,12 @@ mod tests {
         record.sub_state = Some(SubState::Dispatched);
         record.round = 1;
         record.active_job_name = Some("review-job".to_string());
+        // Match the SHA seeded in the mock above so the has_diverged check
+        // during output ingestion doesn't false-positive. make_pending_loop
+        // now sets a placeholder current_sha (to exercise the common
+        // post-/start path), so ingestion tests that also seed a branch in
+        // the mock need to pin the record to the same value.
+        record.current_sha = Some("aabbccdd11223344".to_string());
         store.create_loop(&record).await.unwrap();
 
         // Create the round record (output is None initially)


### PR DESCRIPTION
## Summary

Follow-up to #56 (and in sequence with #40, #43, #46, #48, #51, #53). With the sidecar `/healthz` bind fixed, the agent container finally starts cleanly — and then immediately fails because the `SHA` env var is empty. This is a race in `POST /start` that has been latent for the entire chain of fixes but was masked by everything else failing earlier.

Verified live against a fresh v0.2.8 install: loop FAILs as `BackoffLimitExceeded` within ~30s of `nemo harden`, with the agent logs showing:

```
NAUTILOOP_ERROR: entrypoint: missing required environment variables: SHA
```

## The race

`POST /start` write order in `api/handlers.rs`:

```rust
// 1. insert loop row
// line 120: current_sha: None,
// line 146: state.store.create_loop(&record).await?;
//
// 2. create the git branch (network call, 1-3s)
// line 158: state.git.create_branch(&branch, &default_ref).await?;
//
// 3. backfill the SHA on the row
// line 171: state.store.set_current_sha(loop_id, &branch_sha).await?;
//
// 4. return 201 to the client
```

Between (1) and (3), the row exists in `loops` with `state=PENDING` and `current_sha=NULL`. The reconciler ticks on a timer. If a tick fires inside that 1-3s window:

1. Reconciler picks up the PENDING loop
2. Calls `handle_pending` → `build_context(&updated)`
3. `build_context` does `record.current_sha.clone().unwrap_or_default()` → `""`
4. Job is built with `env_var("SHA", "")`
5. Agent entry script checks `[ -z "${SHA:-}" ]` → `NAUTILOOP_ERROR` → exit 1
6. K8s Job retries twice → `BackoffLimitExceeded` → loop FAILs

The comment on `handlers.rs:169` is telling:

> "Persist the SHA via a narrow SQL update — never use update_loop() from /start because the reconciler may have already advanced the record."

The original author *knew* about the race but patched the wrong half — they made the SHA update robust to the reconciler advancing the record, without preventing the reconciler from dispatching jobs before the SHA was set.

## Why this is new in v0.2.8

This race has existed the entire time, but was hidden by every preceding blocker in the #40→#56 chain — the agent never got far enough in its lifecycle to exercise the `SHA` env var check. Now that #56 let the sidecar's /healthz probes pass and the native-sidecar lifecycle works end-to-end, the agent container actually starts and the latent bug is exposed.

## Fix

Make `build_context` resolve `current_sha` from the bare repo when the record doesn't have it yet. By the time `build_context` runs, it has just called `ensure_worktree(&record.branch, ...)` successfully — so the branch is guaranteed to exist in the bare repo, and `get_branch_sha` returns the real tip.

```diff
+ // Resolve current_sha. The happy path is that POST /start already
+ // set it (create_branch -> set_current_sha before returning 201).
+ // But the handler has an inherent race: the loop row is inserted
+ // with current_sha = NULL *before* create_branch and set_current_sha
+ // run, so a reconciler tick that fires in that 1-3s window picks up
+ // the PENDING loop with no SHA and would otherwise dispatch a job
+ // with SHA="". The agent entrypoint correctly rejects that.
+ //
+ // Fall back to resolving the branch tip from the bare repo. By the
+ // time we get here ensure_worktree has already succeeded for
+ // record.branch, so the branch is guaranteed to exist and
+ // get_branch_sha returns a real SHA.
+ let current_sha = match record.current_sha.clone() {
+     Some(sha) if !sha.is_empty() => sha,
+     _ => self
+         .git
+         .get_branch_sha(&record.branch)
+         .await?
+         .ok_or_else(|| {
+             crate::error::NautiloopError::Internal(format!(
+                 "Failed to resolve current_sha for branch {} — \
+                  branch does not exist in bare repo",
+                 record.branch
+             ))
+         })?,
+ };
```

Happy path (handler won the race): zero extra git calls. Race-window path: one extra `rev-parse` against the bare repo (local, microseconds), then the same LoopContext. Hard-fail if git also doesn't know the branch, which would indicate real corruption, not a race.

## Why not fix the handler instead

A handler-side fix would be better in theory — e.g. insert the row with a non-PENDING "initializing" state, then transition to PENDING after `set_current_sha` runs, so the reconciler never sees a pre-SHA loop. But that expands the state machine, churns more tests, and requires migrating existing in-flight loops on upgrade. This change is narrow, centralizes the guarantee in one function, and leaves the door open to a handler-side fix later without conflicting with it.

## Test plan

- [x] `cargo test -p nautiloop-control-plane`: **107 passed** (106 original + 1 new regression test)
- [x] Existing tests: `make_pending_loop` helper now seeds `current_sha` with a placeholder (matches the state the handler leaves after `set_current_sha`). The old `current_sha: None` made every test implicitly depend on the new fallback path, which would hide bugs in the happy path.
- [x] `test_output_ingestion_on_job_completion`: pinned `current_sha` to the mock branch SHA it seeds, so the `has_diverged` check on ingestion doesn't false-positive now that `make_pending_loop` no longer leaves it `None`.
- [x] **New** `test_build_context_falls_back_to_git_sha_when_record_missing_it`: seeds a branch in the mock git, sets `record.current_sha=None`, asserts that `build_context` returns the seeded SHA (not an empty string). Locks in the race-window fix so it can't regress silently.
- [ ] End-to-end on v0.2.9 install: `nemo harden specs/foo.md` actually reaches a real terminal state (HARDENED, or a domain-level failure — not a CLI/env error). Will run after merge + tag.

## Suggested release

Cut `v0.2.9` after merge. Control-plane rebuild only.

## Note on the closed branch

There is also a remote branch `fix/resolve-current-sha-before-first-dispatch` on the repo that I created earlier by mistake — my local checkout had accidentally stacked this commit on top of the in-progress `spec/rust-sidecar` branch, so that remote branch contains two unrelated spec commits plus this fix. I did not force-push over it. Please delete that branch at your convenience; this PR (`fix/resolve-current-sha-race`) has the clean single-commit version off `main`.