### PR TITLE
feat(cli): nemo logs --tail — live pod stdout without kubectl (#99 first slice)

### DIFF
--- a/cli/src/commands/logs.rs
+++ b/cli/src/commands/logs.rs
@@ -30,14 +30,13 @@ pub async fn run_tail(
     let resp = client.get_stream(&path).await?;
     let status = resp.status();
     let text = resp.text().await?;
+    // Server returns 204 No Content for benign "no pod" states.
+    // 4xx/5xx are real errors. 200 = real log output.
+    if status == reqwest::StatusCode::NO_CONTENT {
+        return Ok(TailResult::NoPod);
+    }
     if !status.is_success() {
         anyhow::bail!("pod-logs returned {status}: {text}");
-    }
-    // The server returns 200 with a "# ..." comment line for benign
-    // no-pod states (between-stage gap, container still creating).
-    // Treat as NoPod so the CLI can fall back to historical logs.
-    if text.starts_with("# ") && text.lines().count() <= 2 {
-        return Ok(TailResult::NoPod);
     }
     print!("{text}");
     if !text.ends_with('\n') {

--- a/cli/src/commands/logs.rs
+++ b/cli/src/commands/logs.rs
@@ -9,12 +9,23 @@ use crate::client::NemoClient;
 /// directly, bypassing the Postgres log stream. Works mid-run and
 /// gives an operator the same information `kubectl logs -c agent`
 /// would, without requiring kubectl access.
+/// Result of `run_tail`: either real pod logs were printed, or an
+/// informational "no pod" banner was received (the caller may want
+/// to fall back to historical logs in that case).
+pub enum TailResult {
+    /// Real log output was printed.
+    Ok,
+    /// Server returned a benign "no pod yet" or similar info banner.
+    /// The caller should fall back to /logs/{id}.
+    NoPod,
+}
+
 pub async fn run_tail(
     client: &NemoClient,
     loop_id: &str,
     tail_lines: u32,
     container: &str,
-) -> Result<()> {
+) -> Result<TailResult> {
     let path = format!("/pod-logs/{loop_id}?tail={tail_lines}&container={container}");
     let resp = client.get_stream(&path).await?;
     let status = resp.status();
@@ -22,11 +33,17 @@ pub async fn run_tail(
     if !status.is_success() {
         anyhow::bail!("pod-logs returned {status}: {text}");
     }
+    // The server returns 200 with a "# ..." comment line for benign
+    // no-pod states (between-stage gap, container still creating).
+    // Treat as NoPod so the CLI can fall back to historical logs.
+    if text.starts_with("# ") && text.lines().count() <= 2 {
+        return Ok(TailResult::NoPod);
+    }
     print!("{text}");
     if !text.ends_with('\n') {
         println!();
     }
-    Ok(())
+    Ok(TailResult::Ok)
 }
 
 pub async fn run(

--- a/cli/src/commands/logs.rs
+++ b/cli/src/commands/logs.rs
@@ -3,6 +3,32 @@ use futures::StreamExt;
 
 use crate::client::NemoClient;
 
+/// One-shot dump of the active pod's container logs (#99).
+///
+/// Hits the /pod-logs/{id} endpoint which reads kubernetes pod logs
+/// directly, bypassing the Postgres log stream. Works mid-run and
+/// gives an operator the same information `kubectl logs -c agent`
+/// would, without requiring kubectl access.
+pub async fn run_tail(
+    client: &NemoClient,
+    loop_id: &str,
+    tail_lines: u32,
+    container: &str,
+) -> Result<()> {
+    let path = format!("/pod-logs/{loop_id}?tail={tail_lines}&container={container}");
+    let resp = client.get_stream(&path).await?;
+    let status = resp.status();
+    let text = resp.text().await?;
+    if !status.is_success() {
+        anyhow::bail!("pod-logs returned {status}: {text}");
+    }
+    print!("{text}");
+    if !text.ends_with('\n') {
+        println!();
+    }
+    Ok(())
+}
+
 pub async fn run(
     client: &NemoClient,
     loop_id: &str,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -332,6 +332,15 @@ async fn main() -> anyhow::Result<()> {
             container,
         } => {
             if tail {
+                // --tail reads raw pod container stdout, which has
+                // no round/stage structure to filter on. Fail loud
+                // instead of silently ignoring the flags.
+                if round.is_some() || stage.is_some() {
+                    anyhow::bail!(
+                        "--round / --stage are not supported with --tail (pod stdout is unstructured); \
+                         run without --tail for filtered historical logs"
+                    );
+                }
                 commands::logs::run_tail(&http_client, &loop_id, tail_lines, &container).await?;
             } else {
                 commands::logs::run(&http_client, &loop_id, round, stage).await?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -100,6 +100,19 @@ enum Commands {
         /// Filter by stage (implement/test/review)
         #[arg(long)]
         stage: Option<String>,
+
+        /// Dump live stdout from the active pod container instead of
+        /// the Postgres log stream. Works mid-run without kubectl.
+        #[arg(long)]
+        tail: bool,
+
+        /// Max lines to return with --tail (default 500, max 10000)
+        #[arg(long, default_value_t = 500)]
+        tail_lines: u32,
+
+        /// Container to read from with --tail ("agent" or "auth-sidecar")
+        #[arg(long, default_value = "agent")]
+        container: String,
     },
 
     /// Cancel a running loop
@@ -314,8 +327,15 @@ async fn main() -> anyhow::Result<()> {
             loop_id,
             round,
             stage,
+            tail,
+            tail_lines,
+            container,
         } => {
-            commands::logs::run(&http_client, &loop_id, round, stage).await?;
+            if tail {
+                commands::logs::run_tail(&http_client, &loop_id, tail_lines, &container).await?;
+            } else {
+                commands::logs::run(&http_client, &loop_id, round, stage).await?;
+            }
         }
         Commands::Cancel { loop_id } => {
             commands::cancel::run(&http_client, &loop_id).await?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -349,8 +349,12 @@ async fn main() -> anyhow::Result<()> {
                 {
                     Ok(commands::logs::TailResult::Ok) => {}
                     Ok(commands::logs::TailResult::NoPod) => {
-                        eprintln!("--tail: no active pod; falling back to historical logs");
-                        commands::logs::run(&http_client, &loop_id, None, None).await?;
+                        // Don't fall back to the SSE stream here — that
+                        // would block forever if the loop is paused or
+                        // awaiting approval/auth. Just inform and exit.
+                        eprintln!(
+                            "No active pod. The loop may be between stages, paused, or awaiting auth. Try again shortly or use `nemo logs {loop_id}` (without --tail) for historical logs."
+                        );
                     }
                     Err(e) => {
                         let msg = e.to_string();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -347,10 +347,14 @@ async fn main() -> anyhow::Result<()> {
                 // should surface directly to the operator.
                 match commands::logs::run_tail(&http_client, &loop_id, tail_lines, &container).await
                 {
-                    Ok(()) => {}
+                    Ok(commands::logs::TailResult::Ok) => {}
+                    Ok(commands::logs::TailResult::NoPod) => {
+                        eprintln!("--tail: no active pod; falling back to historical logs");
+                        commands::logs::run(&http_client, &loop_id, None, None).await?;
+                    }
                     Err(e) => {
                         let msg = e.to_string();
-                        if msg.contains("use `nemo logs") || msg.contains("no active pod") {
+                        if msg.contains("use `nemo logs") {
                             eprintln!("--tail: {msg}; falling back to historical logs");
                             commands::logs::run(&http_client, &loop_id, None, None).await?;
                         } else {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -341,7 +341,15 @@ async fn main() -> anyhow::Result<()> {
                          run without --tail for filtered historical logs"
                     );
                 }
-                commands::logs::run_tail(&http_client, &loop_id, tail_lines, &container).await?;
+                // If --tail fails (e.g. loop is terminal), fall back
+                // to the historical /logs/{id} stream so the user
+                // doesn't have to retype without --tail.
+                if let Err(e) =
+                    commands::logs::run_tail(&http_client, &loop_id, tail_lines, &container).await
+                {
+                    eprintln!("--tail: {e}; falling back to historical logs");
+                    commands::logs::run(&http_client, &loop_id, None, None).await?;
+                }
             } else {
                 commands::logs::run(&http_client, &loop_id, round, stage).await?;
             }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -341,14 +341,22 @@ async fn main() -> anyhow::Result<()> {
                          run without --tail for filtered historical logs"
                     );
                 }
-                // If --tail fails (e.g. loop is terminal), fall back
-                // to the historical /logs/{id} stream so the user
-                // doesn't have to retype without --tail.
-                if let Err(e) =
-                    commands::logs::run_tail(&http_client, &loop_id, tail_lines, &container).await
+                // If --tail fails because the loop is terminal or has
+                // no active pod, fall back to historical logs. Other
+                // errors (bad container name, control plane down, etc.)
+                // should surface directly to the operator.
+                match commands::logs::run_tail(&http_client, &loop_id, tail_lines, &container).await
                 {
-                    eprintln!("--tail: {e}; falling back to historical logs");
-                    commands::logs::run(&http_client, &loop_id, None, None).await?;
+                    Ok(()) => {}
+                    Err(e) => {
+                        let msg = e.to_string();
+                        if msg.contains("use `nemo logs") || msg.contains("no active pod") {
+                            eprintln!("--tail: {msg}; falling back to historical logs");
+                            commands::logs::run(&http_client, &loop_id, None, None).await?;
+                        } else {
+                            return Err(e);
+                        }
+                    }
                 }
             } else {
                 commands::logs::run(&http_client, &loop_id, round, stage).await?;

--- a/control-plane/src/api/handlers.rs
+++ b/control-plane/src/api/handlers.rs
@@ -267,6 +267,93 @@ pub async fn logs(
     )
 }
 
+/// GET /pod-logs/:id?tail=N&container=agent - Live pod logs for a running loop (#99).
+///
+/// Unlike `/logs/{id}`, this bypasses the Postgres logs table and reads the
+/// active pod's container logs directly from the kubernetes API. It's the
+/// fastest path to "what is the agent actually printing right now" without
+/// requiring kubectl access. Returns 200 with a plain-text body or 404 if
+/// the loop has no active pod (terminated, cancelled, between-stage).
+///
+/// Query params:
+/// - `tail`: max lines to return (default 500, max 10000)
+/// - `container`: container name to read from (default "agent"; "auth-sidecar"
+///   is the other interesting one for egress debugging)
+pub async fn pod_logs(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    Query(query): Query<std::collections::HashMap<String, String>>,
+) -> Result<axum::response::Response, NautiloopError> {
+    use axum::http::header;
+    use axum::response::IntoResponse;
+
+    let record = state
+        .store
+        .get_loop(id)
+        .await?
+        .ok_or(NautiloopError::LoopNotFound { id })?;
+
+    let Some(job_name) = record.active_job_name.clone() else {
+        return Err(NautiloopError::BadRequest(format!(
+            "loop {id} has no active pod (state={})",
+            record.state
+        )));
+    };
+
+    let tail_lines: i64 = query
+        .get("tail")
+        .and_then(|s| s.parse().ok())
+        .map(|n: i64| n.clamp(1, 10_000))
+        .unwrap_or(500);
+    let container = query
+        .get("container")
+        .cloned()
+        .unwrap_or_else(|| "agent".to_string());
+    if container != "agent" && container != "auth-sidecar" {
+        return Err(NautiloopError::BadRequest(format!(
+            "container must be 'agent' or 'auth-sidecar', got {container}"
+        )));
+    }
+
+    let kube_client = state.kube_client.as_ref().ok_or_else(|| {
+        NautiloopError::Internal("K8s client not available — pod logs disabled".to_string())
+    })?;
+    let namespace = &state.config.cluster.jobs_namespace;
+    let pods_api: kube::Api<k8s_openapi::api::core::v1::Pod> =
+        kube::Api::namespaced(kube_client.clone(), namespace);
+    let lp = kube::api::ListParams::default().labels(&format!("job-name={job_name}"));
+    let pod_list = pods_api.list(&lp).await.map_err(|e| {
+        NautiloopError::Internal(format!("Failed to list pods for {job_name}: {e}"))
+    })?;
+
+    let Some(pod) = pod_list.items.first() else {
+        return Err(NautiloopError::BadRequest(format!(
+            "no pod found for active job {job_name} (TTL cleanup or pre-creation race?)"
+        )));
+    };
+    let Some(pod_name) = pod.metadata.name.as_ref() else {
+        return Err(NautiloopError::Internal(
+            "pod matched by label selector has no name".to_string(),
+        ));
+    };
+
+    let log_params = kube::api::LogParams {
+        container: Some(container),
+        tail_lines: Some(tail_lines),
+        ..Default::default()
+    };
+    let logs = pods_api.logs(pod_name, &log_params).await.map_err(|e| {
+        NautiloopError::Internal(format!("Failed to read pod logs for {pod_name}: {e}"))
+    })?;
+
+    Ok((
+        axum::http::StatusCode::OK,
+        [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
+        logs,
+    )
+        .into_response())
+}
+
 /// DELETE /cancel/:id - Cancel a running loop.
 pub async fn cancel(
     State(state): State<AppState>,

--- a/control-plane/src/api/handlers.rs
+++ b/control-plane/src/api/handlers.rs
@@ -360,18 +360,40 @@ pub async fn pod_logs(
         )));
     }
 
-    // Iterate matching pods and return the first successful logs result.
-    // A Job can have multiple pods after eviction or node loss, and
-    // list order is not guaranteed by k8s, so trying only the first
-    // pod would be racy. Mirrors control-plane/src/k8s/client.rs
-    // `get_job_logs` which already does this loop.
+    // Sort matching pods: Running > Pending > rest, newest first within
+    // each phase. After eviction/node loss a Job can have multiple pods
+    // and list order is not guaranteed, so without this sort we'd risk
+    // returning stale output from an older terminated pod. The sort key
+    // is (phase_rank, negated creation timestamp) so `first()` after
+    // sort is the best candidate.
+    let mut sorted_pods = pod_list.items.clone();
+    sorted_pods.sort_by(|a, b| {
+        let phase_rank = |p: &k8s_openapi::api::core::v1::Pod| -> u8 {
+            match p.status.as_ref().and_then(|s| s.phase.as_deref()) {
+                Some("Running") => 0,
+                Some("Pending") => 1,
+                _ => 2,
+            }
+        };
+        let ts = |p: &k8s_openapi::api::core::v1::Pod| -> i64 {
+            p.metadata
+                .creation_timestamp
+                .as_ref()
+                .map(|t| t.0.timestamp())
+                .unwrap_or(0)
+        };
+        phase_rank(a)
+            .cmp(&phase_rank(b))
+            .then_with(|| ts(b).cmp(&ts(a)))
+    });
+
     let log_params = kube::api::LogParams {
         container: Some(container),
         tail_lines: Some(tail_lines),
         ..Default::default()
     };
     let mut logs: Option<String> = None;
-    for pod in &pod_list.items {
+    for pod in &sorted_pods {
         if let Some(pod_name) = &pod.metadata.name {
             match pods_api.logs(pod_name, &log_params).await {
                 Ok(l) => {

--- a/control-plane/src/api/handlers.rs
+++ b/control-plane/src/api/handlers.rs
@@ -310,10 +310,21 @@ pub async fn pod_logs(
             .into_response()
     }
 
+    // Terminal loops with no active pod: there's nothing to tail.
+    // Return an appropriate error so the CLI can fall back to the
+    // historical /logs/{id} endpoint. Only non-terminal loops with
+    // no active_job_name (between-stage gap, just-dispatched) get
+    // the benign 200 info_response.
     let Some(job_name) = record.active_job_name.clone() else {
+        if record.state.is_terminal() {
+            return Err(NautiloopError::BadRequest(format!(
+                "loop {id} is {}: use `nemo logs {}` (without --tail) for historical logs",
+                record.state, id,
+            )));
+        }
         return Ok(info_response(format!(
-            "# loop {id} has no active pod right now (state={})\n",
-            record.state
+            "# loop {id} is between stages (state={}), no active pod right now\n",
+            record.state,
         )));
     };
 
@@ -343,27 +354,45 @@ pub async fn pod_logs(
         NautiloopError::Internal(format!("Failed to list pods for {job_name}: {e}"))
     })?;
 
-    let Some(pod) = pod_list.items.first() else {
-        // Normal race: active_job_name is persisted before the Job's
-        // pod exists. Retrying in a few seconds usually works. Return
-        // a 200 with a hint instead of a 4xx so the CLI doesn't bark.
+    if pod_list.items.is_empty() {
         return Ok(info_response(format!(
             "# no pod yet for job {job_name} (pre-creation race or TTL cleanup)\n"
         )));
-    };
-    let Some(pod_name) = pod.metadata.name.as_ref() else {
-        return Err(NautiloopError::Internal(
-            "pod matched by label selector has no name".to_string(),
-        ));
-    };
+    }
 
+    // Iterate matching pods and return the first successful logs result.
+    // A Job can have multiple pods after eviction or node loss, and
+    // list order is not guaranteed by k8s, so trying only the first
+    // pod would be racy. Mirrors control-plane/src/k8s/client.rs
+    // `get_job_logs` which already does this loop.
     let log_params = kube::api::LogParams {
         container: Some(container),
         tail_lines: Some(tail_lines),
         ..Default::default()
     };
-    let logs = pods_api.logs(pod_name, &log_params).await.map_err(|e| {
-        NautiloopError::Internal(format!("Failed to read pod logs for {pod_name}: {e}"))
+    let mut logs: Option<String> = None;
+    for pod in &pod_list.items {
+        if let Some(pod_name) = &pod.metadata.name {
+            match pods_api.logs(pod_name, &log_params).await {
+                Ok(l) => {
+                    logs = Some(l);
+                    break;
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        pod = %pod_name,
+                        error = %e,
+                        "Failed to read logs from pod (trying next)"
+                    );
+                }
+            }
+        }
+    }
+    let logs = logs.ok_or_else(|| {
+        NautiloopError::Internal(format!(
+            "All {} matching pods failed to return logs for job {job_name}",
+            pod_list.items.len()
+        ))
     })?;
 
     Ok((

--- a/control-plane/src/api/handlers.rs
+++ b/control-plane/src/api/handlers.rs
@@ -388,12 +388,30 @@ pub async fn pod_logs(
             }
         }
     }
-    let logs = logs.ok_or_else(|| {
-        NautiloopError::Internal(format!(
-            "All {} matching pods failed to return logs for job {job_name}",
-            pod_list.items.len()
-        ))
-    })?;
+    let logs = match logs {
+        Some(l) => l,
+        None => {
+            // All pods' logs() calls failed. This is normal right
+            // after dispatch when the container is still creating.
+            // Check if any pod is Pending — if so, return the
+            // benign 200 hint instead of a 500.
+            let any_pending = pod_list.items.iter().any(|p| {
+                p.status
+                    .as_ref()
+                    .and_then(|s| s.phase.as_deref())
+                    .is_none_or(|ph| ph == "Pending")
+            });
+            if any_pending {
+                return Ok(info_response(format!(
+                    "# pod for job {job_name} is still initializing (container creating)\n"
+                )));
+            }
+            return Err(NautiloopError::Internal(format!(
+                "All {} matching pods failed to return logs for job {job_name}",
+                pod_list.items.len()
+            )));
+        }
+    };
 
     Ok((
         axum::http::StatusCode::OK,

--- a/control-plane/src/api/handlers.rs
+++ b/control-plane/src/api/handlers.rs
@@ -302,8 +302,10 @@ pub async fn pod_logs(
     fn info_response(msg: String) -> axum::response::Response {
         use axum::http::header;
         use axum::response::IntoResponse;
+        // Custom header so the CLI can detect "info, no real logs"
+        // without guessing from body content (codex round 6 on #99).
         (
-            axum::http::StatusCode::OK,
+            axum::http::StatusCode::NO_CONTENT,
             [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
             msg,
         )

--- a/control-plane/src/api/handlers.rs
+++ b/control-plane/src/api/handlers.rs
@@ -293,9 +293,26 @@ pub async fn pod_logs(
         .await?
         .ok_or(NautiloopError::LoopNotFound { id })?;
 
+    // Helper: build a 200 OK informational text body so the CLI
+    // doesn't treat the benign "pod not ready yet" race condition
+    // like an error. The control plane persists active_job_name
+    // before the pod exists, so nemo logs --tail can land here
+    // right after a dispatch and succeed a few seconds later. A
+    // 4xx here would trigger unnecessary alerting.
+    fn info_response(msg: String) -> axum::response::Response {
+        use axum::http::header;
+        use axum::response::IntoResponse;
+        (
+            axum::http::StatusCode::OK,
+            [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
+            msg,
+        )
+            .into_response()
+    }
+
     let Some(job_name) = record.active_job_name.clone() else {
-        return Err(NautiloopError::BadRequest(format!(
-            "loop {id} has no active pod (state={})",
+        return Ok(info_response(format!(
+            "# loop {id} has no active pod right now (state={})\n",
             record.state
         )));
     };
@@ -327,8 +344,11 @@ pub async fn pod_logs(
     })?;
 
     let Some(pod) = pod_list.items.first() else {
-        return Err(NautiloopError::BadRequest(format!(
-            "no pod found for active job {job_name} (TTL cleanup or pre-creation race?)"
+        // Normal race: active_job_name is persisted before the Job's
+        // pod exists. Retrying in a few seconds usually works. Return
+        // a 200 with a hint instead of a 4xx so the CLI doesn't bark.
+        return Ok(info_response(format!(
+            "# no pod yet for job {job_name} (pre-creation race or TTL cleanup)\n"
         )));
     };
     let Some(pod_name) = pod.metadata.name.as_ref() else {

--- a/control-plane/src/api/mod.rs
+++ b/control-plane/src/api/mod.rs
@@ -56,6 +56,7 @@ fn build_routes(_state: AppState) -> Router<AppState> {
         .route("/start", post(handlers::start))
         .route("/status", get(handlers::status))
         .route("/logs/{id}", get(handlers::logs))
+        .route("/pod-logs/{id}", get(handlers::pod_logs))
         .route("/cancel/{id}", delete(handlers::cancel))
         .route("/approve/{id}", post(handlers::approve))
         .route("/resume/{id}", post(handlers::resume))


### PR DESCRIPTION
Partial progress on #99. The full observability surface (watch, debug, persistence across termination) is multi-PR territory per the issue body; this is the smallest useful slice.

## Problem
`nemo logs <loop-id>` streams from the Postgres logs table via SSE, but `append_log` is defined and never called. On a running loop, `nemo logs` returns empty until the loop terminates. Every mid-loop debug session this week fell back to `kubectl exec` into the pod to tail `/tmp/cli-stdout-*`.

## This PR
- **`GET /pod-logs/{id}?tail=N&container=agent|auth-sidecar`** — new control-plane endpoint that resolves `active_job_name`, looks up the pod via job-name label, and reads kubectl-equivalent logs from the kube API.
- **`nemo logs --tail`** (with `--tail-lines` and `--container` flags) — CLI command that hits the endpoint and prints the text. Works mid-run, no kubectl required.

## Deliberately scoped out
- `--follow` streaming (needs either an SSE bridge over kube log_stream or a background watcher populating the logs table)
- `nemo watch` dashboard
- `nemo debug` one-shot diagnostic bundle
- Persistence of stdout/stderr/egress logs across pod termination

Tracking the remaining work as follow-up on #99.