### PR TITLE
chore: release 0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2322,7 +2322,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-control-plane"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2350,7 +2350,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-sidecar"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bytes",
  "chrono",
@@ -2410,7 +2410,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-cli"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["control-plane", "cli", "sidecar", "sidecar/tests/parity"]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -57,9 +57,9 @@ module "nautiloop" {
   acme_email = "me@mydomain.com"     # required if domain is set
 
   # Optional: images (defaults to latest public GHCR)
-  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.1"
-  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.1"
-  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.1"
+  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.2"
+  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.2"
+  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.2"
 }
 ```
 
@@ -75,9 +75,9 @@ module "nautiloop" {
 | `repo_ssh_private_key` | no | auto-generated | SSH deploy key. If null, generates ED25519 |
 | `domain` | no | `null` | Domain for TLS. null = HTTP on raw IP:8080 |
 | `acme_email` | no | `null` | Let's Encrypt email. Required if domain is set |
-| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.1` | Control plane image |
-| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.1` | Agent base image |
-| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.1` | Auth sidecar image |
+| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.2` | Control plane image |
+| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.2` | Agent base image |
+| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.2` | Auth sidecar image |
 | `k3s_version` | no | `v1.32.13+k3s1` | k3s version (v1.32+ required) |
 | `postgres_password` | no | auto-generated | Postgres password |
 | `postgres_volume_size` | no | `20` | Postgres volume size (Gi) |
@@ -175,9 +175,9 @@ nemo auth                    # pushes credentials (Claude, OpenAI, SSH) to clust
 ```bash
 ./build-images.sh --tag 0.2.0
 terraform apply \
-  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.1" \
-  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.1" \
-  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.1"
+  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.2" \
+  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.2" \
+  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.2"
 ```
 
 All three images must be updated together to avoid version skew.

--- a/terraform/examples/existing-server/variables.tf
+++ b/terraform/examples/existing-server/variables.tf
@@ -50,17 +50,17 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.1"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.2"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.1"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.2"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.1"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.2"
 }

--- a/terraform/examples/hetzner/variables.tf
+++ b/terraform/examples/hetzner/variables.tf
@@ -77,19 +77,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.1"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.2"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.1"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.2"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.1"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.2"
 }
 
 variable "k3s_version" {

--- a/terraform/modules/nautiloop/variables.tf
+++ b/terraform/modules/nautiloop/variables.tf
@@ -79,19 +79,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.1"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.2"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.1"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.2"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.1"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.2"
 }
 
 # --- Optional: tuning ---

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -71,19 +71,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.1"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.2"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.1"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.2"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.1"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.2"
 }
 
 variable "k3s_version" {


### PR DESCRIPTION
This release adds the `nemo models` command for discovering authenticated providers and available models.

## New Features

- **`nemo models`**: Show authenticated providers (claude, openai, ssh)
- **`nemo models`**: List available models per provider with usage examples
- **GET /credentials API endpoint**: For querying registered credentials

## Example Usage

```bash
$ nemo models

Authenticated Providers
========================
  ✓ claude   ~/.claude/credentials.json [control plane: valid]
  ✓ openai   ~/.local/share/opencode/auth.json [control plane: valid]
  ✗ ssh      not found — Run: ssh-keygen -t ed25519

Available Models by Provider
=============================
✓ claude:
  - claude-opus-4
  - claude-sonnet-4
  - claude-haiku-4

✓ openai:
  - gpt-5.4
  - gpt-4o
  - o1-preview
  - o1-mini

Usage Examples
==============

Mix providers:
  nemo start spec.md --model-impl claude-opus-4 --model-review gpt-5.4

Use same model for both:
  nemo start spec.md --model-impl claude-opus-4 --model-review claude-opus-4
```

## Local CLI Update

After this release, update your local CLI immediately without waiting for CI:

```bash
cargo build --release -p nemo-cli
nemo --version  # Should show 0.4.2
```