### PR TITLE
fix(audit): correct model routing for anthropic and content-length on patched bodies

### DIFF
--- a/images/base/nautiloop-agent-entry
+++ b/images/base/nautiloop-agent-entry
@@ -351,8 +351,9 @@ case "$STAGE" in
         # reviewer doesn't silently fall back to a nondeterministic default.
         OPENCODE_MODEL="${MODEL:-gpt-4o-mini}"
         case "$OPENCODE_MODEL" in
-            */*) ;;                              # already has provider prefix
-            *) OPENCODE_MODEL="openai/$OPENCODE_MODEL" ;;
+            */*) ;;                                          # already has provider prefix
+            claude-*) OPENCODE_MODEL="anthropic/$OPENCODE_MODEL" ;;  # Anthropic models
+            *) OPENCODE_MODEL="openai/$OPENCODE_MODEL" ;;            # default: OpenAI
         esac
 
         # opencode v1.3+ removed --prompt-file; the message must be passed as a

--- a/sidecar/src/model_proxy.rs
+++ b/sidecar/src/model_proxy.rs
@@ -377,7 +377,7 @@ async fn handle(
     };
 
     // Build the outgoing request.
-    let mut builder = Request::builder().method(method).uri(uri);
+    let mut builder = Request::builder().method(&method).uri(uri);
     // Copy every header through, then overwrite the auth header and
     // Host header so upstream sees the correct values.
     {
@@ -386,6 +386,13 @@ async fn handle(
         };
         for (k, v) in headers.iter() {
             h.append(k.clone(), v.clone());
+        }
+        // When we patch the body (instructions injection), the byte count
+        // changes. Remove the stale Content-Length so hyper recalculates
+        // it from the Full body's exact size_hint instead of forwarding
+        // the caller's (now-incorrect) value.
+        if method == hyper::Method::POST && path.contains("/v1/responses") {
+            h.remove(http::header::CONTENT_LENGTH);
         }
         // FR-18 / SR-5: the inbound Host header reflects the sidecar's
         // loopback bind (e.g. `127.0.0.1:9090`). Forwarding that verbatim


### PR DESCRIPTION
## Summary

- `claude-*` models were getting `openai/` prefix prepended in the agent entry script, causing `Model not found: openai/claude-opus-4-6`. Added a `claude-*` case to map these to `anthropic/` instead.
- Removed stale `Content-Length` header when injecting `instructions` into POST `/v1/responses` bodies. opencode sets `Content-Length` for the original body; after injection the body grows but `Content-Length` stayed at the original value, which could cause upstream (chatgpt.com) to reject the request.

## Test plan
- [ ] `cargo test --workspace` passes
- [ ] Deploy 0.4.8 and verify `--model-review claude-opus-4-6` routes correctly to `anthropic/claude-opus-4-6`
- [ ] Verify `gpt-5.4` audit jobs no longer return 400 Bad Request