### PR TITLE
feat(loop): nemo resume can restart transient-FAILED loops (#96)

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -119,7 +119,7 @@ enum Commands {
         path: String,
     },
 
-    /// Resume a PAUSED or AWAITING_REAUTH loop
+    /// Resume a PAUSED, AWAITING_REAUTH, or transient-FAILED loop
     Resume {
         /// Loop ID
         loop_id: String,

--- a/control-plane/migrations/20260409000001_add_failed_from_state.sql
+++ b/control-plane/migrations/20260409000001_add_failed_from_state.sql
@@ -1,0 +1,5 @@
+-- Issue #96: nemo resume should support FAILED loops, reusing the worktree.
+-- Mirrors paused_from_state / reauth_from_state: captures which stage was
+-- running when the loop transitioned to Failed so the resume path can
+-- redispatch the correct stage without guessing or losing the round.
+ALTER TABLE loops ADD COLUMN IF NOT EXISTS failed_from_state loop_state;

--- a/control-plane/migrations/20260409000001_add_failed_from_state.sql
+++ b/control-plane/migrations/20260409000001_add_failed_from_state.sql
@@ -3,3 +3,13 @@
 -- running when the loop transitioned to Failed so the resume path can
 -- redispatch the correct stage without guessing or losing the round.
 ALTER TABLE loops ADD COLUMN IF NOT EXISTS failed_from_state loop_state;
+
+-- Extend the partial unique index on `branch` to also cover FAILED loops
+-- with a pending resume_requested flag. Without this, a concurrent
+-- `/start` on the same deterministic branch between the resume request
+-- and the next reconciler tick could insert a second row and both would
+-- be active for the same branch. See codex round-2 review of #96.
+DROP INDEX IF EXISTS idx_loops_active_branch;
+CREATE UNIQUE INDEX idx_loops_active_branch ON loops (branch)
+    WHERE state NOT IN ('CONVERGED', 'FAILED', 'CANCELLED', 'HARDENED', 'SHIPPED')
+       OR (state = 'FAILED' AND resume_requested = TRUE);

--- a/control-plane/src/api/handlers.rs
+++ b/control-plane/src/api/handlers.rs
@@ -116,6 +116,7 @@ pub async fn start(
         resume_requested: false,
         paused_from_state: None,
         reauth_from_state: None,
+        failed_from_state: None,
         failure_reason: None,
         current_sha: None, // Set after git branch creation below
         session_id: None,
@@ -330,7 +331,12 @@ pub async fn approve(
     }))
 }
 
-/// POST /resume/:id - Resume a PAUSED or AWAITING_REAUTH loop.
+/// POST /resume/:id - Resume a PAUSED, AWAITING_REAUTH, or FAILED loop (#96).
+///
+/// FAILED loops can only be resumed if `failed_from_state` is set, which
+/// happens for transient failures (job retry exhaustion, malformed verdict).
+/// Max-rounds-exhausted and other logical failures leave `failed_from_state`
+/// NULL and are rejected — resuming them would just rerun the same condition.
 pub async fn resume(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
@@ -341,11 +347,23 @@ pub async fn resume(
         .await?
         .ok_or(NautiloopError::LoopNotFound { id })?;
 
-    if record.state != LoopState::Paused && record.state != LoopState::AwaitingReauth {
+    let resumable = match record.state {
+        LoopState::Paused | LoopState::AwaitingReauth => true,
+        LoopState::Failed => record.failed_from_state.is_some(),
+        _ => false,
+    };
+
+    if !resumable {
+        let expected = if record.state == LoopState::Failed {
+            "FAILED loop has no resumable stage (max rounds exhausted or logical failure)"
+                .to_string()
+        } else {
+            "PAUSED, AWAITING_REAUTH, or transient-FAILED".to_string()
+        };
         return Err(NautiloopError::InvalidStateTransition {
             action: "resume".to_string(),
             state: record.state.to_string(),
-            expected: "PAUSED or AWAITING_REAUTH".to_string(),
+            expected,
         });
     }
 
@@ -697,6 +715,7 @@ mod tests {
             resume_requested: false,
             paused_from_state: None,
             reauth_from_state: None,
+            failed_from_state: None,
             failure_reason: None,
             current_sha: None,
             session_id: None,
@@ -757,6 +776,7 @@ mod tests {
             resume_requested: false,
             paused_from_state: None,
             reauth_from_state: None,
+            failed_from_state: None,
             failure_reason: None,
             current_sha: None,
             session_id: None,
@@ -811,6 +831,7 @@ mod tests {
             resume_requested: false,
             paused_from_state: None,
             reauth_from_state: None,
+            failed_from_state: None,
             failure_reason: None,
             current_sha: None,
             session_id: None,

--- a/control-plane/src/api/handlers.rs
+++ b/control-plane/src/api/handlers.rs
@@ -367,24 +367,24 @@ pub async fn resume(
         });
     }
 
-    // #96: For FAILED loops, verify no replacement loop has taken over
-    // the same deterministic branch. A branch is a globally unique active
-    // identifier in nautiloop — if `nemo harden` was re-run on the same
-    // spec after the failure, the new loop owns the worktree and
-    // resurrecting this one would either deadlock on the branch uniqueness
-    // constraint (Postgres) or corrupt the live loop's worktree (in-memory).
-    // Reject with a clear message so the user can decide: attach to the
-    // replacement or abandon it first.
+    // #96: For FAILED loops, verify no replacement loop has taken
+    // over the same deterministic branch. Checking any loop (not just
+    // active) with a newer updated_at: a replacement that has since
+    // converged, shipped, or itself failed still mutated the worktree
+    // after this loop's failure, so resuming the older row would run
+    // against a worktree the older loop no longer understands. The
+    // operator has to abandon this row and cut a fresh loop instead.
     if record.state == LoopState::Failed
-        && let Some(active) = state.store.get_loop_by_branch(&record.branch).await?
-        && active.id != record.id
+        && let Some(other) = state.store.get_loop_by_branch_any(&record.branch).await?
+        && other.id != record.id
+        && other.updated_at > record.updated_at
     {
         return Err(NautiloopError::InvalidStateTransition {
             action: "resume".to_string(),
             state: record.state.to_string(),
             expected: format!(
-                "branch {} is owned by active loop {} — cancel it before resuming this one",
-                record.branch, active.id
+                "branch {} was taken over by a newer loop {} (state {}) — the worktree no longer matches this row; start a fresh loop instead",
+                record.branch, other.id, other.state
             ),
         });
     }

--- a/control-plane/src/api/handlers.rs
+++ b/control-plane/src/api/handlers.rs
@@ -367,6 +367,28 @@ pub async fn resume(
         });
     }
 
+    // #96: For FAILED loops, verify no replacement loop has taken over
+    // the same deterministic branch. A branch is a globally unique active
+    // identifier in nautiloop — if `nemo harden` was re-run on the same
+    // spec after the failure, the new loop owns the worktree and
+    // resurrecting this one would either deadlock on the branch uniqueness
+    // constraint (Postgres) or corrupt the live loop's worktree (in-memory).
+    // Reject with a clear message so the user can decide: attach to the
+    // replacement or abandon it first.
+    if record.state == LoopState::Failed
+        && let Some(active) = state.store.get_loop_by_branch(&record.branch).await?
+        && active.id != record.id
+    {
+        return Err(NautiloopError::InvalidStateTransition {
+            action: "resume".to_string(),
+            state: record.state.to_string(),
+            expected: format!(
+                "branch {} is owned by active loop {} — cancel it before resuming this one",
+                record.branch, active.id
+            ),
+        });
+    }
+
     state
         .store
         .set_loop_flag(id, LoopFlag::Resume, true)

--- a/control-plane/src/loop_engine/driver.rs
+++ b/control-plane/src/loop_engine/driver.rs
@@ -62,13 +62,18 @@ impl ConvergentLoopDriver {
             .await?
             .ok_or(NautiloopError::LoopNotFound { id: loop_id })?;
 
-        // Terminal states: clear stale flags and return (never transition out)
+        // Terminal states: clear stale flags and return, EXCEPT for
+        // FAILED with a pending resume_requested flag — issue #96 lets
+        // `nemo resume` bring a transient-failed loop back into the loop.
         if record.state.is_terminal() {
             if record.cancel_requested {
                 let _ = self
                     .store
                     .set_loop_flag(record.id, crate::state::LoopFlag::Cancel, false)
                     .await;
+            }
+            if record.state == LoopState::Failed && record.resume_requested {
+                return self.handle_failed(&record).await;
             }
             return Ok(record.state);
         }
@@ -911,6 +916,60 @@ impl ConvergentLoopDriver {
         }
     }
 
+    /// Handle FAILED: check for resume flag (#96).
+    ///
+    /// When an engineer runs `nemo resume <loop-id>` on a FAILED loop, the
+    /// API handler sets resume_requested=true. The next reconciler tick
+    /// lands here, flips state back to failed_from_state, and calls
+    /// redispatch_current_stage. The existing worktree is preserved
+    /// because redispatch_current_stage does not touch the PVC layout —
+    /// it only issues a fresh K8s Job against the same branch/sha pair.
+    async fn handle_failed(&self, record: &LoopRecord) -> Result<LoopState> {
+        if record.resume_requested {
+            if let Some(failed_from) = record.failed_from_state {
+                let mut updated = record.clone();
+                updated.state = failed_from;
+                updated.failed_from_state = None;
+                updated.retry_count = 0; // Fresh budget for the resumed stage
+                updated.failure_reason = None;
+                updated.active_job_name = None;
+                // Refresh current_sha so the divergence check doesn't
+                // immediately re-pause after resume (same reasoning as
+                // handle_paused / handle_awaiting_reauth).
+                if let Ok(Some(sha)) = self.git.get_branch_sha(&record.branch).await {
+                    updated.current_sha = Some(sha);
+                }
+                let result = self.redispatch_current_stage(&updated).await?;
+                self.store
+                    .set_loop_flag(record.id, crate::state::LoopFlag::Resume, false)
+                    .await?;
+                tracing::info!(
+                    loop_id = %record.id,
+                    round = updated.round,
+                    target_state = ?failed_from,
+                    "Resumed FAILED loop"
+                );
+                Ok(result)
+            } else {
+                // No failed_from_state: either the loop failed via a
+                // non-transient path (max rounds, logical failure) or it
+                // predates #96. Either way, there's nothing to resume to —
+                // clear the flag and stay Failed so nemo resume doesn't
+                // spin forever.
+                self.store
+                    .set_loop_flag(record.id, crate::state::LoopFlag::Resume, false)
+                    .await?;
+                tracing::warn!(
+                    loop_id = %record.id,
+                    "Resume requested on FAILED loop with no failed_from_state; ignoring"
+                );
+                Ok(LoopState::Failed)
+            }
+        } else {
+            Ok(LoopState::Failed)
+        }
+    }
+
     /// Handle AWAITING_REAUTH: check for resume flag (after creds re-pushed).
     async fn handle_awaiting_reauth(&self, record: &LoopRecord) -> Result<LoopState> {
         if record.resume_requested {
@@ -1031,6 +1090,9 @@ impl ConvergentLoopDriver {
             self.redispatch_current_stage(&updated).await
         } else {
             // Exhausted retries: fail the loop
+            // Capture which stage we were in so `nemo resume` can
+            // redispatch it against the same worktree (#96).
+            updated.failed_from_state = Some(updated.state);
             updated.state = LoopState::Failed;
             updated.sub_state = None;
             updated.failure_reason =
@@ -1054,6 +1116,8 @@ impl ConvergentLoopDriver {
             );
             self.redispatch_current_stage(record).await
         } else {
+            // #96: capture which stage to redispatch on resume.
+            record.failed_from_state = Some(record.state);
             record.state = LoopState::Failed;
             record.sub_state = None;
             record.failure_reason = Some(format!(
@@ -1526,6 +1590,7 @@ mod tests {
             resume_requested: false,
             paused_from_state: None,
             reauth_from_state: None,
+            failed_from_state: None,
             failure_reason: None,
             // Matches the real /start handler, which always calls
             // set_current_sha after create_branch before returning 201.
@@ -1816,7 +1881,74 @@ mod tests {
         assert_eq!(new_state, LoopState::Failed);
 
         let updated = store.get_loop(record.id).await.unwrap().unwrap();
-        assert!(updated.failure_reason.unwrap().contains("OOM"));
+        assert!(updated.failure_reason.as_ref().unwrap().contains("OOM"));
+        // #96: failed_from_state is captured so `nemo resume` can
+        // redispatch the same stage later without guessing.
+        assert_eq!(updated.failed_from_state, Some(LoopState::Implementing));
+    }
+
+    #[tokio::test]
+    async fn test_failed_resume_redispatches_same_stage() {
+        // #96: A transient-FAILED loop with resume_requested=true
+        // should flip back to failed_from_state and redispatch on tick.
+        let store = Arc::new(MemoryStateStore::new());
+        let dispatcher = Arc::new(MockJobDispatcher::new());
+        let driver = make_driver(store.clone(), dispatcher.clone());
+
+        let mut record = make_pending_loop(true);
+        record.state = LoopState::Failed;
+        record.failed_from_state = Some(LoopState::Hardening);
+        record.failure_reason = Some("insufficient_quota (after 2 retries)".to_string());
+        record.active_job_name = Some("stale-job".to_string());
+        record.retry_count = 2;
+        record.round = 4;
+        store.create_loop(&record).await.unwrap();
+        store
+            .set_loop_flag(record.id, crate::state::LoopFlag::Resume, true)
+            .await
+            .unwrap();
+
+        let new_state = driver.tick(record.id).await.unwrap();
+        assert_eq!(new_state, LoopState::Hardening);
+
+        let updated = store.get_loop(record.id).await.unwrap().unwrap();
+        assert_eq!(updated.state, LoopState::Hardening);
+        assert_eq!(updated.failed_from_state, None);
+        assert_eq!(updated.failure_reason, None);
+        assert_eq!(updated.retry_count, 0);
+        assert!(
+            !updated.resume_requested,
+            "resume flag should be cleared after successful redispatch"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_failed_resume_without_failed_from_state_noops() {
+        // #96: A FAILED loop with NO failed_from_state (e.g. max-rounds
+        // exhaustion) should stay Failed and just clear the flag — no
+        // infinite reconciler loop, no guessing a stage.
+        let store = Arc::new(MemoryStateStore::new());
+        let dispatcher = Arc::new(MockJobDispatcher::new());
+        let driver = make_driver(store.clone(), dispatcher.clone());
+
+        let mut record = make_pending_loop(true);
+        record.state = LoopState::Failed;
+        record.failed_from_state = None;
+        record.failure_reason = Some("Max harden rounds (10) exceeded".to_string());
+        store.create_loop(&record).await.unwrap();
+        store
+            .set_loop_flag(record.id, crate::state::LoopFlag::Resume, true)
+            .await
+            .unwrap();
+
+        let new_state = driver.tick(record.id).await.unwrap();
+        assert_eq!(new_state, LoopState::Failed);
+
+        let updated = store.get_loop(record.id).await.unwrap().unwrap();
+        assert!(
+            !updated.resume_requested,
+            "resume flag should be cleared even when no target stage exists"
+        );
     }
 
     #[tokio::test]

--- a/control-plane/src/loop_engine/driver.rs
+++ b/control-plane/src/loop_engine/driver.rs
@@ -248,7 +248,7 @@ impl ConvergentLoopDriver {
                         "Implement stage completed without result output, treating as failure"
                     );
                     return self
-                        .handle_job_failed(
+                        .handle_job_failed_non_resumable(
                             &updated,
                             "Implement stage exited successfully but produced no NAUTILOOP_RESULT",
                         )
@@ -681,8 +681,12 @@ impl ConvergentLoopDriver {
                     .await
             }
             None => {
-                // No output: treat as failure, retry
-                self.handle_job_failed(record, "Test stage produced no output")
+                // No output: treat as failure, retry.
+                // Non-resumable — ingest_job_output already stamped
+                // completed_at on this round, so a resumed run's output
+                // would be ignored and the evaluator would re-read the
+                // same empty output. See #96 round-4 codex review.
+                self.handle_job_failed_non_resumable(record, "Test stage produced no output")
                     .await
             }
         }
@@ -985,15 +989,27 @@ impl ConvergentLoopDriver {
                 // objects from the prior exhausted attempts. Their TTL
                 // window can be up to an hour, so without this cleanup
                 // the resumed dispatch hits AlreadyExists on names like
-                // `...-r{round}-t1` and spins. A failure here is fatal
-                // to the resume — see the long comment on the helper —
-                // so we propagate it and leave the loop Failed for retry.
+                // `...-r{round}-t1` and spins. A failure here aborts
+                // the resume — see the long comment on the helper.
+                //
+                // On abort we clear resume_requested so the branch
+                // ownership query (which treats FAILED+resume as
+                // active) stops counting this row. The loop goes back
+                // to plain FAILED: the operator can either re-run
+                // `nemo resume` after fixing the k8s condition, or
+                // abandon it with a fresh `nemo harden` on the same
+                // spec (which is now unblocked from the branch). See
+                // codex round-4 review of #96.
                 if let Err(e) = self.delete_stale_failed_attempts(record, failed_from).await {
                     tracing::error!(
                         loop_id = %record.id,
                         error = %e,
-                        "Failed to clean up stale k8s Jobs; leaving loop Failed so resume can be retried"
+                        "Failed to clean up stale k8s Jobs; releasing branch ownership so operator can retry or abandon"
                     );
+                    let _ = self
+                        .store
+                        .set_loop_flag(record.id, crate::state::LoopFlag::Resume, false)
+                        .await;
                     return Err(e);
                 }
 
@@ -1122,6 +1138,30 @@ impl ConvergentLoopDriver {
 
     /// Handle a failed job: detect auth errors, retry, or fail the loop.
     async fn handle_job_failed(&self, record: &LoopRecord, reason: &str) -> Result<LoopState> {
+        self.handle_job_failed_inner(record, reason, true).await
+    }
+
+    /// Like `handle_job_failed` but does NOT mark the exhausted Failed state
+    /// as resumable via #96. Use this for failures where ingest_job_output
+    /// has already stamped completed_at on the current round (e.g. a job
+    /// that succeeded but produced no NAUTILOOP_RESULT line). Redispatching
+    /// those would emit a new round output that ingest_job_output ignores
+    /// because it only writes rows with completed_at IS NULL, so the
+    /// evaluator would just re-read the stale empty output and fail again.
+    async fn handle_job_failed_non_resumable(
+        &self,
+        record: &LoopRecord,
+        reason: &str,
+    ) -> Result<LoopState> {
+        self.handle_job_failed_inner(record, reason, false).await
+    }
+
+    async fn handle_job_failed_inner(
+        &self,
+        record: &LoopRecord,
+        reason: &str,
+        resumable_on_exhaustion: bool,
+    ) -> Result<LoopState> {
         let mut updated = record.clone();
 
         // Detect credential expiry (FR-10): transition to AWAITING_REAUTH
@@ -1159,10 +1199,15 @@ impl ConvergentLoopDriver {
             );
             self.redispatch_current_stage(&updated).await
         } else {
-            // Exhausted retries: fail the loop
-            // Capture which stage we were in so `nemo resume` can
-            // redispatch it against the same worktree (#96).
-            updated.failed_from_state = Some(updated.state);
+            // Exhausted retries: fail the loop.
+            // Only mark the Failed state resumable (#96) when the
+            // caller vouches that redispatch would actually produce
+            // new round output. Logical failures (empty test output,
+            // implement completed without result) leave failed_from_state
+            // None so /resume rejects them cleanly.
+            if resumable_on_exhaustion {
+                updated.failed_from_state = Some(updated.state);
+            }
             updated.state = LoopState::Failed;
             updated.sub_state = None;
             updated.failure_reason =

--- a/control-plane/src/loop_engine/driver.rs
+++ b/control-plane/src/loop_engine/driver.rs
@@ -1046,11 +1046,34 @@ impl ConvergentLoopDriver {
                         Ok(result)
                     }
                     Err(e) => {
+                        // redispatch_current_stage persists the cloned
+                        // record at the target active state BEFORE
+                        // calling create_job, so a failure here leaves
+                        // the row in e.g. Hardening with no job and no
+                        // failure metadata. Roll it back to FAILED with
+                        // the original failed_from_state restored so
+                        // the operator sees the same row they had
+                        // before the failed resume attempt, and the
+                        // reconciler doesn't auto-redispatch.
                         tracing::error!(
                             loop_id = %record.id,
                             error = %e,
-                            "Redispatch during resume failed; releasing branch ownership so operator can retry or abandon"
+                            "Redispatch during resume failed; rolling row back to FAILED and releasing branch"
                         );
+                        if let Ok(Some(mut current)) = self.store.get_loop(record.id).await {
+                            current.state = LoopState::Failed;
+                            current.sub_state = None;
+                            current.failed_from_state = Some(failed_from);
+                            current.failure_reason = Some(format!("Resume redispatch failed: {e}"));
+                            current.active_job_name = None;
+                            if let Err(update_err) = self.store.update_loop(&current).await {
+                                tracing::error!(
+                                    loop_id = %record.id,
+                                    error = %update_err,
+                                    "Failed to roll row back to FAILED after resume error"
+                                );
+                            }
+                        }
                         let _ = self
                             .store
                             .set_loop_flag(record.id, crate::state::LoopFlag::Resume, false)

--- a/control-plane/src/loop_engine/driver.rs
+++ b/control-plane/src/loop_engine/driver.rs
@@ -1025,17 +1025,39 @@ impl ConvergentLoopDriver {
                 if let Ok(Some(sha)) = self.git.get_branch_sha(&record.branch).await {
                     updated.current_sha = Some(sha);
                 }
-                let result = self.redispatch_current_stage(&updated).await?;
-                self.store
-                    .set_loop_flag(record.id, crate::state::LoopFlag::Resume, false)
-                    .await?;
-                tracing::info!(
-                    loop_id = %record.id,
-                    round = updated.round,
-                    target_state = ?failed_from,
-                    "Resumed FAILED loop"
-                );
-                Ok(result)
+                // Redispatch can still fail after stale cleanup (e.g.
+                // the worktree/branch can no longer be resolved, build_job
+                // fails, k8s create rejects). Clear the resume flag on
+                // error so this terminal row doesn't keep getting picked
+                // up by the reconciler holding the branch hostage. The
+                // loop stays Failed; operator can retry after fixing the
+                // underlying cause.
+                match self.redispatch_current_stage(&updated).await {
+                    Ok(result) => {
+                        self.store
+                            .set_loop_flag(record.id, crate::state::LoopFlag::Resume, false)
+                            .await?;
+                        tracing::info!(
+                            loop_id = %record.id,
+                            round = updated.round,
+                            target_state = ?failed_from,
+                            "Resumed FAILED loop"
+                        );
+                        Ok(result)
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            loop_id = %record.id,
+                            error = %e,
+                            "Redispatch during resume failed; releasing branch ownership so operator can retry or abandon"
+                        );
+                        let _ = self
+                            .store
+                            .set_loop_flag(record.id, crate::state::LoopFlag::Resume, false)
+                            .await;
+                        Err(e)
+                    }
+                }
             } else {
                 // No failed_from_state: either the loop failed via a
                 // non-transient path (max rounds, logical failure) or it

--- a/control-plane/src/loop_engine/driver.rs
+++ b/control-plane/src/loop_engine/driver.rs
@@ -1186,8 +1186,15 @@ impl ConvergentLoopDriver {
             );
             self.redispatch_current_stage(record).await
         } else {
-            // #96: capture which stage to redispatch on resume.
-            record.failed_from_state = Some(record.state);
+            // NOT resumable via #96: by the time we get here, the round
+            // record has already been marked completed by ingest_job_output
+            // with the malformed verdict. Redispatching would produce a
+            // new run whose output gets dropped (ingest_job_output only
+            // writes to rounds where completed_at IS NULL), so the
+            // evaluator would just re-read the same malformed output and
+            // fail again. Leave failed_from_state None so api::resume
+            // rejects it with a clear message until we add per-resume
+            // round-reset logic. See codex round-3 review.
             record.state = LoopState::Failed;
             record.sub_state = None;
             record.failure_reason = Some(format!(

--- a/control-plane/src/loop_engine/driver.rs
+++ b/control-plane/src/loop_engine/driver.rs
@@ -919,33 +919,35 @@ impl ConvergentLoopDriver {
     /// Delete stale k8s Job objects from a failed loop's previous
     /// exhausted retry attempts so the resumed dispatch (which resets
     /// retry_count back to 0) can reuse the lower `-t{N}` name slots
-    /// without hitting AlreadyExists. Best-effort: delete errors are
-    /// logged and ignored because they're usually NotFound after TTL
-    /// cleanup has already run. See #96 codex review.
+    /// without hitting AlreadyExists.
+    ///
+    /// This is NOT best-effort. The kube dispatcher treats 404 NotFound
+    /// as Ok(()) internally (see k8s/client.rs), so any Err returned
+    /// here is a real API/RBAC/network failure. If we swallowed it and
+    /// let redispatch proceed, create_job would hit AlreadyExists on the
+    /// still-present stale attempt, the loop would transition out of
+    /// Failed with failed_from_state=None, and the resume would be
+    /// silently wedged until manual cleanup. Propagate the error so
+    /// handle_failed bails out cleanly with the loop still in Failed
+    /// state and the operator can retry the resume after fixing the
+    /// underlying k8s condition. See codex round-2 review of #96.
     async fn delete_stale_failed_attempts(
         &self,
         record: &LoopRecord,
         failed_from: LoopState,
-    ) -> () {
+    ) -> Result<()> {
         // Map the failed-from state to the stage name used in job names.
         // For Hardening we inspect the last round record to tell audit
         // apart from revise, same logic as redispatch_current_stage.
         let stage_name: Option<String> = match failed_from {
-            LoopState::Hardening => match self.store.get_rounds(record.id).await {
-                Ok(rounds) => rounds
+            LoopState::Hardening => {
+                let rounds = self.store.get_rounds(record.id).await?;
+                rounds
                     .iter()
                     .rfind(|r| r.round == record.round)
                     .map(|r| r.stage.clone())
-                    .or_else(|| Some("audit".to_string())),
-                Err(e) => {
-                    tracing::warn!(
-                        loop_id = %record.id,
-                        error = %e,
-                        "Could not load rounds for stale-attempt cleanup; skipping"
-                    );
-                    None
-                }
-            },
+                    .or_else(|| Some("audit".to_string()))
+            }
             LoopState::Implementing => Some("implement".to_string()),
             LoopState::Testing => Some("test".to_string()),
             LoopState::Reviewing => Some("review".to_string()),
@@ -953,7 +955,7 @@ impl ConvergentLoopDriver {
         };
 
         let Some(stage) = stage_name else {
-            return;
+            return Ok(());
         };
 
         let short_id = &record.id.to_string()[..8];
@@ -963,15 +965,9 @@ impl ConvergentLoopDriver {
         let max_attempt = record.retry_count + 1;
         for attempt in 1..=max_attempt {
             let job_name = format!("nautiloop-{short_id}-{stage}-r{}-t{attempt}", record.round);
-            if let Err(e) = self.dispatcher.delete_job(&job_name, namespace).await {
-                tracing::debug!(
-                    loop_id = %record.id,
-                    job = %job_name,
-                    error = %e,
-                    "Stale-attempt delete returned error (NotFound is expected after TTL)"
-                );
-            }
+            self.dispatcher.delete_job(&job_name, namespace).await?;
         }
+        Ok(())
     }
 
     /// Handle FAILED: check for resume flag (#96).
@@ -989,8 +985,17 @@ impl ConvergentLoopDriver {
                 // objects from the prior exhausted attempts. Their TTL
                 // window can be up to an hour, so without this cleanup
                 // the resumed dispatch hits AlreadyExists on names like
-                // `...-r{round}-t1` and spins. See codex review of #96.
-                self.delete_stale_failed_attempts(record, failed_from).await;
+                // `...-r{round}-t1` and spins. A failure here is fatal
+                // to the resume — see the long comment on the helper —
+                // so we propagate it and leave the loop Failed for retry.
+                if let Err(e) = self.delete_stale_failed_attempts(record, failed_from).await {
+                    tracing::error!(
+                        loop_id = %record.id,
+                        error = %e,
+                        "Failed to clean up stale k8s Jobs; leaving loop Failed so resume can be retried"
+                    );
+                    return Err(e);
+                }
 
                 let mut updated = record.clone();
                 updated.state = failed_from;

--- a/control-plane/src/loop_engine/driver.rs
+++ b/control-plane/src/loop_engine/driver.rs
@@ -916,6 +916,64 @@ impl ConvergentLoopDriver {
         }
     }
 
+    /// Delete stale k8s Job objects from a failed loop's previous
+    /// exhausted retry attempts so the resumed dispatch (which resets
+    /// retry_count back to 0) can reuse the lower `-t{N}` name slots
+    /// without hitting AlreadyExists. Best-effort: delete errors are
+    /// logged and ignored because they're usually NotFound after TTL
+    /// cleanup has already run. See #96 codex review.
+    async fn delete_stale_failed_attempts(
+        &self,
+        record: &LoopRecord,
+        failed_from: LoopState,
+    ) -> () {
+        // Map the failed-from state to the stage name used in job names.
+        // For Hardening we inspect the last round record to tell audit
+        // apart from revise, same logic as redispatch_current_stage.
+        let stage_name: Option<String> = match failed_from {
+            LoopState::Hardening => match self.store.get_rounds(record.id).await {
+                Ok(rounds) => rounds
+                    .iter()
+                    .rfind(|r| r.round == record.round)
+                    .map(|r| r.stage.clone())
+                    .or_else(|| Some("audit".to_string())),
+                Err(e) => {
+                    tracing::warn!(
+                        loop_id = %record.id,
+                        error = %e,
+                        "Could not load rounds for stale-attempt cleanup; skipping"
+                    );
+                    None
+                }
+            },
+            LoopState::Implementing => Some("implement".to_string()),
+            LoopState::Testing => Some("test".to_string()),
+            LoopState::Reviewing => Some("review".to_string()),
+            _ => None,
+        };
+
+        let Some(stage) = stage_name else {
+            return;
+        };
+
+        let short_id = &record.id.to_string()[..8];
+        let namespace = &self.config.cluster.jobs_namespace;
+        // Delete attempts 1..=retry_count+1 — the full range that the
+        // failed loop had consumed before transitioning to Failed.
+        let max_attempt = record.retry_count + 1;
+        for attempt in 1..=max_attempt {
+            let job_name = format!("nautiloop-{short_id}-{stage}-r{}-t{attempt}", record.round);
+            if let Err(e) = self.dispatcher.delete_job(&job_name, namespace).await {
+                tracing::debug!(
+                    loop_id = %record.id,
+                    job = %job_name,
+                    error = %e,
+                    "Stale-attempt delete returned error (NotFound is expected after TTL)"
+                );
+            }
+        }
+    }
+
     /// Handle FAILED: check for resume flag (#96).
     ///
     /// When an engineer runs `nemo resume <loop-id>` on a FAILED loop, the
@@ -927,6 +985,13 @@ impl ConvergentLoopDriver {
     async fn handle_failed(&self, record: &LoopRecord) -> Result<LoopState> {
         if record.resume_requested {
             if let Some(failed_from) = record.failed_from_state {
+                // Before resetting retry_count, delete the stale k8s Job
+                // objects from the prior exhausted attempts. Their TTL
+                // window can be up to an hour, so without this cleanup
+                // the resumed dispatch hits AlreadyExists on names like
+                // `...-r{round}-t1` and spins. See codex review of #96.
+                self.delete_stale_failed_attempts(record, failed_from).await;
+
                 let mut updated = record.clone();
                 updated.state = failed_from;
                 updated.failed_from_state = None;

--- a/control-plane/src/loop_engine/reconciler.rs
+++ b/control-plane/src/loop_engine/reconciler.rs
@@ -206,6 +206,7 @@ mod tests {
             resume_requested: false,
             paused_from_state: None,
             reauth_from_state: None,
+            failed_from_state: None,
             failure_reason: None,
             current_sha: None,
             session_id: None,

--- a/control-plane/src/state/mod.rs
+++ b/control-plane/src/state/mod.rs
@@ -173,10 +173,15 @@ pub mod memory {
     impl StateStore for MemoryStateStore {
         async fn create_loop(&self, record: &LoopRecord) -> Result<LoopRecord> {
             let mut loops = self.loops.write().await;
-            // Enforce unique active branch constraint (mirrors Postgres partial unique index)
-            let has_active = loops
-                .values()
-                .any(|l| l.branch == record.branch && !l.state.is_terminal());
+            // Enforce unique active branch constraint (mirrors Postgres
+            // partial unique index, including the #96 FAILED+resume
+            // exception: a failed loop with a pending resume still owns
+            // the branch and must block new loops on it).
+            let has_active = loops.values().any(|l| {
+                l.branch == record.branch
+                    && (!l.state.is_terminal()
+                        || (l.state == LoopState::Failed && l.resume_requested))
+            });
             if has_active {
                 return Err(crate::error::NautiloopError::Database(
                     sqlx::Error::Database(Box::new(MemoryUniqueViolation)),

--- a/control-plane/src/state/mod.rs
+++ b/control-plane/src/state/mod.rs
@@ -195,7 +195,11 @@ pub mod memory {
             let loops = self.loops.read().await;
             Ok(loops
                 .values()
-                .find(|l| l.branch == branch && !l.state.is_terminal())
+                .find(|l| {
+                    l.branch == branch
+                        && (!l.state.is_terminal()
+                            || (l.state == LoopState::Failed && l.resume_requested))
+                })
                 .cloned())
         }
 
@@ -302,9 +306,11 @@ pub mod memory {
 
         async fn has_active_loop_for_branch(&self, branch: &str) -> Result<bool> {
             let loops = self.loops.read().await;
-            Ok(loops
-                .values()
-                .any(|l| l.branch == branch && !l.state.is_terminal()))
+            Ok(loops.values().any(|l| {
+                l.branch == branch
+                    && (!l.state.is_terminal()
+                        || (l.state == LoopState::Failed && l.resume_requested))
+            }))
         }
 
         async fn create_round(&self, record: &RoundRecord) -> Result<()> {

--- a/control-plane/src/state/mod.rs
+++ b/control-plane/src/state/mod.rs
@@ -213,7 +213,11 @@ pub mod memory {
             let loops = self.loops.read().await;
             Ok(loops
                 .values()
-                .filter(|l| !l.state.is_terminal())
+                .filter(|l| {
+                    // #96: include FAILED loops with a pending resume so
+                    // handle_failed gets a chance to redispatch them.
+                    !l.state.is_terminal() || (l.state == LoopState::Failed && l.resume_requested)
+                })
                 .cloned()
                 .collect())
         }

--- a/control-plane/src/state/postgres.rs
+++ b/control-plane/src/state/postgres.rs
@@ -233,8 +233,16 @@ impl StateStore for PgStateStore {
     }
 
     async fn get_loop_by_branch(&self, branch: &str) -> Result<Option<LoopRecord>> {
+        // #96: A FAILED loop with resume_requested=true is effectively
+        // active — it will flip back to its previous stage on the next
+        // reconciler tick — so it MUST count as branch-owning here.
+        // Otherwise between `nemo resume` and the tick, a second
+        // `/start` could acquire the same branch and corrupt the worktree.
         let row = sqlx::query(
-            "SELECT * FROM loops WHERE branch = $1 AND state NOT IN ('CONVERGED', 'FAILED', 'CANCELLED', 'HARDENED', 'SHIPPED')",
+            "SELECT * FROM loops \
+             WHERE branch = $1 \
+               AND (state NOT IN ('CONVERGED', 'FAILED', 'CANCELLED', 'HARDENED', 'SHIPPED') \
+                    OR (state = 'FAILED' AND resume_requested = TRUE))",
         )
         .bind(branch)
         .fetch_optional(&self.pool)
@@ -381,8 +389,15 @@ impl StateStore for PgStateStore {
     }
 
     async fn has_active_loop_for_branch(&self, branch: &str) -> Result<bool> {
+        // #96: FAILED + resume_requested counts as active — see the
+        // matching comment on get_loop_by_branch.
         let row: (bool,) = sqlx::query_as(
-            "SELECT EXISTS(SELECT 1 FROM loops WHERE branch = $1 AND state NOT IN ('CONVERGED', 'FAILED', 'CANCELLED', 'HARDENED', 'SHIPPED'))",
+            "SELECT EXISTS(\
+                 SELECT 1 FROM loops \
+                 WHERE branch = $1 \
+                   AND (state NOT IN ('CONVERGED', 'FAILED', 'CANCELLED', 'HARDENED', 'SHIPPED') \
+                        OR (state = 'FAILED' AND resume_requested = TRUE))\
+             )",
         )
         .bind(branch)
         .fetch_one(&self.pool)

--- a/control-plane/src/state/postgres.rs
+++ b/control-plane/src/state/postgres.rs
@@ -98,6 +98,10 @@ fn row_to_loop_record(row: &PgRow) -> Result<LoopRecord> {
         resume_requested: row.get("resume_requested"),
         paused_from_state: row.get::<Option<LoopState>, _>("paused_from_state"),
         reauth_from_state: row.get::<Option<LoopState>, _>("reauth_from_state"),
+        failed_from_state: row
+            .try_get::<Option<LoopState>, _>("failed_from_state")
+            .ok()
+            .flatten(),
         failure_reason: row.get("failure_reason"),
         current_sha: row.get("current_sha"),
         session_id: row.get("session_id"),
@@ -250,8 +254,14 @@ impl StateStore for PgStateStore {
     }
 
     async fn get_active_loops(&self) -> Result<Vec<LoopRecord>> {
+        // Terminal states are excluded EXCEPT FAILED loops with a pending
+        // resume_requested flag (#96) — those need one reconciler tick to
+        // land in handle_failed and transition back to their original stage.
         let rows = sqlx::query(
-            "SELECT * FROM loops WHERE state NOT IN ('CONVERGED', 'FAILED', 'CANCELLED', 'HARDENED', 'SHIPPED') ORDER BY created_at ASC",
+            "SELECT * FROM loops \
+             WHERE state NOT IN ('CONVERGED', 'FAILED', 'CANCELLED', 'HARDENED', 'SHIPPED') \
+                OR (state = 'FAILED' AND resume_requested = TRUE) \
+             ORDER BY created_at ASC",
         )
         .fetch_all(&self.pool)
         .await?;
@@ -315,6 +325,7 @@ impl StateStore for PgStateStore {
             UPDATE loops SET
                 spec_path = $2, state = $3::loop_state, sub_state = $4::sub_state, round = $5,
                 paused_from_state = $6::loop_state, reauth_from_state = $7::loop_state,
+                failed_from_state = $17::loop_state,
                 failure_reason = $8, current_sha = $9, session_id = $10,
                 active_job_name = $11, retry_count = $12,
                 merge_sha = $13, merged_at = $14,
@@ -339,6 +350,7 @@ impl StateStore for PgStateStore {
         .bind(record.merged_at)
         .bind(&record.hardened_spec_path)
         .bind(&record.spec_pr_url)
+        .bind(record.failed_from_state.map(loop_state_str))
         .execute(&self.pool)
         .await?;
         Ok(())

--- a/control-plane/src/types/mod.rs
+++ b/control-plane/src/types/mod.rs
@@ -263,6 +263,10 @@ pub struct LoopRecord {
     pub resume_requested: bool,
     pub paused_from_state: Option<LoopState>,
     pub reauth_from_state: Option<LoopState>,
+    /// Stage the loop was running when it transitioned to Failed. Used by
+    /// `nemo resume <loop-id>` on FAILED loops to redispatch the correct
+    /// stage against the existing worktree (issue #96).
+    pub failed_from_state: Option<LoopState>,
     pub failure_reason: Option<String>,
     pub current_sha: Option<String>,
     pub session_id: Option<String>,


### PR DESCRIPTION
Closes #96.

A harden loop that errors out at round 8 on a transient condition (OpenAI quota, expired OAuth token, network blip) used to terminate FAILED and throw away the 7 previous rounds of work even though all that state was sitting in the worktree PVC. The only recovery was kubectl exec + kubectl cp + manual commit.

Now `nemo resume <loop-id>` accepts FAILED loops and redispatches the same stage against the existing worktree. Mirrors the existing Paused / AwaitingReauth resume pattern exactly.

## Changes
- **Migration** `20260409000001_add_failed_from_state.sql` — new `failed_from_state` column on `loops`
- **driver**: `handle_failed` mirrors `handle_awaiting_reauth`; `tick` carves out a Failed+resume exception from the terminal short-circuit; `failed_from_state` is captured at both transient-failure sites (job retry exhaustion, verdict parse exhaustion)
- **state**: `get_active_loops` (Postgres + in-memory) includes Failed-with-resume loops so the reconciler picks them up
- **api::resume**: accepts FAILED with populated `failed_from_state`; rejects max-rounds / logical failures with a clear message
- **CLI**: help text updated

## Tests
- `test_failed_resume_redispatches_same_stage` — end-to-end transition
- `test_failed_resume_without_failed_from_state_noops` — max-rounds path stays Failed
- Assertion added to `test_job_failed_exhausts_retries` that `failed_from_state` is captured

## Deliberate scope
- Max-rounds and other **logical** failures leave `failed_from_state` NULL and are not resumable. Resuming them would rerun the same exhaustion.
- Credentials are re-read from the K8s secret at every dispatch (no change needed), so running `nemo auth` between the failure and the resume automatically picks up the fresh token.