### PR TITLE
chore: release 0.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2322,7 +2322,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-control-plane"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2350,7 +2350,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-sidecar"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "bytes",
  "chrono",
@@ -2410,7 +2410,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-cli"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["control-plane", "cli", "sidecar", "sidecar/tests/parity"]
 
 [workspace.package]
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -57,9 +57,9 @@ module "nautiloop" {
   acme_email = "me@mydomain.com"     # required if domain is set
 
   # Optional: images (defaults to latest public GHCR)
-  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.2"
-  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.2"
-  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.2"
+  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.3"
+  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.3"
+  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.3"
 }
 ```
 
@@ -75,9 +75,9 @@ module "nautiloop" {
 | `repo_ssh_private_key` | no | auto-generated | SSH deploy key. If null, generates ED25519 |
 | `domain` | no | `null` | Domain for TLS. null = HTTP on raw IP:8080 |
 | `acme_email` | no | `null` | Let's Encrypt email. Required if domain is set |
-| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.2` | Control plane image |
-| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.2` | Agent base image |
-| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.2` | Auth sidecar image |
+| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.3` | Control plane image |
+| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.3` | Agent base image |
+| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.3` | Auth sidecar image |
 | `k3s_version` | no | `v1.32.13+k3s1` | k3s version (v1.32+ required) |
 | `postgres_password` | no | auto-generated | Postgres password |
 | `postgres_volume_size` | no | `20` | Postgres volume size (Gi) |
@@ -175,9 +175,9 @@ nemo auth                    # pushes credentials (Claude, OpenAI, SSH) to clust
 ```bash
 ./build-images.sh --tag 0.2.0
 terraform apply \
-  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.2" \
-  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.2" \
-  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.2"
+  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.3" \
+  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.3" \
+  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.3"
 ```
 
 All three images must be updated together to avoid version skew.

--- a/terraform/examples/existing-server/variables.tf
+++ b/terraform/examples/existing-server/variables.tf
@@ -50,17 +50,17 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.2"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.3"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.2"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.3"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.2"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.3"
 }

--- a/terraform/examples/hetzner/variables.tf
+++ b/terraform/examples/hetzner/variables.tf
@@ -77,19 +77,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.2"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.3"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.2"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.3"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.2"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.3"
 }
 
 variable "k3s_version" {

--- a/terraform/modules/nautiloop/variables.tf
+++ b/terraform/modules/nautiloop/variables.tf
@@ -79,19 +79,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.2"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.3"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.2"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.3"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.2"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.3"
 }
 
 # --- Optional: tuning ---

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -71,19 +71,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.2"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.3"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.2"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.3"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.2"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.3"
 }
 
 variable "k3s_version" {


### PR DESCRIPTION
This release fixes a critical OAuth authentication bug in the sidecar.

## Fixes

- **sidecar**: Use access token instead of refresh token for OpenAI OAuth
  
  The sidecar was incorrectly sending the refresh token in the Authorization header, causing "Could not parse your authentication token" errors when using ChatGPT Plus / Codex OAuth credentials.

  Changed: `model_proxy.rs:650` - `oauth.refresh` → `oauth.access`

## Impact

This fix enables proper OAuth authentication for users with ChatGPT Plus subscriptions using the opencode/codex OAuth flow. Previously, loops would fail immediately with 401 Unauthorized errors even with fresh credentials.

## Local CLI Update

After this release, update your local CLI:

```bash
cargo build --release -p nemo-cli
nemo --version  # Should show 0.4.3
```

**Note**: For the OAuth fix to take effect, your cluster must use the new sidecar image (`nautiloop-sidecar:v0.4.3`).