### PR TITLE
fix(agent): route opencode through sidecar OpenAI proxy (closes #62)

### DIFF
--- a/control-plane/src/k8s/job_builder.rs
+++ b/control-plane/src/k8s/job_builder.rs
@@ -291,8 +291,32 @@ fn build_agent_env_vars(ctx: &LoopContext, stage: &StageConfig, is_test: bool) -
         env_var("https_proxy", "http://localhost:9092"),
         env_var("NO_PROXY", "localhost,127.0.0.1,::1"),
         env_var("no_proxy", "localhost,127.0.0.1,::1"),
-        // FR-9: OpenAI API through sidecar model proxy
+        // FR-9: OpenAI API through sidecar model proxy.
+        //
+        // OPENAI_BASE_URL points at the sidecar's :9090 model proxy. The
+        // sidecar reads /secrets/model-credentials/openai and OVERWRITES
+        // the Authorization header on every forwarded request (see
+        // modelProxyHandler in images/sidecar/main.go). So the real
+        // OpenAI Platform key never enters the agent container — the
+        // agent sends a placeholder, the sidecar swaps in the real key.
+        //
+        // OPENAI_API_KEY is a PLACEHOLDER that exists ONLY to make
+        // opencode enable its OpenAI provider. opencode v1.3.x detects
+        // the OpenAI provider via the presence of OPENAI_API_KEY in
+        // the environment (`opencode providers list` shows it in the
+        // "Environment" section). Without it, opencode falls back to
+        // its built-in `opencode/*` models routed through opencode.ai,
+        // which (a) bypasses the sidecar credential-injection path
+        // entirely, (b) sends prompts to a third-party service with
+        // unknown billing/retention, and (c) makes `nemo auth --openai`
+        // dead code. See issue #62.
+        //
+        // The literal value `sk-replaced-by-sidecar` is sent as the
+        // Bearer token in every opencode request to :9090, and the
+        // sidecar replaces it with the real key before forwarding to
+        // api.openai.com. The agent never sees the real key.
         env_var("OPENAI_BASE_URL", "http://localhost:9090/openai"),
+        env_var("OPENAI_API_KEY", "sk-replaced-by-sidecar"),
         // Note: ANTHROPIC_BASE_URL is NOT set. Claude Code authenticates via the
         // mounted ~/.claude/ session directory (FR-25b), not via the sidecar proxy.
         // Base branch for diff context in review/audit stages
@@ -787,10 +811,17 @@ mod tests {
         assert_eq!(find_env("HTTPS_PROXY").unwrap(), "http://localhost:9092");
         assert_eq!(find_env("NO_PROXY").unwrap(), "localhost,127.0.0.1,::1");
 
-        // FR-9: OpenAI base URL
+        // FR-9: OpenAI base URL points at the sidecar model proxy.
         assert_eq!(
             find_env("OPENAI_BASE_URL").unwrap(),
             "http://localhost:9090/openai"
+        );
+        // FR-9/issue #62: OPENAI_API_KEY placeholder is required so opencode
+        // enables its OpenAI provider. The sidecar overwrites the real auth
+        // header on forwarded requests, so the agent never sees a real key.
+        assert_eq!(
+            find_env("OPENAI_API_KEY").unwrap(),
+            "sk-replaced-by-sidecar"
         );
 
         // FR-10: Git identity (display name, not slug)

--- a/images/base/nautiloop-agent-entry
+++ b/images/base/nautiloop-agent-entry
@@ -176,11 +176,28 @@ case "$STAGE" in
     review|audit)
         # FR-6, FR-7: OpenCode for review/audit (read-only)
         export OPENCODE_PERMISSIONS='{"edit":"deny","bash":"deny","read":"allow"}'
+
+        # Pin the provider to `openai` so opencode routes through the sidecar
+        # model proxy (OPENAI_BASE_URL=http://localhost:9090/openai) instead
+        # of falling back to its built-in `opencode/*` models that go to the
+        # opencode.ai hosted backend with unknown billing. See issue #62.
+        #
+        # opencode expects `-m provider/model`. If MODEL is unset or doesn't
+        # contain a provider prefix, we prepend `openai/`. If it already has
+        # a prefix (e.g. user explicitly set `anthropic/...`), pass through.
+        # If MODEL is entirely unset, default to a cheap OpenAI model so the
+        # reviewer doesn't silently fall back to a nondeterministic default.
+        OPENCODE_MODEL="${MODEL:-gpt-4o-mini}"
+        case "$OPENCODE_MODEL" in
+            */*) ;;                              # already has provider prefix
+            *) OPENCODE_MODEL="openai/$OPENCODE_MODEL" ;;
+        esac
+
         # opencode v1.3+ removed --prompt-file; the message is either a
         # positional arg or piped in via stdin. We pipe via stdin to avoid
         # argv length limits for large specs/diffs — same reasoning the
         # original --prompt-file code had.
-        OPENCODE_ARGS=(run --format json)
+        OPENCODE_ARGS=(run --format json -m "$OPENCODE_MODEL")
         if [ -n "${SESSION_ID:-}" ]; then
             OPENCODE_ARGS+=(-s "$SESSION_ID")
         fi


### PR DESCRIPTION
## Summary

Addresses issue #62. Opencode on review/audit was silently bypassing the sidecar model proxy and sending all model traffic to `opencode.ai:443`, which made three pieces of the documented architecture dead:

1. `nemo auth --openai` pushes a key to `/secrets/model-credentials/openai`, but opencode never reads it
2. The sidecar's `modelProxyHandler` on `:9090` — the credential-injection path — is never called
3. Prompts go to a third party with unknown billing, retention, and no chain of custody

## Root cause

opencode v1.3.x auto-selects its built-in `opencode/*` provider (routed through `opencode.ai`) unless it detects a provider credential in the environment. `opencode providers list` shows:

```
┌  Environment
●  OpenAI      OPENAI_API_KEY    <- only enabled if set
└  1 environment variable
```

The agent container had `OPENAI_BASE_URL=http://localhost:9090/openai` but NOT `OPENAI_API_KEY`, so opencode saw zero configured providers and fell back to its hosted default.

## Fix

**`job_builder.rs`**: set `OPENAI_API_KEY=sk-replaced-by-sidecar` in the agent env. This is a **placeholder** whose only job is to trigger opencode's OpenAI provider detection. Requests from the agent go to `http://localhost:9090/openai/*` with `Authorization: Bearer sk-replaced-by-sidecar`. The sidecar's `modelProxyHandler` reads `/secrets/model-credentials/openai` and **overwrites** the Authorization header (already exists — `main.go:157`) with the real Platform key before forwarding to `api.openai.com`. So the real key never enters the agent container.

**`nautiloop-agent-entry`**: normalize MODEL to `openai/<model>` and pass `-m` to opencode so it uses the OpenAI provider explicitly. If MODEL already has a provider prefix (e.g. `anthropic/...`) it's passed through; otherwise `openai/` is prepended. Default: `openai/gpt-4o-mini`.

## What changes for users

| Before | After |
|---|---|
| Review/audit traffic → `opencode.ai:443` | Review/audit traffic → `api.openai.com:443` |
| `nemo auth --openai` is dead code | `nemo auth --openai` is the canonical way to plumb a key |
| Unknown billing / retention | User's own OpenAI Platform billing |
| Sidecar `:9090` proxy is dead code | Sidecar `:9090` proxy is live, exercised every request |
| Prompts leave the trust boundary via opencode.ai | Prompts only go to api.openai.com via the sidecar |

## Test plan

- [x] `cargo test --workspace` — 107/107 pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `bash -n images/base/nautiloop-agent-entry` — clean
- [x] Added assertion for `OPENAI_API_KEY` env var in `test_build_job_agent_env_vars`
- [ ] End-to-end v0.2.10 install: egress log should show `api.openai.com:443` entries instead of `opencode.ai:443`

## Relation to PR #61

This PR is independent of #61 (the ARG_MAX fix) but they both need to ship in v0.2.10. They touch different parts of `nautiloop-agent-entry` and will merge cleanly.