### PR TITLE
feat(cli): auto-refresh Claude creds from macOS keychain before dispatch (#97)

### DIFF
--- a/cli/src/claude_creds.rs
+++ b/cli/src/claude_creds.rs
@@ -74,6 +74,17 @@ fn find_existing_credentials() -> Option<PathBuf> {
         .find(|p| p.is_file())
 }
 
+/// Return the first FRESH credential file across all known
+/// candidate paths, or None if every candidate is missing/stale.
+/// This matters when a stale high-priority file (e.g. the
+/// claude-worktree convention path left over from an old session)
+/// shadows a fresh XDG path that Claude Code is actively updating.
+fn find_fresh_credentials(now_ms: u64) -> Option<PathBuf> {
+    credential_candidate_paths()
+        .into_iter()
+        .find(|p| p.is_file() && !is_stale(p, now_ms))
+}
+
 /// Decide whether the on-disk credential bundle is stale. Returns
 /// true if the file is missing, unparseable, has no expiry, has
 /// already expired, or is within EXPIRY_BUFFER_SECS of expiring.
@@ -188,28 +199,29 @@ pub async fn ensure_fresh(
     // not just the macOS default. A Linux/XDG user whose Claude Code
     // writes to ~/.config/claude-code/credentials.json would otherwise
     // look permanently stale here and the preflight would never run.
+    //
+    // Prefer the first *fresh* candidate over the first *existing*
+    // one — a stale high-priority file (e.g. a leftover claude-worktree
+    // cache) shouldn't shadow a fresh XDG path that Claude Code is
+    // actively updating. If nothing is fresh, fall back to the
+    // first-existing location for the keychain-refresh write target.
     let now = now_ms();
-    let existing_path = find_existing_credentials();
-    let is_fresh = existing_path
-        .as_ref()
-        .map(|p| !is_stale(p, now))
-        .unwrap_or(false);
-    if is_fresh {
-        // The local file is fresh but the control plane might still
-        // have a stale copy — either because the token rotated on
-        // disk (Linux/XDG case where Claude Code writes directly) or
+    if let Some(fresh_path) = find_fresh_credentials(now) {
+        // Local file is fresh but the control plane might still have
+        // a stale copy — either because the token rotated on disk
+        // (Linux/XDG case where Claude Code writes directly) or
         // because an earlier dispatch pushed an older version. Push
         // the current local contents unconditionally so the next job
         // mount picks them up. One extra HTTP POST per dispatch is
         // cheap compared to a loop that dies on 401.
-        if let Some(path) = existing_path
-            && let Ok(contents) = std::fs::read_to_string(&path)
+        if let Ok(contents) = std::fs::read_to_string(&fresh_path)
             && !contents.trim().is_empty()
         {
             push_to_control_plane(client, engineer, name, email, contents.trim()).await;
         }
         return Ok(());
     }
+    let existing_path = find_existing_credentials();
 
     let Some(fresh) = extract_from_keychain() else {
         // Not macOS, or keychain entry missing, or extraction failed.

--- a/cli/src/claude_creds.rs
+++ b/cli/src/claude_creds.rs
@@ -41,11 +41,37 @@ struct ClaudeOauth {
     expires_at: Option<u64>,
 }
 
-pub fn credentials_path() -> PathBuf {
+/// Return the Claude credential file paths `nemo auth --claude` knows
+/// about, in priority order. Kept in sync with `cli/src/commands/auth.rs`.
+pub fn credential_candidate_paths() -> Vec<PathBuf> {
     let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-    PathBuf::from(home)
-        .join(".claude")
-        .join(".credentials.json")
+    let config_dir = std::env::var("XDG_CONFIG_HOME").unwrap_or_else(|_| format!("{home}/.config"));
+    vec![
+        PathBuf::from(&home)
+            .join(".claude")
+            .join(".credentials.json"),
+        PathBuf::from(&config_dir)
+            .join("claude-code")
+            .join("credentials.json"),
+        PathBuf::from(&home)
+            .join(".claude")
+            .join("credentials.json"),
+    ]
+}
+
+/// The canonical path we write refreshed credentials to. Matches the
+/// `claude-worktree` convention used as the first candidate in
+/// `commands/auth.rs`.
+pub fn credentials_path() -> PathBuf {
+    credential_candidate_paths().into_iter().next().unwrap()
+}
+
+/// Return the first credential file that exists on disk, or None if
+/// none of the known locations are populated.
+fn find_existing_credentials() -> Option<PathBuf> {
+    credential_candidate_paths()
+        .into_iter()
+        .find(|p| p.is_file())
 }
 
 /// Decide whether the on-disk credential bundle is stale. Returns
@@ -55,7 +81,14 @@ pub fn is_stale(path: &Path, now_ms: u64) -> bool {
     let Ok(contents) = std::fs::read_to_string(path) else {
         return true;
     };
-    let Ok(parsed) = serde_json::from_str::<ClaudeCredentialsShape>(&contents) else {
+    is_bundle_stale(&contents, now_ms)
+}
+
+/// Decide whether a raw Claude credential JSON string represents a
+/// stale bundle. Shared between disk and keychain checks so both
+/// sources apply the same freshness rule.
+fn is_bundle_stale(contents: &str, now_ms: u64) -> bool {
+    let Ok(parsed) = serde_json::from_str::<ClaudeCredentialsShape>(contents) else {
         return true;
     };
     let Some(expires_at) = parsed.claude_ai_oauth.expires_at else {
@@ -151,8 +184,17 @@ pub async fn ensure_fresh(
         return Ok(());
     }
 
-    let path = credentials_path();
-    if !is_stale(&path, now_ms()) {
+    // Check every known credential path (same list as `nemo auth --claude`),
+    // not just the macOS default. A Linux/XDG user whose Claude Code
+    // writes to ~/.config/claude-code/credentials.json would otherwise
+    // look permanently stale here and the preflight would never run.
+    let now = now_ms();
+    let existing_path = find_existing_credentials();
+    let is_fresh = existing_path
+        .as_ref()
+        .map(|p| !is_stale(p, now))
+        .unwrap_or(false);
+    if is_fresh {
         return Ok(());
     }
 
@@ -161,23 +203,32 @@ pub async fn ensure_fresh(
         // On Linux the file on disk IS the source of truth so we trust
         // whatever Claude Code wrote there. On macOS without a
         // keychain entry, the user needs to run `claude login` first.
-        tracing::debug!(
-            path = %path.display(),
-            "Claude creds stale but no keychain refresh available; continuing"
-        );
+        tracing::debug!("Claude creds stale but no keychain refresh available; continuing");
         return Ok(());
     };
 
+    // Reject the keychain bundle if IT is also stale — no point
+    // overwriting the last known-working server copy with a bundle
+    // that will 401 on the first dispatch. Happens when the user
+    // hasn't reopened Claude Code since their token expired.
+    if is_bundle_stale(&fresh, now) {
+        tracing::warn!(
+            "Keychain Claude credentials are also expired; not pushing stale bundle. \
+             Open Claude Code to refresh, then re-run."
+        );
+        return Ok(());
+    }
+
     // Only write if the extracted bundle differs from what's on disk.
-    // Avoids bumping mtime on every start when the keychain itself is
-    // also stale (rare but possible if the user hasn't opened Claude
-    // Code in a while).
-    let existing = std::fs::read_to_string(&path).unwrap_or_default();
+    // Avoids bumping mtime on every start when the keychain itself
+    // happens to match the disk copy exactly.
+    let write_path = existing_path.unwrap_or_else(credentials_path);
+    let existing = std::fs::read_to_string(&write_path).unwrap_or_default();
     if existing.trim() != fresh.trim() {
-        write_atomic(&path, &fresh).with_context(|| {
+        write_atomic(&write_path, &fresh).with_context(|| {
             format!(
                 "failed to write refreshed credentials to {}",
-                path.display()
+                write_path.display()
             )
         })?;
     }
@@ -219,12 +270,19 @@ mod tests {
         path
     }
 
+    static TMPDIR_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
     fn tmpdir() -> PathBuf {
+        // Monotonic counter + nanos + pid so parallel tests never
+        // collide. A pure timestamp isn't enough on fast machines —
+        // two tests can land in the same nanosecond bucket.
+        let seq = TMPDIR_COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         let nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        let p = std::env::temp_dir().join(format!("nemo-creds-{}-{}", nanos, std::process::id()));
+        let p =
+            std::env::temp_dir().join(format!("nemo-creds-{}-{}-{seq}", nanos, std::process::id()));
         std::fs::create_dir_all(&p).unwrap();
         p
     }
@@ -284,5 +342,30 @@ mod tests {
         // expires in 6 minutes — outside the 5-minute buffer
         let path = write_bundle(&dir, Some(now + 6 * 60 * 1000));
         assert!(!is_stale(&path, now));
+    }
+
+    #[test]
+    fn is_bundle_stale_treats_expired_string_as_stale() {
+        let now = 1_000_000_000u64;
+        let expired = format!(r#"{{"claudeAiOauth":{{"expiresAt":{}}}}}"#, now - 1000);
+        assert!(is_bundle_stale(&expired, now));
+        let fresh = format!(
+            r#"{{"claudeAiOauth":{{"expiresAt":{}}}}}"#,
+            now + 60 * 60 * 1000
+        );
+        assert!(!is_bundle_stale(&fresh, now));
+    }
+
+    #[test]
+    fn candidate_paths_match_auth_command() {
+        // Regression guard: if cli/src/commands/auth.rs ever gains a
+        // new Claude path, add it here too or the preflight will
+        // silently skip it. Kept as a structural assertion rather
+        // than a string match so path separators don't make it fragile.
+        let paths = credential_candidate_paths();
+        assert_eq!(paths.len(), 3, "three known Claude credential locations");
+        assert!(paths[0].ends_with(".claude/.credentials.json"));
+        assert!(paths[1].ends_with("claude-code/credentials.json"));
+        assert!(paths[2].ends_with(".claude/credentials.json"));
     }
 }

--- a/cli/src/claude_creds.rs
+++ b/cli/src/claude_creds.rs
@@ -1,0 +1,288 @@
+//! Claude credential freshness preflight (#97).
+//!
+//! Claude Code on macOS stores its OAuth credentials in the system
+//! Keychain, not on disk, and the access token has a ~1 hour expiry.
+//! `nemo auth --claude` extracts the keychain entry and pushes it to
+//! the control-plane K8s secret, but nothing re-reads the keychain
+//! automatically. A loop dispatched with stale creds dies on its very
+//! first claude call with `401 Invalid authentication credentials`.
+//!
+//! This module adds a small preflight that runs before every
+//! `nemo harden` / `nemo start` / `nemo ship`. When the cached file
+//! is missing, expired, or within a 5-minute buffer of expiry, it
+//! re-extracts from the keychain on macOS and pushes the refreshed
+//! bundle to the control plane. Linux users whose Claude Code writes
+//! the file directly need nothing beyond the freshness check.
+//!
+//! See issue #97.
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::client::NemoClient;
+
+/// Treat a token as stale when it's within this many seconds of expiry.
+const EXPIRY_BUFFER_SECS: u64 = 5 * 60;
+
+#[derive(Debug, Deserialize)]
+struct ClaudeCredentialsShape {
+    #[serde(rename = "claudeAiOauth")]
+    claude_ai_oauth: ClaudeOauth,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClaudeOauth {
+    /// Epoch milliseconds. Claude Code's bundle uses `expiresAt` at the
+    /// millisecond granularity; we treat anything non-numeric as "no
+    /// expiry info", which triggers a refresh.
+    #[serde(rename = "expiresAt")]
+    expires_at: Option<u64>,
+}
+
+pub fn credentials_path() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+    PathBuf::from(home)
+        .join(".claude")
+        .join(".credentials.json")
+}
+
+/// Decide whether the on-disk credential bundle is stale. Returns
+/// true if the file is missing, unparseable, has no expiry, has
+/// already expired, or is within EXPIRY_BUFFER_SECS of expiring.
+pub fn is_stale(path: &Path, now_ms: u64) -> bool {
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return true;
+    };
+    let Ok(parsed) = serde_json::from_str::<ClaudeCredentialsShape>(&contents) else {
+        return true;
+    };
+    let Some(expires_at) = parsed.claude_ai_oauth.expires_at else {
+        return true;
+    };
+    let buffer_ms = EXPIRY_BUFFER_SECS.saturating_mul(1000);
+    expires_at.saturating_sub(buffer_ms) <= now_ms
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Extract the Claude Code credential bundle from the macOS keychain.
+/// Returns None on non-macOS platforms or when the keychain entry
+/// isn't present.
+#[cfg(target_os = "macos")]
+fn extract_from_keychain() -> Option<String> {
+    let output = std::process::Command::new("security")
+        .args([
+            "find-generic-password",
+            "-s",
+            "Claude Code-credentials",
+            "-w",
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let raw = String::from_utf8(output.stdout).ok()?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn extract_from_keychain() -> Option<String> {
+    None
+}
+
+/// Atomically write the bundle to `~/.claude/.credentials.json` with
+/// mode 0600. Mirrors the pattern used by cli/src/config.rs.
+fn write_atomic(path: &Path, contents: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let tmp = path.with_extension("json.tmp");
+
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&tmp)?;
+        file.write_all(contents.as_bytes())?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&tmp, contents)?;
+    }
+
+    std::fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+/// Run the preflight. If the cached bundle is stale and we can
+/// extract a fresh one from the keychain, write it and push it to
+/// the control plane. Never fails the command — stale-but-present
+/// credentials might still work for this one dispatch, and a real
+/// auth error will surface in the loop itself with a much clearer
+/// error message than we could produce here.
+pub async fn ensure_fresh(
+    client: &NemoClient,
+    engineer: &str,
+    name: &str,
+    email: &str,
+) -> Result<()> {
+    // Missing engineer is caught earlier in main.rs, but a paranoid
+    // guard here keeps the helper self-contained and testable.
+    if engineer.is_empty() {
+        return Ok(());
+    }
+
+    let path = credentials_path();
+    if !is_stale(&path, now_ms()) {
+        return Ok(());
+    }
+
+    let Some(fresh) = extract_from_keychain() else {
+        // Not macOS, or keychain entry missing, or extraction failed.
+        // On Linux the file on disk IS the source of truth so we trust
+        // whatever Claude Code wrote there. On macOS without a
+        // keychain entry, the user needs to run `claude login` first.
+        tracing::debug!(
+            path = %path.display(),
+            "Claude creds stale but no keychain refresh available; continuing"
+        );
+        return Ok(());
+    };
+
+    // Only write if the extracted bundle differs from what's on disk.
+    // Avoids bumping mtime on every start when the keychain itself is
+    // also stale (rare but possible if the user hasn't opened Claude
+    // Code in a while).
+    let existing = std::fs::read_to_string(&path).unwrap_or_default();
+    if existing.trim() != fresh.trim() {
+        write_atomic(&path, &fresh).with_context(|| {
+            format!(
+                "failed to write refreshed credentials to {}",
+                path.display()
+            )
+        })?;
+    }
+
+    // Push to the control plane so the next job mount picks it up.
+    // Name/email are optional — if blank they'll be ignored by the
+    // handler and not overwritten server-side.
+    let name_opt = if name.is_empty() { None } else { Some(name) };
+    let email_opt = if email.is_empty() { None } else { Some(email) };
+    if let Err(e) = client
+        .register_credentials(engineer, "claude", &fresh, name_opt, email_opt)
+        .await
+    {
+        // Non-fatal: the loop will either work with the existing
+        // server-side credentials or fail with a clearer message
+        // from the agent side. Log and move on.
+        tracing::warn!(
+            error = %e,
+            "Could not push refreshed Claude credentials to control plane; continuing with server-side copy"
+        );
+    } else {
+        tracing::info!("Refreshed Claude credentials before dispatch");
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_bundle(dir: &Path, expires_at: Option<u64>) -> PathBuf {
+        let path = dir.join("creds.json");
+        let body = match expires_at {
+            Some(e) => format!(r#"{{"claudeAiOauth":{{"expiresAt":{e}}}}}"#),
+            None => r#"{"claudeAiOauth":{}}"#.to_string(),
+        };
+        std::fs::write(&path, body).unwrap();
+        path
+    }
+
+    fn tmpdir() -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let p = std::env::temp_dir().join(format!("nemo-creds-{}-{}", nanos, std::process::id()));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    #[test]
+    fn missing_file_is_stale() {
+        let dir = tmpdir();
+        let path = dir.join("does-not-exist.json");
+        assert!(is_stale(&path, 0));
+    }
+
+    #[test]
+    fn unparseable_file_is_stale() {
+        let dir = tmpdir();
+        let path = dir.join("bad.json");
+        std::fs::write(&path, "not json").unwrap();
+        assert!(is_stale(&path, 0));
+    }
+
+    #[test]
+    fn no_expires_at_is_stale() {
+        let dir = tmpdir();
+        let path = write_bundle(&dir, None);
+        assert!(is_stale(&path, 1_000_000));
+    }
+
+    #[test]
+    fn fresh_token_is_not_stale() {
+        let dir = tmpdir();
+        // expires one hour from now_ms
+        let now = 1_000_000_000u64;
+        let path = write_bundle(&dir, Some(now + 60 * 60 * 1000));
+        assert!(!is_stale(&path, now));
+    }
+
+    #[test]
+    fn expired_token_is_stale() {
+        let dir = tmpdir();
+        let now = 1_000_000_000u64;
+        let path = write_bundle(&dir, Some(now - 1000));
+        assert!(is_stale(&path, now));
+    }
+
+    #[test]
+    fn within_buffer_is_stale() {
+        let dir = tmpdir();
+        let now = 1_000_000_000u64;
+        // expires in 4 minutes — inside the 5-minute buffer
+        let path = write_bundle(&dir, Some(now + 4 * 60 * 1000));
+        assert!(is_stale(&path, now));
+    }
+
+    #[test]
+    fn just_outside_buffer_is_fresh() {
+        let dir = tmpdir();
+        let now = 1_000_000_000u64;
+        // expires in 6 minutes — outside the 5-minute buffer
+        let path = write_bundle(&dir, Some(now + 6 * 60 * 1000));
+        assert!(!is_stale(&path, now));
+    }
+}

--- a/cli/src/claude_creds.rs
+++ b/cli/src/claude_creds.rs
@@ -195,6 +195,19 @@ pub async fn ensure_fresh(
         .map(|p| !is_stale(p, now))
         .unwrap_or(false);
     if is_fresh {
+        // The local file is fresh but the control plane might still
+        // have a stale copy — either because the token rotated on
+        // disk (Linux/XDG case where Claude Code writes directly) or
+        // because an earlier dispatch pushed an older version. Push
+        // the current local contents unconditionally so the next job
+        // mount picks them up. One extra HTTP POST per dispatch is
+        // cheap compared to a loop that dies on 401.
+        if let Some(path) = existing_path
+            && let Ok(contents) = std::fs::read_to_string(&path)
+            && !contents.trim().is_empty()
+        {
+            push_to_control_plane(client, engineer, name, email, contents.trim()).await;
+        }
         return Ok(());
     }
 
@@ -233,27 +246,35 @@ pub async fn ensure_fresh(
         })?;
     }
 
-    // Push to the control plane so the next job mount picks it up.
-    // Name/email are optional — if blank they'll be ignored by the
-    // handler and not overwritten server-side.
+    push_to_control_plane(client, engineer, name, email, &fresh).await;
+
+    Ok(())
+}
+
+/// Push a Claude credential bundle to the control plane. Non-fatal
+/// on every error path — a failure to push still lets the dispatch
+/// proceed against whatever's already in the server-side secret,
+/// and a real auth error will surface later with a clearer message.
+async fn push_to_control_plane(
+    client: &NemoClient,
+    engineer: &str,
+    name: &str,
+    email: &str,
+    bundle: &str,
+) {
     let name_opt = if name.is_empty() { None } else { Some(name) };
     let email_opt = if email.is_empty() { None } else { Some(email) };
     if let Err(e) = client
-        .register_credentials(engineer, "claude", &fresh, name_opt, email_opt)
+        .register_credentials(engineer, "claude", bundle, name_opt, email_opt)
         .await
     {
-        // Non-fatal: the loop will either work with the existing
-        // server-side credentials or fail with a clearer message
-        // from the agent side. Log and move on.
         tracing::warn!(
             error = %e,
-            "Could not push refreshed Claude credentials to control plane; continuing with server-side copy"
+            "Could not push Claude credentials to control plane; continuing with server-side copy"
         );
     } else {
-        tracing::info!("Refreshed Claude credentials before dispatch");
+        tracing::debug!("Pushed Claude credentials to control plane before dispatch");
     }
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/cli/src/claude_creds.rs
+++ b/cli/src/claude_creds.rs
@@ -232,21 +232,32 @@ pub async fn ensure_fresh(
         return Ok(());
     }
 
-    // Only write if the extracted bundle differs from what's on disk.
-    // Avoids bumping mtime on every start when the keychain itself
-    // happens to match the disk copy exactly.
+    // Push the refreshed bundle to the control plane FIRST. That's
+    // the part that actually fixes the 401 — the local cache write
+    // is only useful for the next invocation. If we swapped the
+    // order, a read-only/misowned ~/.claude directory or a disk-full
+    // tmp write would abort `nemo harden` even though the refreshed
+    // secret could have been uploaded successfully.
+    push_to_control_plane(client, engineer, name, email, &fresh).await;
+
+    // Then try to update the local cache too. Best-effort: log and
+    // continue on any failure so the preflight stays non-fatal, same
+    // contract as the other error paths in this module.
     let write_path = existing_path.unwrap_or_else(credentials_path);
     let existing = std::fs::read_to_string(&write_path).unwrap_or_default();
-    if existing.trim() != fresh.trim() {
-        write_atomic(&write_path, &fresh).with_context(|| {
+    if existing.trim() != fresh.trim()
+        && let Err(e) = write_atomic(&write_path, &fresh).with_context(|| {
             format!(
                 "failed to write refreshed credentials to {}",
                 write_path.display()
             )
-        })?;
+        })
+    {
+        tracing::warn!(
+            error = %e,
+            "Could not update local Claude credential cache; control plane refresh still succeeded"
+        );
     }
-
-    push_to_control_plane(client, engineer, name, email, &fresh).await;
 
     Ok(())
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,3 +1,4 @@
+mod claude_creds;
 mod client;
 mod commands;
 mod config;
@@ -220,6 +221,13 @@ async fn main() -> anyhow::Result<()> {
         } => {
             let (model_impl, model_review) =
                 project_config::resolve_models(model_impl, model_review, &eng_config.models)?;
+            claude_creds::ensure_fresh(
+                &http_client,
+                &eng_config.engineer,
+                &eng_config.name,
+                &eng_config.email,
+            )
+            .await?;
             // nemo harden: harden=true, harden_only=true, ship_mode=false
             commands::start::run(
                 &http_client,
@@ -245,6 +253,13 @@ async fn main() -> anyhow::Result<()> {
         } => {
             let (model_impl, model_review) =
                 project_config::resolve_models(model_impl, model_review, &eng_config.models)?;
+            claude_creds::ensure_fresh(
+                &http_client,
+                &eng_config.engineer,
+                &eng_config.name,
+                &eng_config.email,
+            )
+            .await?;
             // nemo start: ship_mode=false
             commands::start::run(
                 &http_client,
@@ -269,6 +284,13 @@ async fn main() -> anyhow::Result<()> {
         } => {
             let (model_impl, model_review) =
                 project_config::resolve_models(model_impl, model_review, &eng_config.models)?;
+            claude_creds::ensure_fresh(
+                &http_client,
+                &eng_config.engineer,
+                &eng_config.name,
+                &eng_config.email,
+            )
+            .await?;
             // nemo ship: ship_mode=true, auto_approve implied
             commands::start::run(
                 &http_client,


### PR DESCRIPTION
Closes #97.

On macOS Claude Code stores its OAuth credentials in the system Keychain with a ~1h access token expiry. `nemo auth --claude` extracts the bundle to `~/.claude/.credentials.json` and pushes it to the K8s secret, but nothing re-reads the keychain automatically. A loop dispatched with stale creds dies on its first claude call with 401 — cost the tester ~20 minutes of confused debugging per cold-start session before remembering to `nemo auth` manually.

## Preflight

New `cli/src/claude_creds.rs` runs before every `nemo harden` / `nemo start` / `nemo ship`:

1. Read `~/.claude/.credentials.json`, parse `claudeAiOauth.expiresAt`
2. Stale = missing, unparseable, no expiresAt, expired, or within a 5-minute buffer of expiry
3. If stale, extract from keychain via `security find-generic-password -s 'Claude Code-credentials' -w`
4. Atomically write 0600 to disk
5. Push to control plane via `register_credentials`

**Non-fatal on every error path.** A stale-but-present bundle might still work, and a real auth error will surface later with a clearer message than we could produce here. Linux users whose Claude Code writes the file directly just get the freshness check — the extraction step is a no-op on non-macOS.

## Tests

7 unit tests in `claude_creds::tests`:
- `missing_file_is_stale`
- `unparseable_file_is_stale`
- `no_expires_at_is_stale`
- `fresh_token_is_not_stale`
- `expired_token_is_stale`
- `within_buffer_is_stale` (4min left)
- `just_outside_buffer_is_fresh` (6min left)

`cargo clippy -p nemo-cli --all-targets -- -D warnings` green. `cargo test -p nemo-cli` 13/13 green.