### PR TITLE
fix(agent-entry): skip --resume when SESSION_ID is wrong format for target tool

### DIFF
--- a/images/base/nautiloop-agent-entry
+++ b/images/base/nautiloop-agent-entry
@@ -311,7 +311,25 @@ case "$STAGE" in
         if [ -n "${MODEL:-}" ]; then
             CLAUDE_ARGS+=(--model "$MODEL")
         fi
-        if [ -n "${SESSION_ID:-}" ]; then
+        # Session IDs do not cross tool boundaries. opencode emits
+        # `ses_<20-char>` IDs; Claude Code v2.x requires UUIDs. When the
+        # loop transitions audit (opencode) -> revise (claude) and
+        # the loop engine dispatches with SESSION_ID still pointing at
+        # the audit's opencode ID, claude rejects it with:
+        #
+        #   Error: --resume requires a valid session ID when used with
+        #   --print. Session IDs must be in UUID format
+        #   (e.g., 550e8400-e29b-41d4-a716-446655440000).
+        #   Provided value "ses_28dede965ffejFSu1XlxxAiqx0" is not a
+        #   valid UUID
+        #
+        # exit 1, revise does zero work, three retries, BackoffLimitExceeded.
+        # Only pass --resume when SESSION_ID is a valid UUID (previous
+        # claude session); silently drop otherwise so the revise starts
+        # a fresh claude session, which is the right behavior for the
+        # first claude stage after an audit.
+        if [ -n "${SESSION_ID:-}" ] && \
+           printf '%s' "$SESSION_ID" | grep -Eq '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'; then
             CLAUDE_ARGS+=(--resume "$SESSION_ID")
         fi
         STDIN_FILE="$PROMPT_FILE" run_and_emit_result "$STAGE" claude "${CLAUDE_ARGS[@]}"
@@ -342,7 +360,12 @@ case "$STAGE" in
         # argv length limits for large specs/diffs — same reasoning the
         # original --prompt-file code had.
         OPENCODE_ARGS=(run --format json -m "$OPENCODE_MODEL")
-        if [ -n "${SESSION_ID:-}" ]; then
+        # Symmetric with the claude branch: only resume when SESSION_ID
+        # looks like an opencode session (`ses_<chars>`), not a claude
+        # UUID carried over from a previous revise. See the matching
+        # comment in the implement|revise branch.
+        if [ -n "${SESSION_ID:-}" ] && \
+           printf '%s' "$SESSION_ID" | grep -Eq '^ses_[a-zA-Z0-9]+$'; then
             OPENCODE_ARGS+=(-s "$SESSION_ID")
         fi
         STDIN_FILE="$PROMPT_FILE" run_and_emit_result "$STAGE" opencode "${OPENCODE_ARGS[@]}"


### PR DESCRIPTION
## Summary

The `stdout_tail` diagnostic from #90 immediately exposed the real revise failure on v0.3.7:

```
Error: --resume requires a valid session ID when used with --print.
Usage: claude -p --resume <session-id>. Session IDs must be in UUID
format (e.g., 550e8400-e29b-41d4-a716-446655440000).
Provided value "ses_28dede965ffejFSu1XlxxAiqx0" is not a valid UUID
```

This is a cross-tool session ID format mismatch. opencode emits `ses_<20-char>` IDs, Claude Code v2.x requires UUIDs, the loop-engine's `LoopRecord.session_id` is a single untyped column that gets forwarded uniformly to every stage, and the agent-entry script blindly passes it to whatever CLI the stage runs. The moment a loop transitions between tools (audit → revise is the obvious case, but also any future review → implement transition) the session ID is wrong-format and the target tool rejects it.

Net effect on a fresh v0.3.7 install: harden audits succeed, correctly transition to revise, then revise dies on every single attempt in under a second with exit 1. The earlier rounds in this debugging session couldn't see the rejection because Claude writes the error to stdout (stream-json), and the pre-#90 failure envelope only captured stderr. We only found this today because #90 landed and surfaced the real message.

## Repro (v0.3.7, without this fix)

```bash
$ nemo harden specs/sprint-4/refactor-openai-responses-api-spec.md
Started loop 1c673e07-...

$ kubectl -n nautiloop-system logs deploy/nautiloop-loop-engine
INFO  Created Job nautiloop-1c673e07-audit-r1-t1
INFO  PENDING -> HARDENING/DISPATCHED
# (~8 minutes of real audit work against gpt-5.4)
INFO  Created Job nautiloop-1c673e07-revise-r1-t1
WARN  Job failed, retrying retry=1 reason="BackoffLimitExceeded"
WARN  Job failed, retrying retry=2 reason="BackoffLimitExceeded"
ERROR Loop FAILED

$ kubectl -n nautiloop-jobs logs <revise-pod> -c agent
NAUTILOOP_RESULT:{"stage":"revise","data":{
  "exit_code":1,
  "error":"",
  "stdout_tail":"{\"type\":\"result\",\"subtype\":\"error_during_execution\",...,
    \"errors\":[\"Error: --resume requires a valid session ID when used with
    --print. Session IDs must be in UUID format ... Provided value
    \\\"ses_28dede965ffejFSu1XlxxAiqx0\\\" is not a valid UUID\"]}"
}}
```

## Why the SESSION_ID is wrong shape

1. `audit` stage dispatches an opencode job
2. opencode finishes its tool-use loop and emits a final `{type:"result"}` event with `session_id: "ses_28dede965ffejFSu1XlxxAiqx0"` on stdout
3. Agent-entry (post-#86) extracts `data.session_id` from that event and includes it in the `ReviewResultData` envelope
4. Loop-engine's ingest path copies `ReviewResultData.session_id` into `LoopRecord.session_id` and persists it
5. Loop-engine dispatches the next stage (revise) and `build_agent_env_vars` sets `SESSION_ID=ses_28dede965ffejFSu1XlxxAiqx0` on the revise container
6. Agent-entry sees `SESSION_ID` set and adds `--resume "$SESSION_ID"` to `CLAUDE_ARGS`
7. Claude's argv parser accepts the flag, then its runtime validation rejects the value as non-UUID and exits 1 before any model call

Step 6 is the bug: the agent-entry script forwards the env var without checking whether it's in the right shape for the tool that's actually running.

## Fix

Defend in the shell. When `SESSION_ID` is set, only pass it to the target tool if it matches the tool's expected format:

```diff
 implement|revise)
-    if [ -n "${SESSION_ID:-}" ]; then
-        CLAUDE_ARGS+=(--resume "$SESSION_ID")
-    fi
+    if [ -n "${SESSION_ID:-}" ] && \
+       printf '%s' "$SESSION_ID" | grep -Eq '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'; then
+        CLAUDE_ARGS+=(--resume "$SESSION_ID")
+    fi

 review|audit)
-    if [ -n "${SESSION_ID:-}" ]; then
-        OPENCODE_ARGS+=(-s "$SESSION_ID")
-    fi
+    if [ -n "${SESSION_ID:-}" ] && \
+       printf '%s' "$SESSION_ID" | grep -Eq '^ses_[a-zA-Z0-9]+$'; then
+        OPENCODE_ARGS+=(-s "$SESSION_ID")
+    fi
```

If the ID is wrong shape for the tool, silently drop it and start a fresh session. That's the correct behavior the first time each tool runs in a loop (first revise after an audit has no prior claude session to resume anyway), and it falls through to the existing claude / opencode new-session code path.

## Why not fix it in the control plane

The cleaner long-term architecture is to store session IDs separately per tool on the `LoopRecord` (e.g., `opencode_session_id`, `claude_session_id`) and only forward the one matching the stage's tool. That's a schema change plus ingest rewiring plus job_builder wiring plus migration for any in-flight loops. It's the right long-term design and I'd file it as a follow-up if you want, but it's not the right scope for unblocking the immediate "every revise fails" symptom.

The bash-side filter is also a correct precondition for any control-plane fix later — even if the control-plane sends the right session ID, the agent-entry defensive check doesn't hurt and provides defense in depth against future regressions.

## Test plan

- [x] `bash -n images/base/nautiloop-agent-entry`: clean
- [x] Regex correctness matrix against four representative inputs:
  - `550e8400-e29b-41d4-a716-446655440000` → UUID ✅, ses_ ❌
  - `ses_28dede965ffejFSu1XlxxAiqx0` → UUID ❌, ses_ ✅
  - empty string → both ❌ (correct, skip)
  - `garbage` → both ❌ (correct, skip)
- [x] Real v0.3.7 repro produced the exact error via #90's stdout_tail envelope, which is how we found this root cause in the first place
- [ ] End-to-end on v0.3.8 install: loop does audit → revise → audit round trip with a dirty spec, neither stage rejects the forwarded session ID, loop eventually reaches HARDENED. Will run after merge + tag.

## Follow-up idea (not this PR)

Long-term, the right answer is probably a typed session ID in the control plane:

```rust
pub enum AgentSessionId {
    Opencode(String),  // ses_<20char>
    Claude(Uuid),      // UUID
}
```

Stored on `LoopRecord` as a tagged union, forwarded to the stage job only when the stage's tool matches the tag. Would catch this class of bug at the Rust layer instead of in bash regex. Worth an enhancement issue, but out of scope for the immediate unblock.

## Suggested release

Cut `v0.3.8` after merge. Agent-base image rebuild only; no control plane or sidecar changes.

## Related

- #90 — added `stdout_tail` to the failure envelope (v0.3.7). Without this PR I could not have seen the real rejection message. Direct cause-and-effect: landed #90, ran harden, read the envelope, identified this bug in minutes.
- #86 — verdict extraction that captures `session_id` from opencode's events. That's where the `ses_*` ID enters `LoopRecord.session_id` in the first place. Not a bug in #86 — the extraction is correct, the downstream forwarding is wrong.
- #88 — added Claude Code v2.x flags including `--resume`. This PR repairs the edge case.
- #51 — earlier "opencode removed --prompt-file" fix. Same shape of bug class: a CLI regression that breaks the loop silently until the diagnostics catch up.