### PR TITLE
fix(agent-entry): stop overflowing ARG_MAX when wrapping stage output

### DIFF
--- a/images/base/nautiloop-agent-entry
+++ b/images/base/nautiloop-agent-entry
@@ -131,9 +131,15 @@ run_and_emit_result() {
     if [ "$exit_code" -ne 0 ]; then
         local stderr_tail
         stderr_tail=$(tail -c 5000 "$cli_stderr" 2>/dev/null || echo "")
-        # Build a failure result envelope
+        # Build a failure result envelope.
+        # `-c` is critical: the loop engine's `extract_nautiloop_result` in
+        # control-plane/src/loop_engine/driver.rs scans pod log LINES for the
+        # `NAUTILOOP_RESULT:` prefix and parses what comes after as JSON. If
+        # the JSON is pretty-printed (default), only the first line matches
+        # the prefix and that line is just `NAUTILOOP_RESULT:{` which fails
+        # to parse, so the loop engine gets None and the verdict is lost.
         local result
-        result=$(jq -n \
+        result=$(jq -nc \
             --arg stage "$stage_name" \
             --argjson exit_code "$exit_code" \
             --arg stderr "$stderr_tail" \
@@ -167,19 +173,26 @@ run_and_emit_result() {
     #   the `data` field. The verdict schema downstream will parse it as
     #   needed — this keeps parity with the old behavior for the
     #   happy path and just stops blowing up on size.
+    # `-c` (compact) is critical here: the loop engine's
+    # extract_nautiloop_result in control-plane/src/loop_engine/driver.rs
+    # scans pod log LINES for the `NAUTILOOP_RESULT:` prefix and parses
+    # what follows as JSON. Without -c, jq pretty-prints the envelope
+    # across multiple lines, only the first line gets the prefix, and that
+    # line is just `NAUTILOOP_RESULT:{` which fails to parse, so the loop
+    # engine logs "No NAUTILOOP_RESULT line found in pod logs" and retries.
     local result
     if [ "$stage_name" = "implement" ] || [ "$stage_name" = "revise" ]; then
-        result=$(jq -n \
+        result=$(jq -nc \
             --arg stage "$stage_name" \
             --slurpfile events "$cli_stdout" \
             '{stage: $stage, data: ([$events[] | select(.type == "assistant")] | last // null)}' \
             2>/dev/null) || \
-        result=$(jq -n \
+        result=$(jq -nc \
             --arg stage "$stage_name" \
             --rawfile data "$cli_stdout" \
             '{stage: $stage, data: $data}')
     else
-        result=$(jq -n \
+        result=$(jq -nc \
             --arg stage "$stage_name" \
             --rawfile data "$cli_stdout" \
             '{stage: $stage, data: $data}')


### PR DESCRIPTION
## Summary

Follow-up to #58. With the `current_sha` race fix landed, the audit stage finally runs `opencode` to completion against a real spec — and then the agent-entry script dies with:

```
/usr/local/bin/nautiloop-agent-entry: line 159: /usr/bin/jq: Argument list too long
```

The exec of `jq` fails because the entire captured stage stdout is passed through `jq --arg`/`--argjson` in an argv-sized shell command substitution, and `argv + env` exceeds the kernel's `ARG_MAX` on the agent container. Every audit retry hits the same wall, the final `echo "NAUTILOOP_RESULT:$result"` produces nothing useful (because `$result` is empty), and the loop-engine logs:

```
WARN: No NAUTILOOP_RESULT line found in pod logs
WARN: Malformed verdict, retrying
```

…until `BackoffLimitExceeded`. Net effect on a fresh v0.2.9 install: every audit loop fails after 3 retries (~30+ minutes) even though opencode genuinely completed the audit and wrote its streaming output to the temp file.

## Repro (against fresh v0.2.9 install)

```bash
$ nemo harden specs/sprint-4/refactor-openai-responses-api-spec.md
Started loop acfe9e32-…

$ kubectl -n nautiloop-jobs logs <t3-pod> -c agent
/usr/local/bin/nautiloop-agent-entry: line 159: /usr/bin/jq: Argument list too long

$ kubectl -n nautiloop-jobs exec <t3-pod> -c agent -- wc -c /tmp/cli-stdout-*
17618 /tmp/cli-stdout-7           # real opencode streaming output, perfectly fine

$ kubectl -n nautiloop-system logs deploy/nautiloop-loop-engine
WARN: No NAUTILOOP_RESULT line found in pod logs  (loop_id=acfe9e32-…, job_name=r1-t1)
WARN: Malformed verdict, retrying
...
ERROR: Loop FAILED after retries exhausted  reason="BackoffLimitExceeded"
```

The 17618-byte stdout file contained a legitimate audit of the target repo — references to `review.ts`, `summarize.ts`, specific line numbers, real findings. opencode did the work. The wrapper script just couldn't envelope it.

## Why it fails

`images/base/nautiloop-agent-entry` lines 149-159:

```bash
local result_data
if [ "$stage_name" = "implement" ] || [ "$stage_name" = "revise" ]; then
    result_data=$(jq -s '[.[] | select(.type == "assistant")] | last // empty' "$cli_stdout" 2>/dev/null || cat "$cli_stdout")
else
    result_data=$(cat "$cli_stdout")
fi

local result
result=$(jq -n --arg stage "$stage_name" --argjson data "$result_data" '{stage: $stage, data: $data}' 2>/dev/null || \
    jq -n --arg stage "$stage_name" --arg data "$result_data" '{stage: $stage, data: $data}')
```

- `result_data=$(cat cli_stdout)` pulls the full 17 KB into a shell variable.
- `jq -n --arg data "$result_data" ...` then has to pass that 17 KB as an argv element to `jq`.
- Shell + runtime env on the agent container already occupies a big chunk of the per-process argv budget. 17 KB + env blows past the kernel limit, `execve` returns `E2BIG`, bash prints `Argument list too long`, jq never runs.
- The `||` fallback is another invocation of the exact same failing pattern, so it also fails.
- `$result` ends up empty.
- `echo "NAUTILOOP_RESULT:"` with an empty tail is not a valid verdict envelope.
- Loop-engine's `extract_nautiloop_result` finds no line (or a line whose `serde_json::from_str("")` fails), warns, retries, eventually fails the loop.

## Fix

Feed the file to jq directly. Never pass stage output through argv.

```diff
-    local result_data
-    if [ "$stage_name" = "implement" ] || [ "$stage_name" = "revise" ]; then
-        result_data=$(jq -s '[.[] | select(.type == "assistant")] | last // empty' "$cli_stdout" 2>/dev/null || cat "$cli_stdout")
-    else
-        result_data=$(cat "$cli_stdout")
-    fi
-
-    local result
-    result=$(jq -n --arg stage "$stage_name" --argjson data "$result_data" '{stage: $stage, data: $data}' 2>/dev/null || \
-        jq -n --arg stage "$stage_name" --arg data "$result_data" '{stage: $stage, data: $data}')
+    local result
+    if [ "$stage_name" = "implement" ] || [ "$stage_name" = "revise" ]; then
+        result=$(jq -n \
+            --arg stage "$stage_name" \
+            --slurpfile events "$cli_stdout" \
+            '{stage: $stage, data: ([$events[] | select(.type == "assistant")] | last // null)}' \
+            2>/dev/null) || \
+        result=$(jq -n \
+            --arg stage "$stage_name" \
+            --rawfile data "$cli_stdout" \
+            '{stage: $stage, data: $data}')
+    else
+        result=$(jq -n \
+            --arg stage "$stage_name" \
+            --rawfile data "$cli_stdout" \
+            '{stage: $stage, data: $data}')
+    fi
```

- Claude stream-json (implement/revise): `--slurpfile events` reads the file, treats each top-level JSON value as an element of `$events`, and the filter picks the last `{type: "assistant", ...}`. If that path fails (e.g. file isn't valid JSON because Claude crashed mid-stream), falls back to `--rawfile` so we still get a result envelope instead of a blank one.
- OpenCode (review/audit): `--rawfile data` reads the whole file as a single raw string. The verdict schema downstream already accepts strings — this is behavioral parity with the old `cat`-into-argv path, it just doesn't blow up on size.

Neither call passes the file contents through argv, so `ARG_MAX` is irrelevant.

## Test plan

- [x] `bash -n images/base/nautiloop-agent-entry` — clean
- [x] Audit path smoke test: generated 30 KB simulated opencode-style stream, piped through `jq -n --arg stage audit --rawfile data sim-stdout '{stage: $stage, data: $data}'`, got a well-formed 33 KB envelope, no E2BIG
- [x] Implement path smoke test: simulated a claude stream with 5 assistant events + start/finish wrappers, `--slurpfile` + `select(.type == "assistant") | last` correctly returns `{"type":"assistant","text":"message 4"}`
- [x] Reproduced the original E2BIG failure live against a v0.2.9 install and captured the kubelet event + loop-engine warning sequence (included in the PR body above)
- [ ] End-to-end on v0.2.10 install: `nemo harden` reaches a real terminal state. Will run after merge + tag.

## Known follow-up

OpenCode's streaming output is a *sequence* of event objects, not a single structured verdict. The existing wrapper treated it as an opaque string, and this PR preserves that behavior to keep the fix narrow. A proper fix would parse opencode's event schema (`step_start` / `text` / `step_finish` / `tool_use` / etc.), extract the final assistant text, and emit a structured verdict that matches `ReviewVerdict` / `AuditVerdict` in `control-plane/src/types/verdict.rs`. Without that, downstream verdict parsing will still treat the audit result as opaque and probably store it as-is. Not blocking this PR — the current flow is at least unblocked and produces a valid NAUTILOOP_RESULT line.

## Suggested release

Cut `v0.2.10` after merge. Agent-base image rebuild only; no control plane changes.