### PR TITLE
chore: release 0.4.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2322,7 +2322,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-control-plane"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2350,7 +2350,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-sidecar"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "bytes",
  "chrono",
@@ -2410,7 +2410,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-cli"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["control-plane", "cli", "sidecar", "sidecar/tests/parity"]
 
 [workspace.package]
-version = "0.4.7"
+version = "0.4.8"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -57,9 +57,9 @@ module "nautiloop" {
   acme_email = "me@mydomain.com"     # required if domain is set
 
   # Optional: images (defaults to latest public GHCR)
-  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.7"
-  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.7"
-  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.7"
+  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.8"
+  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.8"
+  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.8"
 }
 ```
 
@@ -75,9 +75,9 @@ module "nautiloop" {
 | `repo_ssh_private_key` | no | auto-generated | SSH deploy key. If null, generates ED25519 |
 | `domain` | no | `null` | Domain for TLS. null = HTTP on raw IP:8080 |
 | `acme_email` | no | `null` | Let's Encrypt email. Required if domain is set |
-| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.7` | Control plane image |
-| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.7` | Agent base image |
-| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.7` | Auth sidecar image |
+| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.8` | Control plane image |
+| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.8` | Agent base image |
+| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.8` | Auth sidecar image |
 | `k3s_version` | no | `v1.32.13+k3s1` | k3s version (v1.32+ required) |
 | `postgres_password` | no | auto-generated | Postgres password |
 | `postgres_volume_size` | no | `20` | Postgres volume size (Gi) |
@@ -175,9 +175,9 @@ nemo auth                    # pushes credentials (Claude, OpenAI, SSH) to clust
 ```bash
 ./build-images.sh --tag 0.2.0
 terraform apply \
-  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.7" \
-  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.7" \
-  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.7"
+  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.8" \
+  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.8" \
+  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.8"
 ```
 
 All three images must be updated together to avoid version skew.

--- a/images/base/nautiloop-agent-entry
+++ b/images/base/nautiloop-agent-entry
@@ -338,6 +338,13 @@ case "$STAGE" in
     review|audit)
         # FR-6, FR-7: OpenCode for review/audit (read-only)
         export OPENCODE_PERMISSIONS='{"edit":"deny","bash":"deny","read":"allow"}'
+        # Prevent opencode from auto-upgrading its binary at runtime. The image
+        # pins a specific opencode version; a self-upgrade would replace it with
+        # an untested version and void our SHA256 verification at build time.
+        # Also disable the models.dev fetch — the sidecar egress logger showed
+        # this as a ~168KB outbound call that isn't needed for headless operation.
+        export OPENCODE_DISABLE_AUTOUPDATE=1
+        export OPENCODE_DISABLE_MODELS_FETCH=1
 
         # Pin the provider to `openai` so opencode routes through the sidecar
         # model proxy (OPENAI_BASE_URL=http://localhost:9090/openai) instead

--- a/terraform/examples/existing-server/variables.tf
+++ b/terraform/examples/existing-server/variables.tf
@@ -50,17 +50,17 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.7"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.8"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.7"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.8"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.7"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.8"
 }

--- a/terraform/examples/hetzner/variables.tf
+++ b/terraform/examples/hetzner/variables.tf
@@ -77,19 +77,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.7"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.8"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.7"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.8"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.7"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.8"
 }
 
 variable "k3s_version" {

--- a/terraform/modules/nautiloop/variables.tf
+++ b/terraform/modules/nautiloop/variables.tf
@@ -79,19 +79,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.7"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.8"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.7"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.8"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.7"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.8"
 }
 
 # --- Optional: tuning ---

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -71,19 +71,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.7"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.8"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.7"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.8"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.7"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.8"
 }
 
 variable "k3s_version" {


### PR DESCRIPTION
## Summary

Fixes three audit stage bugs present across 0.4.4–0.4.7:

- `claude-*` models no longer get `openai/` prefix. `--model-review claude-opus-4-6` now correctly routes to `anthropic/claude-opus-4-6` instead of failing with "Model not found: openai/claude-opus-4-6".
- Stale `Content-Length` header stripped when sidecar injects `instructions` into POST `/v1/responses`. The patched body was longer than the original, causing chatgpt.com to return 400 Bad Request.
- Disable opencode auto-update (`OPENCODE_DISABLE_AUTOUPDATE=1`) and models fetch (`OPENCODE_DISABLE_MODELS_FETCH=1`) in audit/review pods. Sidecar egress logs confirmed opencode was self-upgrading (~2.5MB download from `release-assets.githubusercontent.com`) on every audit job, replacing the pinned SHA256-verified binary.