### PR TITLE
chore: release 0.4.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2322,7 +2322,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-control-plane"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2350,7 +2350,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-sidecar"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bytes",
  "chrono",
@@ -2410,7 +2410,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-cli"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["control-plane", "cli", "sidecar", "sidecar/tests/parity"]
 
 [workspace.package]
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -57,9 +57,9 @@ module "nautiloop" {
   acme_email = "me@mydomain.com"     # required if domain is set
 
   # Optional: images (defaults to latest public GHCR)
-  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.3"
-  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.3"
-  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.3"
+  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.4"
+  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.4"
+  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.4"
 }
 ```
 
@@ -75,9 +75,9 @@ module "nautiloop" {
 | `repo_ssh_private_key` | no | auto-generated | SSH deploy key. If null, generates ED25519 |
 | `domain` | no | `null` | Domain for TLS. null = HTTP on raw IP:8080 |
 | `acme_email` | no | `null` | Let's Encrypt email. Required if domain is set |
-| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.3` | Control plane image |
-| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.3` | Agent base image |
-| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.3` | Auth sidecar image |
+| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.4` | Control plane image |
+| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.4` | Agent base image |
+| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.4` | Auth sidecar image |
 | `k3s_version` | no | `v1.32.13+k3s1` | k3s version (v1.32+ required) |
 | `postgres_password` | no | auto-generated | Postgres password |
 | `postgres_volume_size` | no | `20` | Postgres volume size (Gi) |
@@ -175,9 +175,9 @@ nemo auth                    # pushes credentials (Claude, OpenAI, SSH) to clust
 ```bash
 ./build-images.sh --tag 0.2.0
 terraform apply \
-  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.3" \
-  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.3" \
-  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.3"
+  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.4" \
+  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.4" \
+  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.4"
 ```
 
 All three images must be updated together to avoid version skew.

--- a/terraform/examples/existing-server/variables.tf
+++ b/terraform/examples/existing-server/variables.tf
@@ -50,17 +50,17 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.3"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.4"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.3"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.4"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.3"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.4"
 }

--- a/terraform/examples/hetzner/variables.tf
+++ b/terraform/examples/hetzner/variables.tf
@@ -77,19 +77,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.3"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.4"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.3"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.4"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.3"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.4"
 }
 
 variable "k3s_version" {

--- a/terraform/modules/nautiloop/variables.tf
+++ b/terraform/modules/nautiloop/variables.tf
@@ -79,19 +79,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.3"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.4"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.3"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.4"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.3"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.4"
 }
 
 # --- Optional: tuning ---

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -71,19 +71,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.3"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.4"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.3"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.4"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.3"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.4"
 }
 
 variable "k3s_version" {


### PR DESCRIPTION
This release fixes the opencode run invocation in the agent entrypoint.

## Fixes

- **agent**: Pass prompt as positional argument to `opencode run`
  
  The entrypoint was piping the prompt via stdin, but `opencode run` requires the message as a positional argument. This caused "Instructions are required" errors in audit/review stages.

  Changed: `images/base/nautiloop-agent-entry`
  - Read prompt file into `PROMPT_CONTENT` variable
  - Pass as positional argument to `opencode run`
  - Truncate to ~100KB to avoid ARG_MAX issues

## Impact

This fix enables proper audit/review stage execution with opencode v1.4.x. Previously, all audit and review stages would fail immediately with "Instructions are required" errors.

## Local CLI Update

After this release, update your local CLI:

```bash
cargo build --release -p nemo-cli
nemo --version  # Should show 0.4.4
```

**Note**: For this fix to take effect, your cluster must use the new agent-base image (`nautiloop-agent-base:v0.4.4`).