### PR TITLE
feat(cli): add nemo helm observability workflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,6 +441,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,6 +605,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,6 +718,31 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crypto-bigint"
@@ -800,8 +854,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -819,12 +883,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn",
 ]
@@ -1738,6 +1826,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,6 +1852,19 @@ checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
  "block-padding 0.4.2",
  "hybrid-array",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling 0.23.0",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1827,6 +1937,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1989,7 +2108,7 @@ version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37745d8a4076b77e0b1952e94e358726866c8e14ec94baaca677d47dcdb98658"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -2076,6 +2195,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -2100,6 +2225,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru-slab"
@@ -2157,6 +2291,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -2280,7 +2415,9 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "crossterm",
  "futures",
+ "ratatui",
  "reqwest",
  "serde",
  "serde_json",
@@ -2498,6 +2635,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pbkdf2"
@@ -2941,6 +3084,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3215,6 +3379,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3222,7 +3399,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -3623,6 +3800,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3940,6 +4138,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3955,6 +4159,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -4002,7 +4228,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -4355,6 +4581,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4640,6 +4895,28 @@ dependencies = [
  "libredox",
  "wasite",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,3 +23,5 @@ tracing-subscriber.workspace = true
 futures.workspace = true
 toml.workspace = true
 urlencoding = "2"
+crossterm = "0.28"
+ratatui = "0.29"

--- a/cli/src/api_types.rs
+++ b/cli/src/api_types.rs
@@ -1,0 +1,19 @@
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct StatusResponse {
+    pub loops: Vec<LoopSummary>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct LoopSummary {
+    pub loop_id: uuid::Uuid,
+    pub engineer: String,
+    pub spec_path: String,
+    pub branch: String,
+    pub state: String,
+    pub sub_state: Option<String>,
+    pub round: i32,
+    pub current_stage: Option<String>,
+    pub active_job_name: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}

--- a/cli/src/api_types.rs
+++ b/cli/src/api_types.rs
@@ -4,6 +4,25 @@ pub struct StatusResponse {
 }
 
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct InspectResponse {
+    pub loop_id: uuid::Uuid,
+    pub engineer: String,
+    pub branch: String,
+    pub state: String,
+    pub rounds: Vec<RoundSummary>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct RoundSummary {
+    pub round: i32,
+    pub implement: Option<serde_json::Value>,
+    pub test: Option<serde_json::Value>,
+    pub review: Option<serde_json::Value>,
+    pub audit: Option<serde_json::Value>,
+    pub revise: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct LoopSummary {
     pub loop_id: uuid::Uuid,
     pub engineer: String,

--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -3,6 +3,7 @@ use reqwest::Client;
 use serde::de::DeserializeOwned;
 
 /// HTTP client wrapper for communicating with the Nemo API server.
+#[derive(Clone)]
 pub struct NemoClient {
     client: Client,
     base_url: String,

--- a/cli/src/commands/helm.rs
+++ b/cli/src/commands/helm.rs
@@ -1,0 +1,869 @@
+use std::collections::VecDeque;
+use std::io::{self, Stdout};
+use std::time::Duration;
+
+use anyhow::Result;
+use crossterm::event::{self, Event as CrosstermEvent, KeyCode, KeyEvent, KeyEventKind};
+use crossterm::execute;
+use crossterm::terminal::{
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+};
+use futures::StreamExt;
+use ratatui::Terminal;
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span, Text};
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap};
+use tokio::sync::{mpsc, watch};
+
+use crate::api_types::LoopSummary;
+use crate::client::NemoClient;
+use crate::commands::status;
+
+const BG: Color = Color::Rgb(15, 15, 14);
+const SURFACE: Color = Color::Rgb(26, 25, 24);
+const BORDER: Color = Color::Rgb(46, 45, 43);
+const TEXT: Color = Color::Rgb(232, 230, 227);
+const MUTED: Color = Color::Rgb(138, 135, 132);
+const TEAL: Color = Color::Rgb(27, 107, 90);
+const AMBER: Color = Color::Rgb(232, 168, 56);
+const GREEN: Color = Color::Rgb(45, 122, 79);
+const RED: Color = Color::Rgb(196, 57, 45);
+const BLUE: Color = Color::Rgb(59, 123, 192);
+const MAX_LOG_LINES: usize = 500;
+
+#[derive(Debug)]
+enum AppEvent {
+    Input(KeyEvent),
+    Resize,
+    Status(Vec<LoopSummary>),
+    StatusError(String),
+    LogLine(uuid::Uuid, String),
+    LogStatus(uuid::Uuid, String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AppAction {
+    None,
+    Quit,
+    SelectionChanged,
+    ReconnectLogs,
+}
+
+#[derive(Debug)]
+struct App {
+    loops: Vec<LoopSummary>,
+    list_state: ListState,
+    selected_loop_id: Option<uuid::Uuid>,
+    logs: VecDeque<String>,
+    status_line: String,
+    log_status: String,
+    team_view: bool,
+}
+
+impl App {
+    fn new(team_view: bool) -> Self {
+        Self {
+            loops: Vec::new(),
+            list_state: ListState::default(),
+            selected_loop_id: None,
+            logs: VecDeque::new(),
+            status_line: "Loading active loops...".to_string(),
+            log_status: "Select a loop to tail persisted logs".to_string(),
+            team_view,
+        }
+    }
+
+    fn selected_loop(&self) -> Option<&LoopSummary> {
+        self.selected_loop_id.and_then(|loop_id| {
+            self.loops
+                .iter()
+                .find(|loop_item| loop_item.loop_id == loop_id)
+        })
+    }
+
+    fn set_loops(&mut self, mut loops: Vec<LoopSummary>) {
+        loops.sort_by(|left, right| right.updated_at.cmp(&left.updated_at));
+        self.loops = loops;
+
+        if self.loops.is_empty() {
+            self.selected_loop_id = None;
+            self.list_state.select(None);
+            self.status_line = if self.team_view {
+                "No active loops across the team".to_string()
+            } else {
+                "No active loops for this engineer".to_string()
+            };
+            return;
+        }
+
+        if self.selected_loop_id.is_none_or(|selected| {
+            self.loops
+                .iter()
+                .all(|loop_item| loop_item.loop_id != selected)
+        }) {
+            self.selected_loop_id = Some(self.loops[0].loop_id);
+        }
+
+        if let Some(selected_loop_id) = self.selected_loop_id {
+            let selected_index = self
+                .loops
+                .iter()
+                .position(|loop_item| loop_item.loop_id == selected_loop_id)
+                .unwrap_or(0);
+            self.list_state.select(Some(selected_index));
+            self.status_line = format!(
+                "{} active loop{}",
+                self.loops.len(),
+                if self.loops.len() == 1 { "" } else { "s" }
+            );
+        }
+    }
+
+    fn move_selection(&mut self, delta: isize) -> bool {
+        if self.loops.is_empty() {
+            return false;
+        }
+
+        let current = self.list_state.selected().unwrap_or(0) as isize;
+        let next = (current + delta).clamp(0, self.loops.len().saturating_sub(1) as isize) as usize;
+        self.list_state.select(Some(next));
+        let next_loop_id = self.loops[next].loop_id;
+        let changed = self.selected_loop_id != Some(next_loop_id);
+        self.selected_loop_id = Some(next_loop_id);
+        changed
+    }
+
+    fn select_first(&mut self) -> bool {
+        if self.loops.is_empty() {
+            return false;
+        }
+        self.list_state.select(Some(0));
+        let loop_id = self.loops[0].loop_id;
+        let changed = self.selected_loop_id != Some(loop_id);
+        self.selected_loop_id = Some(loop_id);
+        changed
+    }
+
+    fn select_last(&mut self) -> bool {
+        if self.loops.is_empty() {
+            return false;
+        }
+        let last = self.loops.len() - 1;
+        self.list_state.select(Some(last));
+        let loop_id = self.loops[last].loop_id;
+        let changed = self.selected_loop_id != Some(loop_id);
+        self.selected_loop_id = Some(loop_id);
+        changed
+    }
+
+    fn reset_logs(&mut self) {
+        self.logs.clear();
+        self.log_status = self
+            .selected_loop()
+            .map(|loop_item| format!("Connecting log stream for {}", loop_item.loop_id))
+            .unwrap_or_else(|| "Select a loop to tail persisted logs".to_string());
+    }
+
+    fn push_log_line(&mut self, line: String) {
+        if self.logs.len() == MAX_LOG_LINES {
+            self.logs.pop_front();
+        }
+        self.logs.push_back(line);
+    }
+
+    fn handle_input(&mut self, key: KeyEvent) -> AppAction {
+        match key.code {
+            KeyCode::Char('q') | KeyCode::Esc => AppAction::Quit,
+            KeyCode::Down | KeyCode::Char('j') => {
+                if self.move_selection(1) {
+                    AppAction::SelectionChanged
+                } else {
+                    AppAction::None
+                }
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                if self.move_selection(-1) {
+                    AppAction::SelectionChanged
+                } else {
+                    AppAction::None
+                }
+            }
+            KeyCode::Char('g') => {
+                if self.select_first() {
+                    AppAction::SelectionChanged
+                } else {
+                    AppAction::None
+                }
+            }
+            KeyCode::Char('G') | KeyCode::End => {
+                if self.select_last() {
+                    AppAction::SelectionChanged
+                } else {
+                    AppAction::None
+                }
+            }
+            KeyCode::Home => {
+                if self.select_first() {
+                    AppAction::SelectionChanged
+                } else {
+                    AppAction::None
+                }
+            }
+            KeyCode::Char('r') => AppAction::ReconnectLogs,
+            _ => AppAction::None,
+        }
+    }
+}
+
+enum StreamOutcome {
+    HistoricalComplete,
+    Ended(String),
+    Disconnected,
+}
+
+pub async fn run(client: &NemoClient, engineer: &str, team: bool) -> Result<()> {
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+    terminal.clear()?;
+
+    let result = run_app(&mut terminal, client.clone(), engineer.to_string(), team).await;
+
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    terminal.show_cursor()?;
+
+    result
+}
+
+async fn run_app(
+    terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    client: NemoClient,
+    engineer: String,
+    team: bool,
+) -> Result<()> {
+    let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+    let (selection_tx, selection_rx) = watch::channel(None::<uuid::Uuid>);
+
+    spawn_input_task(event_tx.clone());
+    spawn_status_task(client.clone(), engineer, team, event_tx.clone());
+    spawn_log_task(client, selection_rx, event_tx.clone());
+
+    let mut app = App::new(team);
+
+    loop {
+        terminal.draw(|frame| render(frame, &mut app))?;
+
+        let Some(event) = event_rx.recv().await else {
+            break;
+        };
+
+        let previous_selection = app.selected_loop_id;
+        match event {
+            AppEvent::Input(key) => match app.handle_input(key) {
+                AppAction::Quit => break,
+                AppAction::SelectionChanged | AppAction::ReconnectLogs => {
+                    app.reset_logs();
+                    let _ = selection_tx.send(app.selected_loop_id);
+                }
+                AppAction::None => {}
+            },
+            AppEvent::Resize => {}
+            AppEvent::Status(loops) => {
+                app.set_loops(loops);
+                if app.selected_loop_id != previous_selection {
+                    app.reset_logs();
+                    let _ = selection_tx.send(app.selected_loop_id);
+                }
+            }
+            AppEvent::StatusError(error) => {
+                app.status_line = format!("status refresh failed: {error}");
+            }
+            AppEvent::LogLine(loop_id, line) => {
+                if Some(loop_id) == app.selected_loop_id {
+                    app.push_log_line(line);
+                }
+            }
+            AppEvent::LogStatus(loop_id, status_line) => {
+                if Some(loop_id) == app.selected_loop_id {
+                    app.log_status = status_line;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn spawn_input_task(event_tx: mpsc::UnboundedSender<AppEvent>) {
+    tokio::task::spawn_blocking(move || {
+        loop {
+            match event::poll(Duration::from_millis(250)) {
+                Ok(true) => match event::read() {
+                    Ok(CrosstermEvent::Key(key)) if key.kind == KeyEventKind::Press => {
+                        if event_tx.send(AppEvent::Input(key)).is_err() {
+                            break;
+                        }
+                    }
+                    Ok(CrosstermEvent::Resize(_, _)) => {
+                        if event_tx.send(AppEvent::Resize).is_err() {
+                            break;
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(_) => {
+                        if event_tx
+                            .send(AppEvent::StatusError(
+                                "terminal input stream failed".to_string(),
+                            ))
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
+                },
+                Ok(false) => {}
+                Err(_) => {
+                    if event_tx
+                        .send(AppEvent::StatusError(
+                            "terminal input polling failed".to_string(),
+                        ))
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+    });
+}
+
+fn spawn_status_task(
+    client: NemoClient,
+    engineer: String,
+    team: bool,
+    event_tx: mpsc::UnboundedSender<AppEvent>,
+) {
+    tokio::spawn(async move {
+        loop {
+            match status::fetch(&client, &engineer, team).await {
+                Ok(response) => {
+                    if event_tx.send(AppEvent::Status(response.loops)).is_err() {
+                        break;
+                    }
+                }
+                Err(error) => {
+                    if event_tx
+                        .send(AppEvent::StatusError(error.to_string()))
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+            }
+
+            tokio::time::sleep(Duration::from_secs(2)).await;
+        }
+    });
+}
+
+fn spawn_log_task(
+    client: NemoClient,
+    mut selection_rx: watch::Receiver<Option<uuid::Uuid>>,
+    event_tx: mpsc::UnboundedSender<AppEvent>,
+) {
+    tokio::spawn(async move {
+        let mut current_task: Option<tokio::task::JoinHandle<()>> = None;
+
+        loop {
+            if let Some(task) = current_task.take() {
+                task.abort();
+            }
+
+            if let Some(loop_id) = *selection_rx.borrow() {
+                let client = client.clone();
+                let event_tx = event_tx.clone();
+                current_task = Some(tokio::spawn(async move {
+                    stream_logs_for_loop(client, loop_id, event_tx).await;
+                }));
+            }
+
+            if selection_rx.changed().await.is_err() {
+                if let Some(task) = current_task {
+                    task.abort();
+                }
+                break;
+            }
+        }
+    });
+}
+
+async fn stream_logs_for_loop(
+    client: NemoClient,
+    loop_id: uuid::Uuid,
+    event_tx: mpsc::UnboundedSender<AppEvent>,
+) {
+    let mut emitted_lines = Vec::new();
+
+    loop {
+        let path = format!("/logs/{loop_id}");
+        let response = match client.get_stream(&path).await {
+            Ok(response) => response,
+            Err(error) => {
+                if event_tx
+                    .send(AppEvent::LogStatus(
+                        loop_id,
+                        format!("log stream failed: {error}"),
+                    ))
+                    .is_err()
+                {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_secs(2)).await;
+                continue;
+            }
+        };
+
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+
+        let outcome = if content_type.contains("text/event-stream") {
+            if event_tx
+                .send(AppEvent::LogStatus(
+                    loop_id,
+                    "Streaming persisted loop logs".to_string(),
+                ))
+                .is_err()
+            {
+                return;
+            }
+            stream_sse_logs(response, loop_id, &event_tx, &mut emitted_lines).await
+        } else {
+            if event_tx
+                .send(AppEvent::LogStatus(
+                    loop_id,
+                    "Showing persisted historical logs".to_string(),
+                ))
+                .is_err()
+            {
+                return;
+            }
+            stream_historical_logs(response, loop_id, &event_tx, &mut emitted_lines).await
+        };
+
+        match outcome {
+            Ok(StreamOutcome::HistoricalComplete) => return,
+            Ok(StreamOutcome::Ended(state)) => {
+                let _ = event_tx.send(AppEvent::LogStatus(loop_id, format!("Loop ended: {state}")));
+                return;
+            }
+            Ok(StreamOutcome::Disconnected) => {
+                if event_tx
+                    .send(AppEvent::LogStatus(
+                        loop_id,
+                        "Log stream disconnected, reconnecting...".to_string(),
+                    ))
+                    .is_err()
+                {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+            Err(error) => {
+                if event_tx
+                    .send(AppEvent::LogStatus(
+                        loop_id,
+                        format!("log decode failed: {error}"),
+                    ))
+                    .is_err()
+                {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_secs(2)).await;
+            }
+        }
+    }
+}
+
+async fn stream_historical_logs(
+    response: reqwest::Response,
+    loop_id: uuid::Uuid,
+    event_tx: &mpsc::UnboundedSender<AppEvent>,
+    emitted_lines: &mut Vec<String>,
+) -> Result<StreamOutcome> {
+    let body = response.text().await?;
+    let logs: Vec<serde_json::Value> = serde_json::from_str(&body)?;
+
+    let mut replay_index = 0;
+    for log in logs {
+        let Some(formatted_line) = format_log_json(&log) else {
+            continue;
+        };
+        emit_or_skip_replayed_line(
+            loop_id,
+            formatted_line,
+            emitted_lines,
+            &mut replay_index,
+            event_tx,
+        )?;
+    }
+
+    Ok(StreamOutcome::HistoricalComplete)
+}
+
+async fn stream_sse_logs(
+    response: reqwest::Response,
+    loop_id: uuid::Uuid,
+    event_tx: &mpsc::UnboundedSender<AppEvent>,
+    emitted_lines: &mut Vec<String>,
+) -> Result<StreamOutcome> {
+    let mut stream = response.bytes_stream();
+    let mut buffer = String::new();
+    let mut replay_index = 0;
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+        buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+        while let Some(position) = buffer.find("\n\n") {
+            let event = buffer[..position].to_string();
+            buffer = buffer[position + 2..].to_string();
+
+            for line in event.lines() {
+                let Some(data) = line.strip_prefix("data: ") else {
+                    continue;
+                };
+                let parsed: serde_json::Value = match serde_json::from_str(data) {
+                    Ok(parsed) => parsed,
+                    Err(_) => continue,
+                };
+
+                if parsed.get("type").and_then(|value| value.as_str()) == Some("end") {
+                    let state = parsed
+                        .get("state")
+                        .and_then(|value| value.as_str())
+                        .unwrap_or("UNKNOWN")
+                        .to_string();
+                    return Ok(StreamOutcome::Ended(state));
+                }
+
+                let Some(formatted_line) = format_log_json(&parsed) else {
+                    continue;
+                };
+                emit_or_skip_replayed_line(
+                    loop_id,
+                    formatted_line,
+                    emitted_lines,
+                    &mut replay_index,
+                    event_tx,
+                )?;
+            }
+        }
+    }
+
+    Ok(StreamOutcome::Disconnected)
+}
+
+fn emit_or_skip_replayed_line(
+    loop_id: uuid::Uuid,
+    formatted_line: String,
+    emitted_lines: &mut Vec<String>,
+    replay_index: &mut usize,
+    event_tx: &mpsc::UnboundedSender<AppEvent>,
+) -> Result<()> {
+    if *replay_index < emitted_lines.len() && emitted_lines[*replay_index] == formatted_line {
+        *replay_index += 1;
+        return Ok(());
+    }
+
+    emitted_lines.push(formatted_line.clone());
+    event_tx
+        .send(AppEvent::LogLine(loop_id, formatted_line))
+        .map_err(|_| anyhow::anyhow!("helm event channel closed"))
+}
+
+fn format_log_json(value: &serde_json::Value) -> Option<String> {
+    let stage = value.get("stage")?.as_str()?;
+    let round = value.get("round")?.as_i64()?;
+    let line = value.get("line")?.as_str()?;
+    Some(format!("[{stage}/r{round}] {line}"))
+}
+
+fn render(frame: &mut ratatui::Frame<'_>, app: &mut App) {
+    let root = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(0), Constraint::Length(1)])
+        .split(frame.area());
+    let content = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(34), Constraint::Percentage(66)])
+        .split(root[0]);
+    let right = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(9), Constraint::Min(0)])
+        .split(content[1]);
+
+    frame.render_widget(render_details(app), right[0]);
+    frame.render_widget(render_logs(app, right[1]), right[1]);
+    frame.render_stateful_widget(render_loop_selector(app), content[0], &mut app.list_state);
+    frame.render_widget(render_footer(app), root[1]);
+}
+
+fn render_loop_selector(app: &App) -> List<'static> {
+    let items = if app.loops.is_empty() {
+        vec![ListItem::new(Line::from(Span::styled(
+            "No active loops",
+            Style::default().fg(MUTED),
+        )))]
+    } else {
+        app.loops
+            .iter()
+            .map(|loop_item| {
+                let stage = loop_item.current_stage.as_deref().unwrap_or("-");
+                let line = format!(
+                    "{: <10} {: <18} {: <8} r{: <3} {}",
+                    loop_item.engineer,
+                    state_label(loop_item),
+                    stage,
+                    loop_item.round,
+                    loop_item.spec_path
+                );
+                ListItem::new(Line::from(Span::styled(line, Style::default().fg(TEXT))))
+            })
+            .collect()
+    };
+
+    List::new(items)
+        .block(
+            Block::default()
+                .title(Span::styled(
+                    format!(" helm {} ", app.status_line),
+                    Style::default().fg(TEXT).add_modifier(Modifier::BOLD),
+                ))
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(BORDER).bg(SURFACE))
+                .style(Style::default().bg(SURFACE)),
+        )
+        .highlight_style(
+            Style::default()
+                .fg(TEXT)
+                .bg(Color::Rgb(36, 35, 34))
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("> ")
+}
+
+fn render_details(app: &App) -> Paragraph<'static> {
+    let body = if let Some(loop_item) = app.selected_loop() {
+        Text::from(vec![
+            detail_line("engineer", &loop_item.engineer),
+            Line::from(vec![
+                Span::styled(
+                    format!("{:>8} ", "state"),
+                    Style::default().fg(MUTED).add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    state_label(loop_item),
+                    Style::default()
+                        .fg(state_color(&loop_item.state))
+                        .add_modifier(Modifier::BOLD),
+                ),
+            ]),
+            detail_line("stage", loop_item.current_stage.as_deref().unwrap_or("-")),
+            detail_line("round", &loop_item.round.to_string()),
+            detail_line("job", loop_item.active_job_name.as_deref().unwrap_or("-")),
+            detail_line("branch", &loop_item.branch),
+            detail_line("loop", &loop_item.loop_id.to_string()),
+            detail_line("spec", &loop_item.spec_path),
+        ])
+    } else {
+        Text::from(vec![Line::from(Span::styled(
+            "Waiting for an active loop selection",
+            Style::default().fg(MUTED),
+        ))])
+    };
+
+    Paragraph::new(body)
+        .block(
+            Block::default()
+                .title(Span::styled(
+                    " overview ",
+                    Style::default().fg(TEXT).add_modifier(Modifier::BOLD),
+                ))
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(BORDER).bg(SURFACE))
+                .style(Style::default().bg(SURFACE)),
+        )
+        .style(Style::default().fg(TEXT).bg(SURFACE))
+        .wrap(Wrap { trim: false })
+}
+
+fn render_logs(app: &App, area: Rect) -> Paragraph<'static> {
+    let lines: Vec<Line<'static>> = if app.logs.is_empty() {
+        vec![Line::from(Span::styled(
+            app.log_status.clone(),
+            Style::default().fg(MUTED),
+        ))]
+    } else {
+        app.logs
+            .iter()
+            .map(|line| Line::from(Span::styled(line.clone(), Style::default().fg(TEXT))))
+            .collect()
+    };
+
+    let inner_height = area.height.saturating_sub(2) as usize;
+    let scroll = lines.len().saturating_sub(inner_height) as u16;
+
+    Paragraph::new(Text::from(lines))
+        .block(
+            Block::default()
+                .title(Span::styled(
+                    " logs ",
+                    Style::default().fg(TEXT).add_modifier(Modifier::BOLD),
+                ))
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(BORDER).bg(SURFACE))
+                .style(Style::default().bg(BG)),
+        )
+        .style(Style::default().fg(TEXT).bg(BG))
+        .wrap(Wrap { trim: false })
+        .scroll((scroll, 0))
+}
+
+fn render_footer(app: &App) -> Paragraph<'static> {
+    let mode = if app.team_view { "team" } else { "engineer" };
+    Paragraph::new(Line::from(vec![
+        Span::styled("mode ", Style::default().fg(MUTED)),
+        Span::styled(mode, Style::default().fg(BLUE).add_modifier(Modifier::BOLD)),
+        Span::raw("   "),
+        Span::styled("keys ", Style::default().fg(MUTED)),
+        Span::styled("q", Style::default().fg(TEAL).add_modifier(Modifier::BOLD)),
+        Span::styled(" quit  ", Style::default().fg(MUTED)),
+        Span::styled(
+            "j/k",
+            Style::default().fg(TEAL).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" move  ", Style::default().fg(MUTED)),
+        Span::styled(
+            "g/G",
+            Style::default().fg(TEAL).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" top/bottom  ", Style::default().fg(MUTED)),
+        Span::styled("r", Style::default().fg(AMBER).add_modifier(Modifier::BOLD)),
+        Span::styled(" reconnect logs", Style::default().fg(MUTED)),
+    ]))
+    .style(Style::default().fg(TEXT).bg(BG))
+}
+
+fn detail_line(label: &str, value: &str) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(
+            format!("{label:>8} "),
+            Style::default().fg(MUTED).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(value.to_string(), Style::default().fg(TEXT)),
+    ])
+}
+
+fn state_label(loop_item: &LoopSummary) -> String {
+    match &loop_item.sub_state {
+        Some(sub_state) => format!("{}/{}", loop_item.state, sub_state),
+        None => loop_item.state.clone(),
+    }
+}
+
+fn state_color(state: &str) -> Color {
+    if matches!(state, "CONVERGED" | "HARDENED" | "SHIPPED") {
+        GREEN
+    } else if matches!(state, "FAILED" | "CANCELLED") {
+        RED
+    } else if matches!(state, "PAUSED" | "AWAITING_REAUTH" | "AWAITING_APPROVAL") {
+        AMBER
+    } else {
+        TEAL
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn loop_summary(id: uuid::Uuid, engineer: &str, updated_at: &str) -> LoopSummary {
+        LoopSummary {
+            loop_id: id,
+            engineer: engineer.to_string(),
+            spec_path: "specs/test.md".to_string(),
+            branch: format!("agent/{engineer}/test"),
+            state: "IMPLEMENTING".to_string(),
+            sub_state: Some("RUNNING".to_string()),
+            round: 2,
+            current_stage: Some("implement".to_string()),
+            active_job_name: Some("job-1".to_string()),
+            created_at: updated_at.to_string(),
+            updated_at: updated_at.to_string(),
+        }
+    }
+
+    #[test]
+    fn replay_dedupe_skips_replayed_prefix() {
+        let loop_id = uuid::Uuid::new_v4();
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let mut emitted_lines = vec!["[implement/r1] first".to_string()];
+        let mut replay_index = 0;
+
+        emit_or_skip_replayed_line(
+            loop_id,
+            "[implement/r1] first".to_string(),
+            &mut emitted_lines,
+            &mut replay_index,
+            &event_tx,
+        )
+        .unwrap();
+        emit_or_skip_replayed_line(
+            loop_id,
+            "[implement/r1] second".to_string(),
+            &mut emitted_lines,
+            &mut replay_index,
+            &event_tx,
+        )
+        .unwrap();
+
+        let received = event_rx.try_recv().unwrap();
+        match received {
+            AppEvent::LogLine(received_loop_id, line) => {
+                assert_eq!(received_loop_id, loop_id);
+                assert_eq!(line, "[implement/r1] second");
+            }
+            _ => panic!("expected log line event"),
+        }
+        assert!(event_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn set_loops_preserves_selected_loop_when_still_present() {
+        let first_id = uuid::Uuid::new_v4();
+        let second_id = uuid::Uuid::new_v4();
+        let mut app = App::new(false);
+        app.set_loops(vec![
+            loop_summary(first_id, "alice", "2026-04-10T10:00:00Z"),
+            loop_summary(second_id, "bob", "2026-04-10T09:00:00Z"),
+        ]);
+        app.selected_loop_id = Some(second_id);
+
+        app.set_loops(vec![
+            loop_summary(second_id, "bob", "2026-04-10T11:00:00Z"),
+            loop_summary(first_id, "alice", "2026-04-10T10:00:00Z"),
+        ]);
+
+        assert_eq!(app.selected_loop_id, Some(second_id));
+        assert_eq!(app.list_state.selected(), Some(0));
+    }
+}

--- a/cli/src/commands/helm.rs
+++ b/cli/src/commands/helm.rs
@@ -40,6 +40,8 @@ enum AppEvent {
     Resize,
     Status(Vec<LoopSummary>),
     StatusError(String),
+    InspectLoaded(String, InspectResponse),
+    InspectError(String, String),
     LogLine(uuid::Uuid, String),
     LogStatus(uuid::Uuid, String),
 }
@@ -51,10 +53,11 @@ enum LogSource {
     SidecarPod,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct LogSelection {
     loop_id: uuid::Uuid,
     source: LogSource,
+    job_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -134,9 +137,13 @@ impl App {
     }
 
     fn current_log_selection(&self) -> Option<LogSelection> {
-        self.selected_loop_id.map(|loop_id| LogSelection {
-            loop_id,
+        self.selected_loop().map(|loop_item| LogSelection {
+            loop_id: loop_item.loop_id,
             source: self.log_source,
+            job_name: match self.log_source {
+                LogSource::Persisted => None,
+                LogSource::AgentPod | LogSource::SidecarPod => loop_item.active_job_name.clone(),
+            },
         })
     }
 
@@ -343,10 +350,12 @@ async fn run_app(
 ) -> Result<()> {
     let (event_tx, mut event_rx) = mpsc::unbounded_channel();
     let (selection_tx, selection_rx) = watch::channel(None::<LogSelection>);
+    let (inspect_tx, inspect_rx) = watch::channel(None::<String>);
 
     spawn_input_task(event_tx.clone());
     spawn_status_task(client.clone(), engineer.clone(), team, event_tx.clone());
     spawn_log_task(client.clone(), selection_rx, event_tx.clone());
+    spawn_inspect_task(client.clone(), inspect_rx, event_tx.clone());
 
     let mut app = App::new(team);
 
@@ -357,7 +366,8 @@ async fn run_app(
             break;
         };
 
-        let previous_selection = app.selected_loop_id;
+        let previous_log_selection = app.current_log_selection();
+        let previous_branch = app.selected_branch();
         match event {
             AppEvent::Input(key) => match app.handle_input(key) {
                 AppAction::Quit => break,
@@ -365,6 +375,7 @@ async fn run_app(
                     app.reset_logs();
                     app.reset_inspect();
                     let _ = selection_tx.send(app.current_log_selection());
+                    let _ = inspect_tx.send(app.selected_branch());
                 }
                 AppAction::ReconnectLogs | AppAction::SourceChanged => {
                     app.reset_logs();
@@ -386,12 +397,14 @@ async fn run_app(
                         match status::fetch(&client, &engineer, team).await {
                             Ok(response) => {
                                 app.set_loops(response.loops);
-                                if app.selected_loop_id != previous_selection {
+                                if app.current_log_selection() != previous_log_selection {
                                     app.reset_logs();
-                                    app.reset_inspect();
                                     let _ = selection_tx.send(app.current_log_selection());
                                 }
-                                refresh_selected_inspect(&client, &mut app).await;
+                                if app.selected_branch() != previous_branch {
+                                    app.reset_inspect();
+                                    let _ = inspect_tx.send(app.selected_branch());
+                                }
                             }
                             Err(error) => {
                                 app.status_line =
@@ -407,15 +420,29 @@ async fn run_app(
             AppEvent::Resize => {}
             AppEvent::Status(loops) => {
                 app.set_loops(loops);
-                if app.selected_loop_id != previous_selection {
+                if app.current_log_selection() != previous_log_selection {
                     app.reset_logs();
-                    app.reset_inspect();
                     let _ = selection_tx.send(app.current_log_selection());
                 }
-                refresh_selected_inspect(&client, &mut app).await;
+                if app.selected_branch() != previous_branch {
+                    app.reset_inspect();
+                    let _ = inspect_tx.send(app.selected_branch());
+                }
             }
             AppEvent::StatusError(error) => {
                 app.status_line = format!("status refresh failed: {error}");
+            }
+            AppEvent::InspectLoaded(branch, inspect) => {
+                if app.selected_branch().as_deref() == Some(branch.as_str()) {
+                    app.inspect_status = format!("inspect synced for {branch}");
+                    app.inspect = Some(inspect);
+                }
+            }
+            AppEvent::InspectError(branch, error) => {
+                if app.selected_branch().as_deref() == Some(branch.as_str()) {
+                    app.inspect = None;
+                    app.inspect_status = format!("inspect refresh failed: {error}");
+                }
             }
             AppEvent::LogLine(loop_id, line) => {
                 if Some(loop_id) == app.selected_loop_id {
@@ -506,25 +533,6 @@ async fn perform_loop_action(
     }
 }
 
-async fn refresh_selected_inspect(client: &NemoClient, app: &mut App) {
-    let Some(branch) = app.selected_branch() else {
-        app.inspect = None;
-        app.inspect_status = "Select a loop to inspect".to_string();
-        return;
-    };
-
-    match inspect::fetch(client, &branch).await {
-        Ok(response) => {
-            app.inspect = Some(response);
-            app.inspect_status = format!("inspect synced for {branch}");
-        }
-        Err(error) => {
-            app.inspect = None;
-            app.inspect_status = format!("inspect refresh failed: {error}");
-        }
-    }
-}
-
 fn spawn_input_task(event_tx: mpsc::UnboundedSender<AppEvent>) {
     tokio::task::spawn_blocking(move || {
         loop {
@@ -566,6 +574,66 @@ fn spawn_input_task(event_tx: mpsc::UnboundedSender<AppEvent>) {
             }
         }
     });
+}
+
+fn spawn_inspect_task(
+    client: NemoClient,
+    mut branch_rx: watch::Receiver<Option<String>>,
+    event_tx: mpsc::UnboundedSender<AppEvent>,
+) {
+    tokio::spawn(async move {
+        let mut current_task: Option<tokio::task::JoinHandle<()>> = None;
+
+        loop {
+            if let Some(task) = current_task.take() {
+                task.abort();
+            }
+
+            if let Some(branch) = branch_rx.borrow().clone() {
+                let client = client.clone();
+                let event_tx = event_tx.clone();
+                current_task = Some(tokio::spawn(async move {
+                    poll_inspect_for_branch(client, branch, event_tx).await;
+                }));
+            }
+
+            if branch_rx.changed().await.is_err() {
+                if let Some(task) = current_task {
+                    task.abort();
+                }
+                break;
+            }
+        }
+    });
+}
+
+async fn poll_inspect_for_branch(
+    client: NemoClient,
+    branch: String,
+    event_tx: mpsc::UnboundedSender<AppEvent>,
+) {
+    loop {
+        match inspect::fetch(&client, &branch).await {
+            Ok(response) => {
+                if event_tx
+                    .send(AppEvent::InspectLoaded(branch.clone(), response))
+                    .is_err()
+                {
+                    return;
+                }
+            }
+            Err(error) => {
+                if event_tx
+                    .send(AppEvent::InspectError(branch.clone(), error.to_string()))
+                    .is_err()
+                {
+                    return;
+                }
+            }
+        }
+
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
 }
 
 fn spawn_status_task(
@@ -610,7 +678,7 @@ fn spawn_log_task(
                 task.abort();
             }
 
-            if let Some(selection) = *selection_rx.borrow() {
+            if let Some(selection) = selection_rx.borrow().clone() {
                 let client = client.clone();
                 let event_tx = event_tx.clone();
                 current_task = Some(tokio::spawn(async move {
@@ -1383,6 +1451,46 @@ mod tests {
             AppAction::SourceChanged
         );
         assert_eq!(app.log_source, LogSource::Persisted);
+    }
+
+    #[test]
+    fn persisted_log_selection_does_not_restart_on_job_name_changes() {
+        let first_id = uuid::Uuid::new_v4();
+        let mut app = App::new(false);
+        app.set_loops(vec![loop_summary(
+            first_id,
+            "alice",
+            "2026-04-10T10:00:00Z",
+        )]);
+
+        let first_selection = app.current_log_selection();
+        app.set_loops(vec![LoopSummary {
+            active_job_name: Some("job-2".to_string()),
+            ..loop_summary(first_id, "alice", "2026-04-10T11:00:00Z")
+        }]);
+
+        assert_eq!(first_selection, app.current_log_selection());
+    }
+
+    #[test]
+    fn pod_log_selection_tracks_active_job_name() {
+        let first_id = uuid::Uuid::new_v4();
+        let mut app = App::new(false);
+        app.log_source = LogSource::AgentPod;
+        app.set_loops(vec![loop_summary(
+            first_id,
+            "alice",
+            "2026-04-10T10:00:00Z",
+        )]);
+
+        assert_eq!(
+            app.current_log_selection(),
+            Some(LogSelection {
+                loop_id: first_id,
+                source: LogSource::AgentPod,
+                job_name: Some("job-1".to_string()),
+            })
+        );
     }
 
     #[test]

--- a/cli/src/commands/helm.rs
+++ b/cli/src/commands/helm.rs
@@ -17,9 +17,9 @@ use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap};
 use tokio::sync::{mpsc, watch};
 
-use crate::api_types::LoopSummary;
+use crate::api_types::{InspectResponse, LoopSummary, RoundSummary};
 use crate::client::NemoClient;
-use crate::commands::status;
+use crate::commands::{inspect, status};
 
 const BG: Color = Color::Rgb(15, 15, 14);
 const SURFACE: Color = Color::Rgb(26, 25, 24);
@@ -32,6 +32,7 @@ const GREEN: Color = Color::Rgb(45, 122, 79);
 const RED: Color = Color::Rgb(196, 57, 45);
 const BLUE: Color = Color::Rgb(59, 123, 192);
 const MAX_LOG_LINES: usize = 500;
+const POD_TAIL_LINES: u32 = 200;
 
 #[derive(Debug)]
 enum AppEvent {
@@ -41,6 +42,19 @@ enum AppEvent {
     StatusError(String),
     LogLine(uuid::Uuid, String),
     LogStatus(uuid::Uuid, String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LogSource {
+    Persisted,
+    AgentPod,
+    SidecarPod,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct LogSelection {
+    loop_id: uuid::Uuid,
+    source: LogSource,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -55,6 +69,7 @@ enum AppAction {
     None,
     Quit,
     SelectionChanged,
+    SourceChanged,
     ReconnectLogs,
     Trigger(LoopCommand),
 }
@@ -86,8 +101,11 @@ struct App {
     list_state: ListState,
     selected_loop_id: Option<uuid::Uuid>,
     logs: VecDeque<String>,
+    log_source: LogSource,
     status_line: String,
     log_status: String,
+    inspect_status: String,
+    inspect: Option<InspectResponse>,
     team_view: bool,
 }
 
@@ -98,8 +116,11 @@ impl App {
             list_state: ListState::default(),
             selected_loop_id: None,
             logs: VecDeque::new(),
+            log_source: LogSource::Persisted,
             status_line: "Loading active loops...".to_string(),
             log_status: "Select a loop to tail persisted logs".to_string(),
+            inspect_status: "Loading inspect data...".to_string(),
+            inspect: None,
             team_view,
         }
     }
@@ -112,6 +133,18 @@ impl App {
         })
     }
 
+    fn current_log_selection(&self) -> Option<LogSelection> {
+        self.selected_loop_id.map(|loop_id| LogSelection {
+            loop_id,
+            source: self.log_source,
+        })
+    }
+
+    fn selected_branch(&self) -> Option<String> {
+        self.selected_loop()
+            .map(|loop_item| loop_item.branch.clone())
+    }
+
     fn set_loops(&mut self, mut loops: Vec<LoopSummary>) {
         loops.sort_by(|left, right| right.updated_at.cmp(&left.updated_at));
         self.loops = loops;
@@ -119,6 +152,8 @@ impl App {
         if self.loops.is_empty() {
             self.selected_loop_id = None;
             self.list_state.select(None);
+            self.inspect = None;
+            self.inspect_status = "No selected loop".to_string();
             self.status_line = if self.team_view {
                 "No active loops across the team".to_string()
             } else {
@@ -189,10 +224,34 @@ impl App {
 
     fn reset_logs(&mut self) {
         self.logs.clear();
-        self.log_status = self
+        self.log_status = match self.selected_loop() {
+            Some(loop_item) => match self.log_source {
+                LogSource::Persisted => {
+                    format!("Connecting persisted logs for {}", loop_item.loop_id)
+                }
+                LogSource::AgentPod => format!("Polling agent pod logs for {}", loop_item.loop_id),
+                LogSource::SidecarPod => {
+                    format!("Polling auth-sidecar logs for {}", loop_item.loop_id)
+                }
+            },
+            None => "Select a loop to tail logs".to_string(),
+        };
+    }
+
+    fn reset_inspect(&mut self) {
+        self.inspect = None;
+        self.inspect_status = self
             .selected_loop()
-            .map(|loop_item| format!("Connecting log stream for {}", loop_item.loop_id))
-            .unwrap_or_else(|| "Select a loop to tail persisted logs".to_string());
+            .map(|loop_item| format!("Loading inspect data for {}", loop_item.branch))
+            .unwrap_or_else(|| "Select a loop to inspect".to_string());
+    }
+
+    fn cycle_log_source(&mut self) {
+        self.log_source = match self.log_source {
+            LogSource::Persisted => LogSource::AgentPod,
+            LogSource::AgentPod => LogSource::SidecarPod,
+            LogSource::SidecarPod => LogSource::Persisted,
+        };
     }
 
     fn push_log_line(&mut self, line: String) {
@@ -240,6 +299,10 @@ impl App {
                     AppAction::None
                 }
             }
+            KeyCode::Char('l') => {
+                self.cycle_log_source();
+                AppAction::SourceChanged
+            }
             KeyCode::Char('a') => AppAction::Trigger(LoopCommand::Approve),
             KeyCode::Char('u') => AppAction::Trigger(LoopCommand::Resume),
             KeyCode::Char('c') => AppAction::Trigger(LoopCommand::Cancel),
@@ -279,7 +342,7 @@ async fn run_app(
     team: bool,
 ) -> Result<()> {
     let (event_tx, mut event_rx) = mpsc::unbounded_channel();
-    let (selection_tx, selection_rx) = watch::channel(None::<uuid::Uuid>);
+    let (selection_tx, selection_rx) = watch::channel(None::<LogSelection>);
 
     spawn_input_task(event_tx.clone());
     spawn_status_task(client.clone(), engineer.clone(), team, event_tx.clone());
@@ -298,9 +361,14 @@ async fn run_app(
         match event {
             AppEvent::Input(key) => match app.handle_input(key) {
                 AppAction::Quit => break,
-                AppAction::SelectionChanged | AppAction::ReconnectLogs => {
+                AppAction::SelectionChanged => {
                     app.reset_logs();
-                    let _ = selection_tx.send(app.selected_loop_id);
+                    app.reset_inspect();
+                    let _ = selection_tx.send(app.current_log_selection());
+                }
+                AppAction::ReconnectLogs | AppAction::SourceChanged => {
+                    app.reset_logs();
+                    let _ = selection_tx.send(app.current_log_selection());
                 }
                 AppAction::Trigger(command) => {
                     if let Some(loop_id) = app.selected_loop_id {
@@ -320,8 +388,10 @@ async fn run_app(
                                 app.set_loops(response.loops);
                                 if app.selected_loop_id != previous_selection {
                                     app.reset_logs();
-                                    let _ = selection_tx.send(app.selected_loop_id);
+                                    app.reset_inspect();
+                                    let _ = selection_tx.send(app.current_log_selection());
                                 }
+                                refresh_selected_inspect(&client, &mut app).await;
                             }
                             Err(error) => {
                                 app.status_line =
@@ -339,8 +409,10 @@ async fn run_app(
                 app.set_loops(loops);
                 if app.selected_loop_id != previous_selection {
                     app.reset_logs();
-                    let _ = selection_tx.send(app.selected_loop_id);
+                    app.reset_inspect();
+                    let _ = selection_tx.send(app.current_log_selection());
                 }
+                refresh_selected_inspect(&client, &mut app).await;
             }
             AppEvent::StatusError(error) => {
                 app.status_line = format!("status refresh failed: {error}");
@@ -367,6 +439,16 @@ impl LoopCommand {
             Self::Approve => "approve",
             Self::Resume => "resume",
             Self::Cancel => "cancel",
+        }
+    }
+}
+
+impl LogSource {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Persisted => "persisted",
+            Self::AgentPod => "agent",
+            Self::SidecarPod => "sidecar",
         }
     }
 }
@@ -420,6 +502,25 @@ async fn perform_loop_action(
                     response.loop_id, response.state
                 )
             })
+        }
+    }
+}
+
+async fn refresh_selected_inspect(client: &NemoClient, app: &mut App) {
+    let Some(branch) = app.selected_branch() else {
+        app.inspect = None;
+        app.inspect_status = "Select a loop to inspect".to_string();
+        return;
+    };
+
+    match inspect::fetch(client, &branch).await {
+        Ok(response) => {
+            app.inspect = Some(response);
+            app.inspect_status = format!("inspect synced for {branch}");
+        }
+        Err(error) => {
+            app.inspect = None;
+            app.inspect_status = format!("inspect refresh failed: {error}");
         }
     }
 }
@@ -498,7 +599,7 @@ fn spawn_status_task(
 
 fn spawn_log_task(
     client: NemoClient,
-    mut selection_rx: watch::Receiver<Option<uuid::Uuid>>,
+    mut selection_rx: watch::Receiver<Option<LogSelection>>,
     event_tx: mpsc::UnboundedSender<AppEvent>,
 ) {
     tokio::spawn(async move {
@@ -509,11 +610,11 @@ fn spawn_log_task(
                 task.abort();
             }
 
-            if let Some(loop_id) = *selection_rx.borrow() {
+            if let Some(selection) = *selection_rx.borrow() {
                 let client = client.clone();
                 let event_tx = event_tx.clone();
                 current_task = Some(tokio::spawn(async move {
-                    stream_logs_for_loop(client, loop_id, event_tx).await;
+                    stream_logs_for_selection(client, selection, event_tx).await;
                 }));
             }
 
@@ -527,7 +628,25 @@ fn spawn_log_task(
     });
 }
 
-async fn stream_logs_for_loop(
+async fn stream_logs_for_selection(
+    client: NemoClient,
+    selection: LogSelection,
+    event_tx: mpsc::UnboundedSender<AppEvent>,
+) {
+    match selection.source {
+        LogSource::Persisted => {
+            stream_persisted_logs(client, selection.loop_id, event_tx).await;
+        }
+        LogSource::AgentPod => {
+            stream_pod_logs(client, selection.loop_id, "agent", event_tx).await;
+        }
+        LogSource::SidecarPod => {
+            stream_pod_logs(client, selection.loop_id, "auth-sidecar", event_tx).await;
+        }
+    }
+}
+
+async fn stream_persisted_logs(
     client: NemoClient,
     loop_id: uuid::Uuid,
     event_tx: mpsc::UnboundedSender<AppEvent>,
@@ -616,6 +735,99 @@ async fn stream_logs_for_loop(
             }
         }
     }
+}
+
+async fn stream_pod_logs(
+    client: NemoClient,
+    loop_id: uuid::Uuid,
+    container: &'static str,
+    event_tx: mpsc::UnboundedSender<AppEvent>,
+) {
+    let mut previous_lines: Vec<String> = Vec::new();
+
+    loop {
+        match fetch_pod_log_snapshot(&client, loop_id, container).await {
+            Ok(PodLogSnapshot::Lines(lines)) => {
+                if event_tx
+                    .send(AppEvent::LogStatus(
+                        loop_id,
+                        format!("Polling {container} pod logs"),
+                    ))
+                    .is_err()
+                {
+                    return;
+                }
+
+                let overlap = overlapping_suffix_len(&previous_lines, &lines);
+                for line in lines.iter().skip(overlap) {
+                    if event_tx
+                        .send(AppEvent::LogLine(loop_id, line.clone()))
+                        .is_err()
+                    {
+                        return;
+                    }
+                }
+                previous_lines = lines;
+            }
+            Ok(PodLogSnapshot::Info(message)) => {
+                if event_tx
+                    .send(AppEvent::LogStatus(loop_id, message))
+                    .is_err()
+                {
+                    return;
+                }
+            }
+            Err(error) => {
+                if event_tx
+                    .send(AppEvent::LogStatus(
+                        loop_id,
+                        format!("{container} pod log polling failed: {error}"),
+                    ))
+                    .is_err()
+                {
+                    return;
+                }
+            }
+        }
+
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+}
+
+enum PodLogSnapshot {
+    Lines(Vec<String>),
+    Info(String),
+}
+
+async fn fetch_pod_log_snapshot(
+    client: &NemoClient,
+    loop_id: uuid::Uuid,
+    container: &str,
+) -> Result<PodLogSnapshot> {
+    let path = format!("/pod-logs/{loop_id}?tail={POD_TAIL_LINES}&container={container}");
+    let response = client.get_stream(&path).await?;
+    let status = response.status();
+    let body = response.text().await?;
+
+    if status == reqwest::StatusCode::NO_CONTENT {
+        let message = body.trim();
+        return Ok(PodLogSnapshot::Info(if message.is_empty() {
+            format!("No {container} pod logs available yet")
+        } else {
+            message.to_string()
+        }));
+    }
+
+    let lines = body.lines().map(ToOwned::to_owned).collect();
+    Ok(PodLogSnapshot::Lines(lines))
+}
+
+fn overlapping_suffix_len(previous: &[String], current: &[String]) -> usize {
+    let max_overlap = previous.len().min(current.len());
+    (0..=max_overlap)
+        .rev()
+        .find(|count| previous[previous.len().saturating_sub(*count)..] == current[..*count])
+        .unwrap_or(0)
 }
 
 async fn stream_historical_logs(
@@ -733,7 +945,7 @@ fn render(frame: &mut ratatui::Frame<'_>, app: &mut App) {
         .split(root[0]);
     let right = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Length(9), Constraint::Min(0)])
+        .constraints([Constraint::Length(17), Constraint::Min(0)])
         .split(content[1]);
 
     frame.render_widget(render_details(app), right[0]);
@@ -788,7 +1000,7 @@ fn render_loop_selector(app: &App) -> List<'static> {
 
 fn render_details(app: &App) -> Paragraph<'static> {
     let body = if let Some(loop_item) = app.selected_loop() {
-        Text::from(vec![
+        let mut lines = vec![
             detail_line("engineer", &loop_item.engineer),
             Line::from(vec![
                 Span::styled(
@@ -808,7 +1020,26 @@ fn render_details(app: &App) -> Paragraph<'static> {
             detail_line("branch", &loop_item.branch),
             detail_line("loop", &loop_item.loop_id.to_string()),
             detail_line("spec", &loop_item.spec_path),
-        ])
+            Line::from(Span::styled("", Style::default())),
+            Line::from(vec![
+                Span::styled(
+                    format!("{:>8} ", "inspect"),
+                    Style::default().fg(MUTED).add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(app.inspect_status.clone(), Style::default().fg(MUTED)),
+            ]),
+        ];
+
+        if let Some(inspect) = &app.inspect
+            && let Some(round) = latest_round(inspect)
+        {
+            lines.push(detail_line("latest", &format!("round {}", round.round)));
+            for (label, summary) in round_stage_summaries(round) {
+                lines.push(detail_line(label, &summary));
+            }
+        }
+
+        Text::from(lines)
     } else {
         Text::from(vec![Line::from(Span::styled(
             "Waiting for an active loop selection",
@@ -820,7 +1051,7 @@ fn render_details(app: &App) -> Paragraph<'static> {
         .block(
             Block::default()
                 .title(Span::styled(
-                    " overview ",
+                    " overview + inspect ",
                     Style::default().fg(TEXT).add_modifier(Modifier::BOLD),
                 ))
                 .borders(Borders::ALL)
@@ -851,7 +1082,7 @@ fn render_logs(app: &App, area: Rect) -> Paragraph<'static> {
         .block(
             Block::default()
                 .title(Span::styled(
-                    " logs ",
+                    format!(" logs {} ", app.log_source.label()),
                     Style::default().fg(TEXT).add_modifier(Modifier::BOLD),
                 ))
                 .borders(Borders::ALL)
@@ -861,6 +1092,121 @@ fn render_logs(app: &App, area: Rect) -> Paragraph<'static> {
         .style(Style::default().fg(TEXT).bg(BG))
         .wrap(Wrap { trim: false })
         .scroll((scroll, 0))
+}
+
+fn latest_round(inspect: &InspectResponse) -> Option<&RoundSummary> {
+    inspect.rounds.iter().max_by_key(|round| round.round)
+}
+
+fn round_stage_summaries(round: &RoundSummary) -> Vec<(&'static str, String)> {
+    let mut summaries = Vec::new();
+
+    if let Some(summary) = summarize_impl_stage(round.implement.as_ref()) {
+        summaries.push(("impl", summary));
+    }
+    if let Some(summary) = summarize_test_stage(round.test.as_ref()) {
+        summaries.push(("test", summary));
+    }
+    if let Some(summary) = summarize_verdict_stage(round.review.as_ref(), "review") {
+        summaries.push(("review", summary));
+    }
+    if let Some(summary) = summarize_verdict_stage(round.audit.as_ref(), "audit") {
+        summaries.push(("audit", summary));
+    }
+    if let Some(summary) = summarize_revise_stage(round.revise.as_ref()) {
+        summaries.push(("revise", summary));
+    }
+
+    if summaries.is_empty() {
+        summaries.push(("round", "No persisted stage outputs yet".to_string()));
+    }
+
+    summaries
+}
+
+fn summarize_impl_stage(value: Option<&serde_json::Value>) -> Option<String> {
+    let value = value?;
+    value
+        .get("new_sha")
+        .and_then(|sha| sha.as_str())
+        .map(|sha| format!("new sha {}", short_sha(sha)))
+}
+
+fn summarize_revise_stage(value: Option<&serde_json::Value>) -> Option<String> {
+    let value = value?;
+    if let Some(path) = value
+        .get("revised_spec_path")
+        .and_then(|path| path.as_str())
+    {
+        return Some(format!("revised {path}"));
+    }
+    value
+        .get("new_sha")
+        .and_then(|sha| sha.as_str())
+        .map(|sha| format!("new sha {}", short_sha(sha)))
+}
+
+fn summarize_test_stage(value: Option<&serde_json::Value>) -> Option<String> {
+    let value = value?;
+    let all_passed = value.get("all_passed").and_then(|flag| flag.as_bool())?;
+    let ci_status = value
+        .get("ci_status")
+        .and_then(|status| status.as_str())
+        .unwrap_or("unknown");
+    let failing_services = value
+        .get("services")
+        .and_then(|services| services.as_array())
+        .map(|services| {
+            services
+                .iter()
+                .filter(|service| {
+                    service.get("passed").and_then(|passed| passed.as_bool()) == Some(false)
+                })
+                .count()
+        })
+        .unwrap_or(0);
+    Some(if all_passed {
+        format!("pass ({ci_status})")
+    } else {
+        format!(
+            "fail ({ci_status}, {failing_services} service{})",
+            if failing_services == 1 { "" } else { "s" }
+        )
+    })
+}
+
+fn summarize_verdict_stage(value: Option<&serde_json::Value>, kind: &str) -> Option<String> {
+    let value = value?;
+    let verdict = value.get("verdict").unwrap_or(value);
+    let clean = verdict.get("clean").and_then(|flag| flag.as_bool())?;
+    let issue_count = verdict
+        .get("issues")
+        .and_then(|issues| issues.as_array())
+        .map(|issues| issues.len())
+        .unwrap_or(0);
+    let summary = verdict
+        .get("summary")
+        .and_then(|summary| summary.as_str())
+        .unwrap_or("")
+        .trim();
+
+    Some(match (clean, summary.is_empty()) {
+        (true, true) => format!("clean {kind}"),
+        (true, false) => format!("clean, {summary}"),
+        (false, true) => format!(
+            "{issue_count} issue{}",
+            if issue_count == 1 { "" } else { "s" }
+        ),
+        (false, false) => format!(
+            "{issue_count} issue{}, {summary}",
+            if issue_count == 1 { "" } else { "s" }
+        ),
+    })
+}
+
+fn short_sha(sha: &str) -> &str {
+    let len = sha.len().min(8);
+    &sha[..len]
 }
 
 fn render_footer(app: &App) -> Paragraph<'static> {
@@ -882,6 +1228,8 @@ fn render_footer(app: &App) -> Paragraph<'static> {
             Style::default().fg(TEAL).add_modifier(Modifier::BOLD),
         ),
         Span::styled(" top/bottom  ", Style::default().fg(MUTED)),
+        Span::styled("l", Style::default().fg(BLUE).add_modifier(Modifier::BOLD)),
+        Span::styled(" log source  ", Style::default().fg(MUTED)),
         Span::styled("r", Style::default().fg(AMBER).add_modifier(Modifier::BOLD)),
         Span::styled(" reconnect logs  ", Style::default().fg(MUTED)),
         Span::styled(
@@ -1013,5 +1361,35 @@ mod tests {
             app.handle_input(KeyEvent::from(KeyCode::Char('c'))),
             AppAction::Trigger(LoopCommand::Cancel)
         );
+    }
+
+    #[test]
+    fn log_source_hotkey_cycles_sources() {
+        let mut app = App::new(false);
+
+        assert_eq!(app.log_source, LogSource::Persisted);
+        assert_eq!(
+            app.handle_input(KeyEvent::from(KeyCode::Char('l'))),
+            AppAction::SourceChanged
+        );
+        assert_eq!(app.log_source, LogSource::AgentPod);
+        assert_eq!(
+            app.handle_input(KeyEvent::from(KeyCode::Char('l'))),
+            AppAction::SourceChanged
+        );
+        assert_eq!(app.log_source, LogSource::SidecarPod);
+        assert_eq!(
+            app.handle_input(KeyEvent::from(KeyCode::Char('l'))),
+            AppAction::SourceChanged
+        );
+        assert_eq!(app.log_source, LogSource::Persisted);
+    }
+
+    #[test]
+    fn overlapping_suffix_len_matches_appended_pod_logs() {
+        let previous = vec!["a".to_string(), "b".to_string()];
+        let current = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+
+        assert_eq!(overlapping_suffix_len(&previous, &current), 2);
     }
 }

--- a/cli/src/commands/helm.rs
+++ b/cli/src/commands/helm.rs
@@ -44,11 +44,40 @@ enum AppEvent {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LoopCommand {
+    Approve,
+    Resume,
+    Cancel,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum AppAction {
     None,
     Quit,
     SelectionChanged,
     ReconnectLogs,
+    Trigger(LoopCommand),
+}
+
+#[derive(serde::Deserialize)]
+struct ApproveActionResponse {
+    loop_id: uuid::Uuid,
+    state: String,
+    approve_requested: bool,
+}
+
+#[derive(serde::Deserialize)]
+struct ResumeActionResponse {
+    loop_id: uuid::Uuid,
+    state: String,
+    resume_requested: bool,
+}
+
+#[derive(serde::Deserialize)]
+struct CancelActionResponse {
+    loop_id: uuid::Uuid,
+    state: String,
+    cancel_requested: bool,
 }
 
 #[derive(Debug)]
@@ -211,6 +240,9 @@ impl App {
                     AppAction::None
                 }
             }
+            KeyCode::Char('a') => AppAction::Trigger(LoopCommand::Approve),
+            KeyCode::Char('u') => AppAction::Trigger(LoopCommand::Resume),
+            KeyCode::Char('c') => AppAction::Trigger(LoopCommand::Cancel),
             KeyCode::Char('r') => AppAction::ReconnectLogs,
             _ => AppAction::None,
         }
@@ -250,8 +282,8 @@ async fn run_app(
     let (selection_tx, selection_rx) = watch::channel(None::<uuid::Uuid>);
 
     spawn_input_task(event_tx.clone());
-    spawn_status_task(client.clone(), engineer, team, event_tx.clone());
-    spawn_log_task(client, selection_rx, event_tx.clone());
+    spawn_status_task(client.clone(), engineer.clone(), team, event_tx.clone());
+    spawn_log_task(client.clone(), selection_rx, event_tx.clone());
 
     let mut app = App::new(team);
 
@@ -269,6 +301,36 @@ async fn run_app(
                 AppAction::SelectionChanged | AppAction::ReconnectLogs => {
                     app.reset_logs();
                     let _ = selection_tx.send(app.selected_loop_id);
+                }
+                AppAction::Trigger(command) => {
+                    if let Some(loop_id) = app.selected_loop_id {
+                        app.status_line = format!("sending {} for {loop_id}", command.verb());
+                        match perform_loop_action(&client, command, loop_id).await {
+                            Ok(message) => {
+                                app.status_line = message;
+                            }
+                            Err(error) => {
+                                app.status_line =
+                                    format!("{} failed for {loop_id}: {error}", command.verb());
+                            }
+                        }
+
+                        match status::fetch(&client, &engineer, team).await {
+                            Ok(response) => {
+                                app.set_loops(response.loops);
+                                if app.selected_loop_id != previous_selection {
+                                    app.reset_logs();
+                                    let _ = selection_tx.send(app.selected_loop_id);
+                                }
+                            }
+                            Err(error) => {
+                                app.status_line =
+                                    format!("{} sent, but refresh failed: {error}", command.verb());
+                            }
+                        }
+                    } else {
+                        app.status_line = format!("No loop selected for {}", command.verb());
+                    }
                 }
                 AppAction::None => {}
             },
@@ -297,6 +359,69 @@ async fn run_app(
     }
 
     Ok(())
+}
+
+impl LoopCommand {
+    fn verb(self) -> &'static str {
+        match self {
+            Self::Approve => "approve",
+            Self::Resume => "resume",
+            Self::Cancel => "cancel",
+        }
+    }
+}
+
+async fn perform_loop_action(
+    client: &NemoClient,
+    command: LoopCommand,
+    loop_id: uuid::Uuid,
+) -> Result<String> {
+    match command {
+        LoopCommand::Approve => {
+            let response: ApproveActionResponse = client
+                .post(&format!("/approve/{loop_id}"), &serde_json::json!({}))
+                .await?;
+            Ok(if response.approve_requested {
+                format!("approved {} ({})", response.loop_id, response.state)
+            } else {
+                format!(
+                    "approve not applicable for {} ({})",
+                    response.loop_id, response.state
+                )
+            })
+        }
+        LoopCommand::Resume => {
+            let response: ResumeActionResponse = client
+                .post(&format!("/resume/{loop_id}"), &serde_json::json!({}))
+                .await?;
+            Ok(if response.resume_requested {
+                format!(
+                    "resume requested for {} ({})",
+                    response.loop_id, response.state
+                )
+            } else {
+                format!(
+                    "resume not applicable for {} ({})",
+                    response.loop_id, response.state
+                )
+            })
+        }
+        LoopCommand::Cancel => {
+            let response: CancelActionResponse =
+                client.delete(&format!("/cancel/{loop_id}")).await?;
+            Ok(if response.cancel_requested {
+                format!(
+                    "cancel requested for {} ({})",
+                    response.loop_id, response.state
+                )
+            } else {
+                format!(
+                    "cancel not applicable for {} ({})",
+                    response.loop_id, response.state
+                )
+            })
+        }
+    }
 }
 
 fn spawn_input_task(event_tx: mpsc::UnboundedSender<AppEvent>) {
@@ -758,7 +883,12 @@ fn render_footer(app: &App) -> Paragraph<'static> {
         ),
         Span::styled(" top/bottom  ", Style::default().fg(MUTED)),
         Span::styled("r", Style::default().fg(AMBER).add_modifier(Modifier::BOLD)),
-        Span::styled(" reconnect logs", Style::default().fg(MUTED)),
+        Span::styled(" reconnect logs  ", Style::default().fg(MUTED)),
+        Span::styled(
+            "a/u/c",
+            Style::default().fg(TEAL).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" approve/resume/cancel", Style::default().fg(MUTED)),
     ]))
     .style(Style::default().fg(TEXT).bg(BG))
 }
@@ -865,5 +995,23 @@ mod tests {
 
         assert_eq!(app.selected_loop_id, Some(second_id));
         assert_eq!(app.list_state.selected(), Some(0));
+    }
+
+    #[test]
+    fn action_hotkeys_map_to_loop_commands() {
+        let mut app = App::new(false);
+
+        assert_eq!(
+            app.handle_input(KeyEvent::from(KeyCode::Char('a'))),
+            AppAction::Trigger(LoopCommand::Approve)
+        );
+        assert_eq!(
+            app.handle_input(KeyEvent::from(KeyCode::Char('u'))),
+            AppAction::Trigger(LoopCommand::Resume)
+        );
+        assert_eq!(
+            app.handle_input(KeyEvent::from(KeyCode::Char('c'))),
+            AppAction::Trigger(LoopCommand::Cancel)
+        );
     }
 }

--- a/cli/src/commands/inspect.rs
+++ b/cli/src/commands/inspect.rs
@@ -1,6 +1,13 @@
 use anyhow::Result;
 
+use crate::api_types::InspectResponse;
 use crate::client::NemoClient;
+
+pub async fn fetch(client: &NemoClient, branch: &str) -> Result<InspectResponse> {
+    client
+        .get(&format!("/inspect?branch={}", urlencoding::encode(branch)))
+        .await
+}
 
 pub async fn run(client: &NemoClient, path: &str) -> Result<()> {
     // Prepend "agent/" if not already present so users can pass "alice/slug-hash"
@@ -11,9 +18,7 @@ pub async fn run(client: &NemoClient, path: &str) -> Result<()> {
     };
 
     // Pass branch as query param (not path segment) because branch names contain slashes
-    let resp: serde_json::Value = client
-        .get(&format!("/inspect?branch={}", urlencoding::encode(&branch)))
-        .await?;
+    let resp = fetch(client, &branch).await?;
 
     println!("{}", serde_json::to_string_pretty(&resp)?);
     Ok(())

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod approve;
 pub mod auth;
 pub mod cancel;
 pub mod config;
+pub mod helm;
 pub mod init;
 pub mod inspect;
 pub mod logs;

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -1,27 +1,14 @@
 use anyhow::Result;
 
+use crate::api_types::StatusResponse;
 use crate::client::NemoClient;
 
-#[derive(serde::Deserialize)]
-struct StatusResponse {
-    loops: Vec<LoopSummary>,
+pub async fn fetch(client: &NemoClient, engineer: &str, team: bool) -> Result<StatusResponse> {
+    client.get(&status_path(engineer, team)).await
 }
 
-#[derive(serde::Deserialize, serde::Serialize)]
-struct LoopSummary {
-    loop_id: uuid::Uuid,
-    engineer: String,
-    spec_path: String,
-    branch: String,
-    state: String,
-    sub_state: Option<String>,
-    round: i32,
-    created_at: String,
-    updated_at: String,
-}
-
-pub async fn run(client: &NemoClient, engineer: &str, team: bool, json: bool) -> Result<()> {
-    let path = if team {
+fn status_path(engineer: &str, team: bool) -> String {
+    if team {
         "/status?team=true".to_string()
     } else {
         // Percent-encode engineer name to handle special characters
@@ -36,9 +23,11 @@ pub async fn run(client: &NemoClient, engineer: &str, team: bool, json: bool) ->
             })
             .collect();
         format!("/status?engineer={encoded}")
-    };
+    }
+}
 
-    let resp: StatusResponse = client.get(&path).await?;
+pub async fn run(client: &NemoClient, engineer: &str, team: bool, json: bool) -> Result<()> {
+    let resp = fetch(client, engineer, team).await?;
 
     if json {
         println!("{}", serde_json::to_string_pretty(&resp.loops)?);
@@ -52,19 +41,20 @@ pub async fn run(client: &NemoClient, engineer: &str, team: bool, json: bool) ->
 
     // Table output
     println!(
-        "{:<38} {:<12} {:<20} {:<45} {:<8}",
-        "LOOP ID", "STATE", "ENGINEER", "SPEC", "ROUND"
+        "{:<38} {:<12} {:<10} {:<20} {:<40} {:<8}",
+        "LOOP ID", "STATE", "STAGE", "ENGINEER", "SPEC", "ROUND"
     );
-    println!("{}", "-".repeat(123));
+    println!("{}", "-".repeat(138));
 
     for l in &resp.loops {
         let state_display = match &l.sub_state {
             Some(sub) => format!("{}/{}", l.state, sub),
             None => l.state.clone(),
         };
+        let stage_display = l.current_stage.as_deref().unwrap_or("-");
         println!(
-            "{:<38} {:<12} {:<20} {:<45} {:<8}",
-            l.loop_id, state_display, l.engineer, l.spec_path, l.round
+            "{:<38} {:<12} {:<10} {:<20} {:<40} {:<8}",
+            l.loop_id, state_display, stage_display, l.engineer, l.spec_path, l.round
         );
     }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,3 +1,4 @@
+mod api_types;
 mod claude_creds;
 mod client;
 mod commands;
@@ -86,6 +87,13 @@ enum Commands {
         /// Output as JSON
         #[arg(long)]
         json: bool,
+    },
+
+    /// K9s-style loop overview with live logs
+    Helm {
+        /// Show all engineers' loops
+        #[arg(long)]
+        team: bool,
     },
 
     /// Stream logs for a loop
@@ -219,6 +227,7 @@ async fn main() -> anyhow::Result<()> {
         | Commands::Start { .. }
         | Commands::Ship { .. }
         | Commands::Auth { .. } => true,
+        Commands::Helm { team } => !team,
         Commands::Status { team, .. } => !team,
         _ => false,
     };
@@ -322,6 +331,9 @@ async fn main() -> anyhow::Result<()> {
         }
         Commands::Status { team, json } => {
             commands::status::run(&http_client, &eng_config.engineer, team, json).await?;
+        }
+        Commands::Helm { team } => {
+            commands::helm::run(&http_client, &eng_config.engineer, team).await?;
         }
         Commands::Logs {
             loop_id,

--- a/control-plane/src/api/handlers.rs
+++ b/control-plane/src/api/handlers.rs
@@ -209,22 +209,71 @@ pub async fn status(
         )
         .await?;
 
-    let summaries = loops
-        .into_iter()
-        .map(|l| LoopSummary {
-            loop_id: l.id,
-            engineer: l.engineer,
-            spec_path: l.spec_path,
-            branch: l.branch,
-            state: l.state,
-            sub_state: l.sub_state,
-            round: l.round,
-            created_at: l.created_at,
-            updated_at: l.updated_at,
-        })
-        .collect();
+    let mut summaries = Vec::with_capacity(loops.len());
+    for loop_record in loops {
+        let current_stage = current_stage_for_loop(&state, &loop_record).await?;
+        let active_job_name = loop_record.active_job_name.clone();
+        summaries.push(LoopSummary {
+            loop_id: loop_record.id,
+            engineer: loop_record.engineer,
+            spec_path: loop_record.spec_path,
+            branch: loop_record.branch,
+            state: loop_record.state,
+            sub_state: loop_record.sub_state,
+            round: loop_record.round,
+            current_stage,
+            active_job_name,
+            created_at: loop_record.created_at,
+            updated_at: loop_record.updated_at,
+        });
+    }
 
     Ok(Json(StatusResponse { loops: summaries }))
+}
+
+fn current_stage_source_state(record: &LoopRecord) -> Option<LoopState> {
+    if record.state.is_active_stage() {
+        return Some(record.state);
+    }
+
+    match record.state {
+        LoopState::Paused => record.paused_from_state,
+        LoopState::AwaitingReauth => record.reauth_from_state,
+        LoopState::Failed => record.failed_from_state,
+        _ => None,
+    }
+}
+
+async fn current_stage_for_loop(
+    state: &AppState,
+    record: &LoopRecord,
+) -> Result<Option<String>, NautiloopError> {
+    let Some(source_state) = current_stage_source_state(record) else {
+        return Ok(None);
+    };
+
+    let direct_stage = match source_state {
+        LoopState::Implementing => Some("implement"),
+        LoopState::Testing => Some("test"),
+        LoopState::Reviewing => Some("review"),
+        _ => None,
+    };
+    if let Some(stage) = direct_stage {
+        return Ok(Some(stage.to_string()));
+    }
+
+    if source_state != LoopState::Hardening {
+        return Ok(None);
+    }
+
+    let rounds = state.store.get_rounds(record.id).await?;
+    Ok(Some(
+        rounds
+            .iter()
+            .rfind(|round| round.round == record.round)
+            .map(|round| round.stage.clone())
+            .unwrap_or_else(|| "audit".to_string()),
+    ))
 }
 
 /// GET /logs/:id - Stream logs via SSE.
@@ -921,7 +970,7 @@ mod tests {
             current_sha: None,
             opencode_session_id: None,
             claude_session_id: None,
-            active_job_name: None,
+            active_job_name: Some("implement-job".to_string()),
             retry_count: 0,
             model_implementor: None,
             model_reviewer: None,
@@ -983,7 +1032,7 @@ mod tests {
             current_sha: None,
             opencode_session_id: None,
             claude_session_id: None,
-            active_job_name: None,
+            active_job_name: Some("implement-job".to_string()),
             retry_count: 0,
             model_implementor: None,
             model_reviewer: None,
@@ -1039,7 +1088,7 @@ mod tests {
             current_sha: None,
             opencode_session_id: None,
             claude_session_id: None,
-            active_job_name: None,
+            active_job_name: Some("implement-job".to_string()),
             retry_count: 0,
             model_implementor: None,
             model_reviewer: None,
@@ -1071,6 +1120,11 @@ mod tests {
         let resp: StatusResponse = serde_json::from_slice(&body).unwrap();
         assert_eq!(resp.loops.len(), 1);
         assert_eq!(resp.loops[0].engineer, "alice");
+        assert_eq!(resp.loops[0].current_stage.as_deref(), Some("implement"));
+        assert_eq!(
+            resp.loops[0].active_job_name.as_deref(),
+            Some("implement-job")
+        );
     }
 
     #[tokio::test]

--- a/control-plane/src/k8s/client.rs
+++ b/control-plane/src/k8s/client.rs
@@ -122,9 +122,10 @@ impl JobDispatcher for KubeJobDispatcher {
 
         for pod in &pod_list.items {
             if let Some(pod_name) = &pod.metadata.name {
+                // Fetch the full log so the driver can reconcile without
+                // silently dropping lines if a job emits more than a fixed tail.
                 let log_params = kube::api::LogParams {
                     container: Some("agent".to_string()),
-                    tail_lines: Some(5000), // Large enough for verbose agent output
                     ..Default::default()
                 };
                 match pods_api.logs(pod_name, &log_params).await {

--- a/control-plane/src/loop_engine/driver.rs
+++ b/control-plane/src/loop_engine/driver.rs
@@ -12,7 +12,7 @@ use crate::types::verdict::{
     TestResultData,
 };
 use crate::types::{
-    LoopContext, LoopKind, LoopRecord, LoopState, RoundRecord, StageConfig, SubState,
+    LogEvent, LoopContext, LoopKind, LoopRecord, LoopState, RoundRecord, StageConfig, SubState,
 };
 
 /// The convergent loop driver. Processes one tick per loop, advancing its state machine.
@@ -183,6 +183,8 @@ impl ConvergentLoopDriver {
                             return Ok(LoopState::Paused);
                         }
 
+                        self.sync_current_stage_logs(record).await;
+
                         Ok(record.state)
                     }
                     JobStatus::Succeeded => {
@@ -230,6 +232,8 @@ impl ConvergentLoopDriver {
     async fn handle_job_completed(&self, record: &LoopRecord) -> Result<LoopState> {
         let mut updated = record.clone();
         updated.sub_state = Some(SubState::Completed);
+
+        self.sync_current_stage_logs(record).await;
 
         // Ingest job output: read verdict from git, update round record, set current_sha
         self.ingest_job_output(&mut updated).await?;
@@ -420,6 +424,118 @@ impl ConvergentLoopDriver {
                 );
             }
         }
+    }
+
+    async fn sync_current_stage_logs(&self, record: &LoopRecord) {
+        let Some(job_name) = record.active_job_name.as_deref() else {
+            return;
+        };
+
+        let Some((round, stage)) = self.current_log_context(record).await else {
+            return;
+        };
+
+        let logs = match self
+            .dispatcher
+            .get_job_logs(job_name, &self.config.cluster.jobs_namespace)
+            .await
+        {
+            Ok(logs) => logs,
+            Err(error) => {
+                tracing::warn!(
+                    loop_id = %record.id,
+                    job_name,
+                    error = %error,
+                    "Failed to sync live stage logs"
+                );
+                return;
+            }
+        };
+
+        if let Err(error) = self
+            .append_new_log_lines(record.id, round, &stage, &logs)
+            .await
+        {
+            tracing::warn!(
+                loop_id = %record.id,
+                round,
+                stage,
+                error = %error,
+                "Failed to persist live stage logs"
+            );
+        }
+    }
+
+    async fn current_log_context(&self, record: &LoopRecord) -> Option<(i32, String)> {
+        if record.round <= 0 {
+            return None;
+        }
+
+        let rounds = match self.store.get_rounds(record.id).await {
+            Ok(rounds) => rounds,
+            Err(error) => {
+                tracing::warn!(
+                    loop_id = %record.id,
+                    error = %error,
+                    "Failed to load rounds for log sync"
+                );
+                return None;
+            }
+        };
+
+        rounds
+            .iter()
+            .rfind(|round| round.round == record.round && round.completed_at.is_none())
+            .or_else(|| rounds.iter().rfind(|round| round.round == record.round))
+            .map(|round| (round.round, round.stage.clone()))
+    }
+
+    async fn append_new_log_lines(
+        &self,
+        loop_id: Uuid,
+        round: i32,
+        stage: &str,
+        logs: &str,
+    ) -> Result<()> {
+        let existing = self
+            .store
+            .get_logs(loop_id, Some(round), Some(stage))
+            .await?;
+        let existing_lines: Vec<String> = existing.into_iter().map(|event| event.line).collect();
+        let new_lines: Vec<String> = logs
+            .lines()
+            .map(str::trim_end)
+            .filter(|line| !line.is_empty() && !line.starts_with("NAUTILOOP_RESULT:"))
+            .map(ToOwned::to_owned)
+            .collect();
+
+        if new_lines.is_empty() {
+            return Ok(());
+        }
+
+        let max_overlap = existing_lines.len().min(new_lines.len());
+        let overlap = (0..=max_overlap)
+            .rev()
+            .find(|count| {
+                existing_lines[existing_lines.len().saturating_sub(*count)..] == new_lines[..*count]
+            })
+            .unwrap_or(0);
+
+        let base_timestamp = chrono::Utc::now();
+        for (offset, line) in new_lines.into_iter().skip(overlap).enumerate() {
+            self.store
+                .append_log(&LogEvent {
+                    id: Uuid::new_v4(),
+                    loop_id,
+                    round,
+                    stage: stage.to_string(),
+                    timestamp: base_timestamp + chrono::Duration::milliseconds(offset as i64),
+                    line,
+                })
+                .await?;
+        }
+
+        Ok(())
     }
 
     /// Evaluate harden stage output (audit or revise).
@@ -1184,6 +1300,8 @@ impl ConvergentLoopDriver {
 
     /// Handle cancel request: kill job and transition to CANCELLED.
     async fn handle_cancel(&self, record: &LoopRecord) -> Result<LoopState> {
+        self.sync_current_stage_logs(record).await;
+
         // Delete active job if any (log failure but proceed — orphan cleanup handles stragglers)
         if let Some(ref job_name) = record.active_job_name
             && let Err(e) = self
@@ -1213,6 +1331,8 @@ impl ConvergentLoopDriver {
     /// Handle auth expiry (exit code 42 detected by K8s pod inspection).
     async fn handle_auth_expired(&self, record: &LoopRecord, reason: &str) -> Result<LoopState> {
         let mut updated = record.clone();
+
+        self.sync_current_stage_logs(record).await;
 
         if let Some(ref job_name) = record.active_job_name
             && let Err(e) = self
@@ -1263,6 +1383,8 @@ impl ConvergentLoopDriver {
         resumable_on_exhaustion: bool,
     ) -> Result<LoopState> {
         let mut updated = record.clone();
+
+        self.sync_current_stage_logs(record).await;
 
         // Detect credential expiry (FR-10): transition to AWAITING_REAUTH
         if is_auth_error(reason) && record.state.is_active_stage() {
@@ -2892,6 +3014,91 @@ mod tests {
             Some("aabbccdd11223344".to_string()),
             "current_sha should be populated from branch tip"
         );
+    }
+
+    #[tokio::test]
+    async fn test_running_job_syncs_live_logs_without_duplicates() {
+        let store = Arc::new(MemoryStateStore::new());
+        let dispatcher = Arc::new(MockJobDispatcher::new());
+        let git = Arc::new(MockGitOperations::new());
+        let driver = ConvergentLoopDriver::new(
+            store.clone(),
+            dispatcher.clone(),
+            git.clone(),
+            NautiloopConfig::default(),
+        );
+
+        git.set_branch_sha("agent/alice/test-abc12345", "aabbccdd11223344")
+            .await;
+
+        let mut record = make_pending_loop(true);
+        record.state = LoopState::Implementing;
+        record.sub_state = Some(SubState::Dispatched);
+        record.round = 1;
+        record.active_job_name = Some("impl-job".to_string());
+        record.current_sha = Some("aabbccdd11223344".to_string());
+        store.create_loop(&record).await.unwrap();
+
+        store
+            .create_round(&RoundRecord {
+                id: Uuid::new_v4(),
+                loop_id: record.id,
+                round: 1,
+                stage: "implement".to_string(),
+                input: None,
+                output: None,
+                started_at: Some(chrono::Utc::now() - chrono::Duration::seconds(30)),
+                completed_at: None,
+                duration_secs: None,
+                job_name: Some("impl-job".to_string()),
+            })
+            .await
+            .unwrap();
+
+        let job = k8s_openapi::api::batch::v1::Job {
+            metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta {
+                name: Some("impl-job".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        dispatcher.create_job(&job).await.unwrap();
+        dispatcher
+            .set_job_status("impl-job", JobStatus::Running)
+            .await;
+
+        dispatcher
+            .set_job_logs("impl-job", "first line\nsecond line\n")
+            .await;
+        let new_state = driver.tick(record.id).await.unwrap();
+        assert_eq!(new_state, LoopState::Implementing);
+
+        let logs = store
+            .get_logs(record.id, Some(1), Some("implement"))
+            .await
+            .unwrap();
+        let lines: Vec<&str> = logs.iter().map(|event| event.line.as_str()).collect();
+        assert_eq!(lines, vec!["first line", "second line"]);
+
+        driver.tick(record.id).await.unwrap();
+        let logs = store
+            .get_logs(record.id, Some(1), Some("implement"))
+            .await
+            .unwrap();
+        let lines: Vec<&str> = logs.iter().map(|event| event.line.as_str()).collect();
+        assert_eq!(lines, vec!["first line", "second line"]);
+
+        dispatcher
+            .set_job_logs("impl-job", "first line\nsecond line\nthird line\n")
+            .await;
+        driver.tick(record.id).await.unwrap();
+
+        let logs = store
+            .get_logs(record.id, Some(1), Some("implement"))
+            .await
+            .unwrap();
+        let lines: Vec<&str> = logs.iter().map(|event| event.line.as_str()).collect();
+        assert_eq!(lines, vec!["first line", "second line", "third line"]);
     }
 
     #[tokio::test]

--- a/control-plane/src/types/api.rs
+++ b/control-plane/src/types/api.rs
@@ -58,6 +58,10 @@ pub struct LoopSummary {
     pub state: LoopState,
     pub sub_state: Option<SubState>,
     pub round: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_stage: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active_job_name: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }


### PR DESCRIPTION
## Summary
- persist live stage logs into the existing loop log stream so CLI observability survives pod churn and terminal transitions
- add `nemo helm`, a k9s-style TUI with loop overview, latest inspect/verdict context, live persisted logs, and agent or auth-sidecar pod log views
- add operator controls in `helm` for approve, resume, and cancel, and extend status responses with current stage and active job metadata

## Testing
- cargo test --workspace
- cargo clippy --workspace -- -D warnings