### PR TITLE
test(sidecar): add model proxy end-to-end integration tests

### DIFF
--- a/sidecar/Cargo.toml
+++ b/sidecar/Cargo.toml
@@ -119,3 +119,8 @@ __test_utils = []
 name = "git_ssh_proxy_e2e"
 path = "tests/git_ssh_proxy_e2e.rs"
 required-features = ["__test_utils"]
+
+[[test]]
+name = "model_proxy_e2e"
+path = "tests/model_proxy_e2e.rs"
+required-features = ["__test_utils"]

--- a/sidecar/src/model_proxy.rs
+++ b/sidecar/src/model_proxy.rs
@@ -34,6 +34,25 @@ use tokio::sync::{Mutex, watch};
 use crate::logging;
 use crate::ssrf_connector::SsrfConnector;
 
+/// Test-only configuration that redirects upstream calls to local mock servers.
+///
+/// Enabled only under `#[cfg(feature = "__test_utils")]`. Production builds
+/// must never include this type.
+#[cfg(feature = "__test_utils")]
+pub struct TestProxyConfig {
+    /// Path to the OpenAI credential file (may be a tempfile path).
+    pub openai_cred_path: String,
+    /// Path to the Anthropic credential file (may be a tempfile path).
+    pub anthropic_cred_path: String,
+    /// Base URL for OpenAI upstream, e.g. `"http://127.0.0.1:PORT"`.
+    pub openai_base_url: String,
+    /// Base URL for Anthropic upstream, e.g. `"http://127.0.0.1:PORT"`.
+    pub anthropic_base_url: String,
+    /// Base URL for CodexOauth upstream (replaces the chatgpt.com codex
+    /// endpoint), e.g. `"http://127.0.0.1:PORT"`.
+    pub codex_base_url: String,
+}
+
 const OPENAI_HOST: &str = "api.openai.com";
 const CHATGPT_CODEX_HOST: &str = "chatgpt.com";
 const ANTHROPIC_HOST: &str = "api.anthropic.com";
@@ -296,12 +315,30 @@ pub async fn serve(
     Ok(())
 }
 
-/// Handle a single request end-to-end.
+/// Handle a single request end-to-end (production path).
 async fn handle(
     req: Request<Incoming>,
     client: &UpstreamClient,
     openai_oauth_cache: &Mutex<Option<CodexOauthCredential>>,
 ) -> Response<BoxBody<Bytes, hyper::Error>> {
+    handle_inner(req, client, openai_oauth_cache, None).await
+}
+
+/// Shared request handling logic, parameterised over the connector type
+/// so the same code path runs in both production (SsrfConnector + TLS)
+/// and integration tests (plain HttpConnector).
+///
+/// When `test_config` is `Some`, credential paths and upstream base URLs
+/// are taken from the config instead of the production constants.
+async fn handle_inner<C>(
+    req: Request<Incoming>,
+    client: &Client<C, UpstreamBody>,
+    openai_oauth_cache: &Mutex<Option<CodexOauthCredential>>,
+    test_config: Option<&TestProxyConfigInner>,
+) -> Response<BoxBody<Bytes, hyper::Error>>
+where
+    C: hyper_util::client::legacy::connect::Connect + Clone + Send + Sync + 'static,
+{
     let path = req.uri().path().to_string();
     let query = req.uri().query().map(|s| s.to_string());
     let method = req.method().clone();
@@ -311,13 +348,16 @@ async fn handle(
         return forbidden_response();
     };
 
+    // Resolve credential paths: use test overrides when present.
+    let openai_path: &str = resolve_openai_path(&target, test_config);
+    let anthropic_path: &str = resolve_anthropic_path(&target, test_config);
+
     let openai_credential = if target.kind == UpstreamKind::OpenAi {
-        let credential = match read_openai_credential(target.kind.credential_path()).await {
+        let credential = match read_openai_credential(openai_path).await {
             Ok(credential) => credential,
             Err(e) => {
                 logging::error(&format!(
-                    "failed to read credentials from {}: {e}",
-                    target.kind.credential_path()
+                    "failed to read credentials from {openai_path}: {e}"
                 ));
                 return error_response(500, "credential read failed");
             }
@@ -336,12 +376,11 @@ async fn handle(
     };
 
     let raw_credential = if target.kind == UpstreamKind::Anthropic {
-        match read_credential(target.kind.credential_path()).await {
+        match read_credential(anthropic_path).await {
             Ok(credential) => Some(credential),
             Err(e) => {
                 logging::error(&format!(
-                    "failed to read credentials from {}: {e}",
-                    target.kind.credential_path()
+                    "failed to read credentials from {anthropic_path}: {e}"
                 ));
                 return error_response(500, "credential read failed");
             }
@@ -350,11 +389,25 @@ async fn handle(
         None
     };
 
-    let uri_string = upstream_uri(&target, query.as_deref(), openai_credential.as_ref());
+    // Compute the upstream URI. In test mode, substitute base URLs from config.
+    let is_codex_oauth =
+        matches!(openai_credential.as_ref(), Some(OpenAiCredential::CodexOauth(_)));
+
+    let uri_string = build_upstream_uri(
+        &target,
+        query.as_deref(),
+        openai_credential.as_ref(),
+        is_codex_oauth,
+        test_config,
+    );
     let uri: hyper::Uri = match uri_string.parse() {
         Ok(u) => u,
         Err(_) => return error_response(500, "invalid upstream URI"),
     };
+
+    // Determine host header value.
+    let host_header_value: String =
+        resolve_host_header(&target, openai_credential.as_ref(), is_codex_oauth, test_config);
 
     // For POST /v1/responses we must buffer the body to patch it before
     // forwarding. Two transforms are applied:
@@ -368,7 +421,6 @@ async fn handle(
     //    "Unsupported parameter: max_output_tokens" otherwise.
     //
     // All other requests stream through without buffering (FR-28).
-    let is_codex_oauth = matches!(openai_credential.as_ref(), Some(OpenAiCredential::CodexOauth(_)));
     let body = if method == hyper::Method::POST && path.contains("/v1/responses") {
         match req.into_body().collect().await {
             Ok(collected) => {
@@ -407,7 +459,7 @@ async fn handle(
         // loopback bind (e.g. `127.0.0.1:9090`). Forwarding that verbatim
         // would poison upstream virtual-host routing and break TLS-SNI
         // audit expectations. Rewrite it to the upstream hostname.
-        rewrite_host_header(h, upstream_host(&target, openai_credential.as_ref()));
+        rewrite_host_header(h, &host_header_value);
         inject_auth_header(
             h,
             target.kind,
@@ -444,6 +496,171 @@ async fn handle(
         Ok(r) => r,
         Err(_) => error_response(500, "failed to build response"),
     }
+}
+
+/// Internal type alias used by `handle_inner`. In non-test builds this is
+/// a zero-sized uninhabited alias so the compiler elides all `if let Some`
+/// branches that reference it — they are statically unreachable.
+#[cfg(feature = "__test_utils")]
+type TestProxyConfigInner = TestProxyConfig;
+
+/// Uninhabited sentinel used in non-test builds so `handle_inner` compiles
+/// with the same signature regardless of the feature flag.
+#[cfg(not(feature = "__test_utils"))]
+enum TestProxyConfigInner {}
+
+/// Build the upstream URI string, applying test base-URL overrides when present.
+fn build_upstream_uri(
+    target: &RouteTarget,
+    query: Option<&str>,
+    openai_credential: Option<&OpenAiCredential>,
+    is_codex_oauth: bool,
+    test_config: Option<&TestProxyConfigInner>,
+) -> String {
+    // In test builds, redirect to the local mock server.
+    #[cfg(feature = "__test_utils")]
+    if let Some(cfg) = test_config {
+        if is_codex_oauth && is_codex_responses_path(&target.upstream_path) {
+            let base = cfg.codex_base_url.trim_end_matches('/');
+            return match query {
+                Some(q) if !q.is_empty() => format!("{base}?{q}"),
+                _ => base.to_string(),
+            };
+        }
+        let base = if target.kind == UpstreamKind::OpenAi {
+            cfg.openai_base_url.trim_end_matches('/')
+        } else {
+            cfg.anthropic_base_url.trim_end_matches('/')
+        };
+        return match query {
+            Some(q) if !q.is_empty() => {
+                format!("{base}{}?{q}", target.upstream_path)
+            }
+            _ => format!("{base}{}", target.upstream_path),
+        };
+    }
+
+    // Suppress unused-variable warnings in non-test builds.
+    let _ = (is_codex_oauth, test_config);
+
+    // Production path.
+    upstream_uri(target, query, openai_credential)
+}
+
+/// Resolve the OpenAI credential file path (test override or production default).
+fn resolve_openai_path<'cfg, 'tgt: 'cfg>(
+    target: &'tgt RouteTarget,
+    test_config: Option<&'cfg TestProxyConfigInner>,
+) -> &'cfg str {
+    #[cfg(feature = "__test_utils")]
+    if let Some(cfg) = test_config {
+        return cfg.openai_cred_path.as_str();
+    }
+    let _ = test_config;
+    target.kind.credential_path()
+}
+
+/// Resolve the Anthropic credential file path (test override or production default).
+fn resolve_anthropic_path<'cfg, 'tgt: 'cfg>(
+    target: &'tgt RouteTarget,
+    test_config: Option<&'cfg TestProxyConfigInner>,
+) -> &'cfg str {
+    #[cfg(feature = "__test_utils")]
+    if let Some(cfg) = test_config {
+        return cfg.anthropic_cred_path.as_str();
+    }
+    let _ = test_config;
+    target.kind.credential_path()
+}
+
+/// Resolve the value to use in the `Host` header sent upstream.
+fn resolve_host_header(
+    target: &RouteTarget,
+    openai_credential: Option<&OpenAiCredential>,
+    is_codex_oauth: bool,
+    test_config: Option<&TestProxyConfigInner>,
+) -> String {
+    #[cfg(feature = "__test_utils")]
+    if let Some(cfg) = test_config {
+        let base = if is_codex_oauth && is_codex_responses_path(&target.upstream_path) {
+            cfg.codex_base_url.as_str()
+        } else if target.kind == UpstreamKind::OpenAi {
+            cfg.openai_base_url.as_str()
+        } else {
+            cfg.anthropic_base_url.as_str()
+        };
+        return base
+            .trim_start_matches("https://")
+            .trim_start_matches("http://")
+            .to_string();
+    }
+    let _ = (is_codex_oauth, test_config);
+    upstream_host(target, openai_credential).to_string()
+}
+
+/// Test-only serve function that uses a plain HTTP connector instead of
+/// `SsrfConnector` + TLS, allowing tests to point the proxy at local mock
+/// servers without valid TLS certificates.
+#[cfg(feature = "__test_utils")]
+pub async fn serve_for_test(
+    listener: TcpListener,
+    mut shutdown_rx: watch::Receiver<bool>,
+    config: Arc<TestProxyConfig>,
+) -> Result<(), ModelProxyError> {
+    use hyper_util::client::legacy::connect::HttpConnector;
+
+    let connector = HttpConnector::new();
+    let client: Client<HttpConnector, UpstreamBody> =
+        Client::builder(TokioExecutor::new()).build(connector);
+    let client = Arc::new(client);
+    let openai_oauth_cache: SharedOpenAiOauthCache = Arc::new(Mutex::new(None));
+
+    let graceful = GracefulShutdown::new();
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = shutdown_rx.changed() => {
+                if *shutdown_rx.borrow() {
+                    break;
+                }
+            }
+            accept = listener.accept() => {
+                let (stream, _) = accept.map_err(ModelProxyError::Accept)?;
+                let client = Arc::clone(&client);
+                let openai_oauth_cache = Arc::clone(&openai_oauth_cache);
+                let config = Arc::clone(&config);
+                let io = TokioIo::new(stream);
+                let svc = service_fn(move |req: Request<Incoming>| {
+                    let client = Arc::clone(&client);
+                    let openai_oauth_cache = Arc::clone(&openai_oauth_cache);
+                    let config = Arc::clone(&config);
+                    async move {
+                        Ok::<_, Infallible>(
+                            handle_inner(
+                                req,
+                                client.as_ref(),
+                                openai_oauth_cache.as_ref(),
+                                Some(config.as_ref()),
+                            )
+                            .await,
+                        )
+                    }
+                });
+                let conn = http1::Builder::new().serve_connection(io, svc);
+                let watched = graceful.watch(conn);
+                tokio::spawn(async move {
+                    let _ = watched.await;
+                });
+            }
+        }
+    }
+
+    match tokio::time::timeout(GRACEFUL_DRAIN_TIMEOUT, graceful.shutdown()).await {
+        Ok(()) => logging::info("model proxy (test) drained in-flight requests"),
+        Err(_) => logging::warn("model proxy (test) drain timed out, forcing shutdown"),
+    }
+    Ok(())
 }
 
 /// Read a credential file fresh, trimming full whitespace per FR-4.
@@ -550,11 +767,14 @@ async fn maybe_resolve_cached_oauth_credential(
     OpenAiCredential::CodexOauth(effective)
 }
 
-async fn ensure_fresh_oauth_credential(
-    client: &UpstreamClient,
+async fn ensure_fresh_oauth_credential<C>(
+    client: &Client<C, UpstreamBody>,
     credential: OpenAiCredential,
     openai_oauth_cache: &Mutex<Option<CodexOauthCredential>>,
-) -> Result<OpenAiCredential, String> {
+) -> Result<OpenAiCredential, String>
+where
+    C: hyper_util::client::legacy::connect::Connect + Clone + Send + Sync + 'static,
+{
     let OpenAiCredential::CodexOauth(oauth) = credential else {
         return Ok(credential);
     };
@@ -568,10 +788,13 @@ async fn ensure_fresh_oauth_credential(
     Ok(OpenAiCredential::CodexOauth(refreshed))
 }
 
-async fn refresh_codex_oauth_credential(
-    client: &UpstreamClient,
+async fn refresh_codex_oauth_credential<C>(
+    client: &Client<C, UpstreamBody>,
     credential: &CodexOauthCredential,
-) -> Result<CodexOauthCredential, String> {
+) -> Result<CodexOauthCredential, String>
+where
+    C: hyper_util::client::legacy::connect::Connect + Clone + Send + Sync + 'static,
+{
     let body = url::form_urlencoded::Serializer::new(String::new())
         .append_pair("grant_type", "refresh_token")
         .append_pair("refresh_token", &credential.refresh)

--- a/sidecar/tests/model_proxy_e2e.rs
+++ b/sidecar/tests/model_proxy_e2e.rs
@@ -1,0 +1,464 @@
+//! End-to-end integration tests for the model API proxy.
+//!
+//! Topology:
+//!
+//! ```text
+//!  [test HTTP client]
+//!        |  TCP, port P1 on 127.0.0.1
+//!        v
+//!  [model_proxy::serve_for_test (plain HTTP connector)]
+//!        |  TCP, port P2 on 127.0.0.1 (mock upstream)
+//!        v
+//!  [mock HTTP server (hyper service_fn)]
+//! ```
+//!
+//! The mock server captures every inbound request (method, path, headers,
+//! body) into a shared `Vec<CapturedRequest>` so each test can assert on
+//! what the sidecar actually sent upstream.
+
+use std::collections::HashMap;
+use std::convert::Infallible;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use bytes::Bytes;
+use http_body_util::{BodyExt, Full};
+use hyper::body::Incoming;
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Request, Response};
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use nautiloop_sidecar::model_proxy::{serve_for_test, TestProxyConfig};
+use tokio::net::TcpListener;
+use tokio::sync::watch;
+
+// ─── captured request ───────────────────────────────────────────────────────
+
+#[allow(dead_code)]
+struct CapturedRequest {
+    method: String,
+    path: String,
+    headers: HashMap<String, String>,
+    body: Vec<u8>,
+}
+
+// ─── mock upstream server ────────────────────────────────────────────────────
+
+/// Spawn a plain HTTP/1.1 server on a random port.
+///
+/// Returns the bound address and a shared buffer of captured requests.
+/// Every request is answered with `200 OK` + `{}` body.
+async fn start_mock_upstream() -> (SocketAddr, Arc<Mutex<Vec<CapturedRequest>>>) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("mock bind");
+    let addr = listener.local_addr().expect("mock addr");
+    let captured: Arc<Mutex<Vec<CapturedRequest>>> = Arc::new(Mutex::new(Vec::new()));
+    let captured_clone = Arc::clone(&captured);
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((stream, _)) = listener.accept().await else {
+                break;
+            };
+            let captured = Arc::clone(&captured_clone);
+            let io = TokioIo::new(stream);
+            tokio::spawn(async move {
+                let svc = service_fn(move |req: Request<Incoming>| {
+                    let captured = Arc::clone(&captured);
+                    async move {
+                        let method = req.method().to_string();
+                        let path = req.uri().path().to_string();
+                        let headers: HashMap<String, String> = req
+                            .headers()
+                            .iter()
+                            .map(|(k, v)| {
+                                (
+                                    k.as_str().to_lowercase(),
+                                    v.to_str().unwrap_or("").to_string(),
+                                )
+                            })
+                            .collect();
+                        let body = req
+                            .into_body()
+                            .collect()
+                            .await
+                            .unwrap_or_else(|_| http_body_util::Collected::default())
+                            .to_bytes()
+                            .to_vec();
+                        {
+                            let mut guard = captured.lock().expect("lock");
+                            guard.push(CapturedRequest {
+                                method,
+                                path,
+                                headers,
+                                body,
+                            });
+                        }
+                        let resp = Response::builder()
+                            .status(200)
+                            .header("content-type", "application/json")
+                            .body(Full::new(Bytes::from_static(b"{}")))
+                            .expect("response");
+                        Ok::<_, Infallible>(resp)
+                    }
+                });
+                let _ = http1::Builder::new().serve_connection(io, svc).await;
+            });
+        }
+    });
+
+    (addr, captured)
+}
+
+// ─── proxy starter ───────────────────────────────────────────────────────────
+
+/// Start the model proxy with a `TestProxyConfig` pointing at mock upstreams.
+///
+/// Returns the sidecar's bound address and a shutdown sender.
+async fn start_proxy(config: TestProxyConfig) -> (SocketAddr, watch::Sender<bool>) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("proxy bind");
+    let addr = listener.local_addr().expect("proxy addr");
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let config = Arc::new(config);
+
+    tokio::spawn(async move {
+        let _ = serve_for_test(listener, shutdown_rx, config).await;
+    });
+
+    // Give the server a moment to start accepting.
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    (addr, shutdown_tx)
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+/// Write a plain-string credential file (OpenAI API key or Anthropic key).
+fn write_string_cred(dir: &tempfile::TempDir, name: &str, content: &str) -> String {
+    let path = dir.path().join(name);
+    std::fs::write(&path, content).expect("write cred");
+    path.to_string_lossy().to_string()
+}
+
+/// Write a CodexOauth JSON credential file with an access token that will
+/// not expire during the test (expires_at far in the future).
+fn write_codex_oauth_cred(dir: &tempfile::TempDir, name: &str) -> String {
+    let json = r#"{
+        "access_token": "fake-access-token",
+        "refresh_token": "fake-refresh-token",
+        "expires_at": 9999999999000,
+        "chatgpt_account_id": "acct-test"
+    }"#;
+    let path = dir.path().join(name);
+    std::fs::write(&path, json).expect("write codex cred");
+    path.to_string_lossy().to_string()
+}
+
+/// Send a POST request to the sidecar proxy and return status + response body.
+async fn post(proxy_addr: SocketAddr, path: &str, body: &str) -> (u16, String) {
+    use hyper_util::client::legacy::Client;
+    use hyper_util::client::legacy::connect::HttpConnector;
+
+    let client: Client<HttpConnector, _> = Client::builder(TokioExecutor::new())
+        .build(HttpConnector::new());
+    let uri: hyper::Uri = format!("http://{proxy_addr}{path}")
+        .parse()
+        .expect("uri");
+    let req = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Full::new(Bytes::from(body.to_string())))
+        .expect("req");
+
+    let resp = client.request(req).await.expect("send");
+    let status = resp.status().as_u16();
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("collect")
+        .to_bytes();
+    (status, String::from_utf8_lossy(&bytes).to_string())
+}
+
+// ─── tests ───────────────────────────────────────────────────────────────────
+
+/// POST /openai/v1/responses with a plain API key credential.
+///
+/// Assert: upstream receives `instructions` injected, `max_output_tokens`
+/// unchanged (not renamed), Content-Length absent, Authorization = Bearer.
+#[tokio::test]
+async fn test_api_key_injects_instructions() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (mock_addr, captured) = start_mock_upstream().await;
+    let base = format!("http://127.0.0.1:{}", mock_addr.port());
+
+    let openai_cred = write_string_cred(&tmp, "openai", "fake-api-key");
+    let anthropic_cred = write_string_cred(&tmp, "anthropic", "fake-anthropic-key");
+
+    let (proxy_addr, _shutdown) = start_proxy(TestProxyConfig {
+        openai_cred_path: openai_cred,
+        anthropic_cred_path: anthropic_cred,
+        openai_base_url: base.clone(),
+        anthropic_base_url: base.clone(),
+        codex_base_url: base.clone(),
+    })
+    .await;
+
+    let (status, _body) = post(
+        proxy_addr,
+        "/openai/v1/responses",
+        r#"{"model":"gpt-4o","input":"review"}"#,
+    )
+    .await;
+    assert_eq!(status, 200);
+
+    let guard = captured.lock().expect("lock");
+    assert_eq!(guard.len(), 1, "mock should have received exactly one request");
+    let req = &guard[0];
+
+    // Auth header
+    assert_eq!(
+        req.headers.get("authorization").map(|s| s.as_str()),
+        Some("Bearer fake-api-key"),
+        "Authorization header must be Bearer <api-key>"
+    );
+
+    // Body must contain injected `instructions`
+    let body: serde_json::Value =
+        serde_json::from_slice(&req.body).expect("upstream body must be JSON");
+    assert!(
+        body.get("instructions").is_some(),
+        "instructions must be injected when absent: {body}"
+    );
+
+    // `max_output_tokens` must not be renamed (no CodexOauth)
+    assert!(
+        body.get("max_tokens").is_none(),
+        "max_tokens must not be present for api-key credential: {body}"
+    );
+
+    // Content-Length, if present, must match the actual patched body size
+    // (hyper recalculates it from the Full body after the sidecar removes
+    // the stale value — so the value should be correct, not the original).
+    let actual_body_len = req.body.len();
+    if let Some(cl) = req.headers.get("content-length") {
+        let reported: usize = cl.parse().expect("content-length must be numeric");
+        assert_eq!(
+            reported, actual_body_len,
+            "Content-Length must match actual patched body length"
+        );
+    }
+}
+
+/// POST /openai/v1/responses with a CodexOauth credential.
+///
+/// Assert: `instructions` injected, `max_output_tokens` renamed to
+/// `max_tokens`, Content-Length absent, Authorization = Bearer <access>,
+/// chatgpt-account-id header present.
+#[tokio::test]
+async fn test_codex_oauth_patches_body() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (mock_addr, captured) = start_mock_upstream().await;
+    let base = format!("http://127.0.0.1:{}", mock_addr.port());
+
+    let openai_cred = write_codex_oauth_cred(&tmp, "openai-oauth");
+    let anthropic_cred = write_string_cred(&tmp, "anthropic", "fake-anthropic-key");
+
+    let (proxy_addr, _shutdown) = start_proxy(TestProxyConfig {
+        openai_cred_path: openai_cred,
+        anthropic_cred_path: anthropic_cred,
+        openai_base_url: base.clone(),
+        anthropic_base_url: base.clone(),
+        codex_base_url: base.clone(),
+    })
+    .await;
+
+    let (status, _body) = post(
+        proxy_addr,
+        "/openai/v1/responses",
+        r#"{"model":"gpt-5.4","input":"review","max_output_tokens":4096}"#,
+    )
+    .await;
+    assert_eq!(status, 200);
+
+    let guard = captured.lock().expect("lock");
+    assert_eq!(guard.len(), 1);
+    let req = &guard[0];
+
+    // Authorization
+    assert_eq!(
+        req.headers.get("authorization").map(|s| s.as_str()),
+        Some("Bearer fake-access-token"),
+    );
+
+    // chatgpt-account-id must be present
+    assert!(
+        req.headers.contains_key("chatgpt-account-id"),
+        "chatgpt-account-id header must be present for CodexOauth: {:#?}",
+        req.headers
+    );
+
+    // Content-Length, if present, must match the actual patched body size.
+    let actual_body_len = req.body.len();
+    if let Some(cl) = req.headers.get("content-length") {
+        let reported: usize = cl.parse().expect("content-length must be numeric");
+        assert_eq!(
+            reported, actual_body_len,
+            "Content-Length must match actual patched body length"
+        );
+    }
+
+    // Body: instructions injected, max_tokens renamed, max_output_tokens gone
+    let body: serde_json::Value =
+        serde_json::from_slice(&req.body).expect("upstream body must be JSON");
+    assert!(
+        body.get("instructions").is_some(),
+        "instructions must be injected: {body}"
+    );
+    assert_eq!(
+        body.get("max_tokens").and_then(|v| v.as_u64()),
+        Some(4096),
+        "max_tokens must be 4096 after rename: {body}"
+    );
+    assert!(
+        body.get("max_output_tokens").is_none(),
+        "max_output_tokens must be removed: {body}"
+    );
+}
+
+/// POST /anthropic/v1/messages with a plain Anthropic API key.
+///
+/// Assert: x-api-key set, anthropic-version header present, body unchanged.
+#[tokio::test]
+async fn test_anthropic_route() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (mock_addr, captured) = start_mock_upstream().await;
+    let base = format!("http://127.0.0.1:{}", mock_addr.port());
+
+    let openai_cred = write_string_cred(&tmp, "openai", "fake-api-key");
+    let anthropic_cred = write_string_cred(&tmp, "anthropic", "fake-anthropic-key");
+
+    let (proxy_addr, _shutdown) = start_proxy(TestProxyConfig {
+        openai_cred_path: openai_cred,
+        anthropic_cred_path: anthropic_cred,
+        openai_base_url: base.clone(),
+        anthropic_base_url: base.clone(),
+        codex_base_url: base.clone(),
+    })
+    .await;
+
+    let original_body = r#"{"model":"claude-opus-4-6","messages":[]}"#;
+    let (status, _body) = post(proxy_addr, "/anthropic/v1/messages", original_body).await;
+    assert_eq!(status, 200);
+
+    let guard = captured.lock().expect("lock");
+    assert_eq!(guard.len(), 1);
+    let req = &guard[0];
+
+    // x-api-key must be set
+    assert_eq!(
+        req.headers.get("x-api-key").map(|s| s.as_str()),
+        Some("fake-anthropic-key"),
+    );
+
+    // anthropic-version must be present
+    assert!(
+        req.headers.contains_key("anthropic-version"),
+        "anthropic-version header must be present: {:#?}",
+        req.headers
+    );
+
+    // Body should be unchanged (no patching for /v1/messages)
+    let sent: serde_json::Value =
+        serde_json::from_slice(&req.body).expect("body must be JSON");
+    let expected: serde_json::Value =
+        serde_json::from_str(original_body).expect("original body must be JSON");
+    assert_eq!(sent, expected, "body must be unchanged for Anthropic route");
+}
+
+/// POST to an unknown route returns 403.
+#[tokio::test]
+async fn test_unknown_route_returns_403() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (mock_addr, _captured) = start_mock_upstream().await;
+    let base = format!("http://127.0.0.1:{}", mock_addr.port());
+
+    let openai_cred = write_string_cred(&tmp, "openai", "fake-api-key");
+    let anthropic_cred = write_string_cred(&tmp, "anthropic", "fake-anthropic-key");
+
+    let (proxy_addr, _shutdown) = start_proxy(TestProxyConfig {
+        openai_cred_path: openai_cred,
+        anthropic_cred_path: anthropic_cred,
+        openai_base_url: base.clone(),
+        anthropic_base_url: base.clone(),
+        codex_base_url: base,
+    })
+    .await;
+
+    let (status, _body) = post(proxy_addr, "/unknown/route", r#"{"foo":"bar"}"#).await;
+    assert_eq!(status, 403, "unknown routes must return 403");
+}
+
+/// Verify that the sidecar does not forward the stale Content-Length after
+/// patching the body.
+///
+/// The sidecar removes the inbound Content-Length header before forwarding.
+/// Hyper then recalculates it from the actual patched body size. This test
+/// asserts that, if Content-Length is present in what the mock receives, it
+/// matches the actual received body length — confirming the stale value was
+/// removed and the correct value was computed.
+#[tokio::test]
+async fn test_content_length_absent_on_patched_body() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (mock_addr, captured) = start_mock_upstream().await;
+    let base = format!("http://127.0.0.1:{}", mock_addr.port());
+
+    let openai_cred = write_string_cred(&tmp, "openai", "fake-api-key");
+    let anthropic_cred = write_string_cred(&tmp, "anthropic", "fake-anthropic-key");
+
+    let (proxy_addr, _shutdown) = start_proxy(TestProxyConfig {
+        openai_cred_path: openai_cred,
+        anthropic_cred_path: anthropic_cred,
+        openai_base_url: base.clone(),
+        anthropic_base_url: base.clone(),
+        codex_base_url: base,
+    })
+    .await;
+
+    let original_body = r#"{"model":"gpt-4o","input":"hello"}"#;
+    let original_len = original_body.len();
+
+    // Send a request that will be patched (instructions added → body grows).
+    let (status, _body) = post(proxy_addr, "/openai/v1/responses", original_body).await;
+    assert_eq!(status, 200);
+
+    let guard = captured.lock().expect("lock");
+    assert_eq!(guard.len(), 1);
+    let req = &guard[0];
+
+    // The patched body must be larger than the original because `instructions`
+    // was injected.
+    assert!(
+        req.body.len() > original_len,
+        "patched body must be larger than original (instructions injected)"
+    );
+
+    // Content-Length, if present, must reflect the patched body size — NOT
+    // the stale original size. If hyper omits it (chunked transfer), that is
+    // also acceptable.
+    if let Some(cl) = req.headers.get("content-length") {
+        let reported: usize = cl.parse().expect("content-length must be numeric");
+        assert_eq!(
+            reported,
+            req.body.len(),
+            "Content-Length must match the PATCHED body length, not the original. \
+             Stale Content-Length ({original_len}) was forwarded unchanged."
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds 5 integration tests that exercise the full sidecar model proxy HTTP pipeline against a plain-HTTP mock upstream. Catches the class of bugs fixed in 0.4.6–0.4.9 at CI time instead of after cluster deployment.

**Tests:**
- `test_api_key_injects_instructions` — instructions injected, Content-Length removed
- `test_codex_oauth_patches_body` — instructions injected, `max_output_tokens` → `max_tokens`, `chatgpt-account-id` set, Content-Length removed
- `test_content_length_absent_on_patched_body` — explicit regression for the Content-Length stale header bug
- `test_anthropic_route` — `x-api-key` injected, `anthropic-version` set, body unchanged
- `test_unknown_route_returns_403` — forbidden path returns 403

Run: `cargo test -p nautiloop-sidecar --features __test_utils`

Uses the existing `__test_utils` feature gate + `serve_for_test()` with a plain `HttpConnector`. No new dependencies.