### PR TITLE
feat(dev): local k3d development environment

### DIFF
--- a/control-plane/src/config/mod.rs
+++ b/control-plane/src/config/mod.rs
@@ -341,6 +341,11 @@ pub struct ClusterConfig {
     /// Default branch name for the target repo (e.g., "main", "master", "trunk").
     #[serde(default = "default_branch_name")]
     pub default_branch: String,
+    /// Skip the init-iptables container. Set to true for local dev (k3d)
+    /// where NET_ADMIN privileged init containers may not behave identically
+    /// to production. Egress enforcement is best-effort in dev.
+    #[serde(default)]
+    pub skip_iptables: bool,
 }
 
 impl Default for ClusterConfig {
@@ -361,6 +366,7 @@ impl Default for ClusterConfig {
             max_connections: default_max_connections(),
             reconcile_interval_secs: default_reconcile_interval(),
             default_branch: default_branch_name(),
+            skip_iptables: false,
         }
     }
 }

--- a/control-plane/src/k8s/job_builder.rs
+++ b/control-plane/src/k8s/job_builder.rs
@@ -24,6 +24,8 @@ pub struct JobBuildConfig {
     pub git_repo_url: String,
     /// ConfigMap name containing SSH known_hosts for sidecar host key verification.
     pub ssh_known_hosts_configmap: String,
+    /// Skip the init-iptables container (for local dev with k3d).
+    pub skip_iptables: bool,
 }
 
 /// Build a K8s Job spec for a given stage.
@@ -207,8 +209,14 @@ pub fn build_job(ctx: &LoopContext, stage: &StageConfig, cfg: &JobBuildConfig) -
         ..Default::default()
     };
 
-    // FR-41a: Init container for iptables network enforcement (runs and exits)
-    let init_container = build_init_iptables_container();
+    // FR-41a: Init container for iptables network enforcement (runs and exits).
+    // Skipped in local dev (k3d) where NET_ADMIN privileged init containers
+    // may not behave identically to production.
+    let maybe_init_container = if cfg.skip_iptables {
+        None
+    } else {
+        Some(build_init_iptables_container())
+    };
 
     let timeout_secs = stage.timeout.as_secs();
     let active_deadline = if timeout_secs > 0 {
@@ -248,7 +256,12 @@ pub fn build_job(ctx: &LoopContext, stage: &StageConfig, cfg: &JobBuildConfig) -
                     // (native sidecar via restartPolicy: Always) then
                     // stays up for the lifetime of the agent and is
                     // auto-terminated when the agent exits.
-                    init_containers: Some(vec![init_container, sidecar_container]),
+                    init_containers: Some(
+                        maybe_init_container
+                            .into_iter()
+                            .chain(std::iter::once(sidecar_container))
+                            .collect(),
+                    ),
                     containers: vec![agent_container],
                     volumes: Some(volumes),
                     image_pull_secrets,
@@ -700,6 +713,7 @@ mod tests {
             image_pull_secret: None,
             git_repo_url: "git@github.com:test-org/test-repo.git".to_string(),
             ssh_known_hosts_configmap: "nautiloop-ssh-known-hosts".to_string(),
+            skip_iptables: false,
         }
     }
 

--- a/control-plane/src/loop_engine/driver.rs
+++ b/control-plane/src/loop_engine/driver.rs
@@ -49,6 +49,7 @@ impl ConvergentLoopDriver {
             image_pull_secret: self.config.cluster.image_pull_secret.clone(),
             git_repo_url: self.config.cluster.git_repo_url.clone(),
             ssh_known_hosts_configmap: self.config.cluster.ssh_known_hosts_configmap.clone(),
+            skip_iptables: self.config.cluster.skip_iptables,
         }
     }
 

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,56 @@
+# Nautiloop Local Dev Environment
+
+Run a full nautiloop cluster on your machine using k3d. No Terraform, no Hetzner.
+
+## Prerequisites
+
+- [k3d](https://k3d.io/) >= 5.0
+- [kubectl](https://kubernetes.io/docs/tasks/tools/)
+- [Docker](https://docs.docker.com/get-docker/)
+- [cargo](https://www.rust-lang.org/tools/install) (for building the control plane)
+- `nemo` CLI on your PATH (`cargo install --path cli` from the repo root)
+
+## Quick Start
+
+```bash
+# 1. Set required env vars (see setup.sh for the full list)
+export NAUTILOOP_GIT_REPO_URL="git@github.com:your-org/your-repo.git"
+export NAUTILOOP_GITHUB_TOKEN="ghp_..."
+export NAUTILOOP_ANTHROPIC_KEY="sk-ant-..."
+
+# 2. Bring up the cluster
+./dev/setup.sh
+
+# 3. Run a smoke test job
+./dev/smoke-test.sh
+```
+
+## What the Smoke Test Does
+
+Submits a minimal harden job using `dev/test-spec.md`, then streams logs until the
+loop reaches HARDENED or FAILED. The test spec asks the agent to add a trivial
+`hello_world()` function — it exists to exercise the full pipeline (dispatch,
+sidecar, agent, review) without modifying anything meaningful.
+
+## Resetting
+
+```bash
+./dev/teardown.sh   # Destroys the k3d cluster and registry
+./dev/setup.sh      # Recreates from scratch
+```
+
+Postgres data and the bare repo live on ephemeral k3d node storage, so teardown
+wipes everything.
+
+## Rebuilding Images
+
+```bash
+./dev/build.sh                          # All images
+./dev/build.sh --control-plane         # Only the control plane
+./dev/build.sh --sidecar               # Only the sidecar
+./dev/build.sh --agent-base            # Only the agent base
+
+# Then redeploy:
+kubectl rollout restart deployment/nautiloop-api-server deployment/nautiloop-loop-engine \
+  -n nautiloop-system
+```

--- a/dev/build.sh
+++ b/dev/build.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REGISTRY="localhost:5001"
+CONTEXT="$(cd "$(dirname "$0")/.." && pwd)"
+
+BUILD_CONTROL_PLANE=false
+BUILD_SIDECAR=false
+BUILD_AGENT_BASE=false
+
+# Parse flags
+if [ $# -eq 0 ]; then
+    BUILD_CONTROL_PLANE=true
+    BUILD_SIDECAR=true
+    BUILD_AGENT_BASE=true
+fi
+
+for arg in "$@"; do
+    case "$arg" in
+        --control-plane) BUILD_CONTROL_PLANE=true ;;
+        --sidecar)       BUILD_SIDECAR=true ;;
+        --agent-base)    BUILD_AGENT_BASE=true ;;
+        *) echo "Unknown flag: $arg (valid: --control-plane, --sidecar, --agent-base)" >&2; exit 1 ;;
+    esac
+done
+
+if "$BUILD_CONTROL_PLANE"; then
+    echo "==> Building control-plane image..."
+    docker build \
+        -f "${CONTEXT}/images/control-plane/Dockerfile" \
+        -t "${REGISTRY}/nautiloop-control-plane:dev" \
+        "${CONTEXT}"
+    docker push "${REGISTRY}/nautiloop-control-plane:dev"
+    echo "    Pushed ${REGISTRY}/nautiloop-control-plane:dev"
+fi
+
+if "$BUILD_SIDECAR"; then
+    echo "==> Building sidecar image..."
+    docker build \
+        -f "${CONTEXT}/sidecar/Dockerfile" \
+        -t "${REGISTRY}/nautiloop-sidecar:dev" \
+        "${CONTEXT}"
+    docker push "${REGISTRY}/nautiloop-sidecar:dev"
+    echo "    Pushed ${REGISTRY}/nautiloop-sidecar:dev"
+fi
+
+if "$BUILD_AGENT_BASE"; then
+    echo "==> Building agent-base image..."
+    docker build \
+        -f "${CONTEXT}/images/base/Dockerfile" \
+        -t "${REGISTRY}/nautiloop-agent-base:dev" \
+        "${CONTEXT}"
+    docker push "${REGISTRY}/nautiloop-agent-base:dev"
+    echo "    Pushed ${REGISTRY}/nautiloop-agent-base:dev"
+fi
+
+echo "==> Build complete."

--- a/dev/k8s/00-namespaces.yaml
+++ b/dev/k8s/00-namespaces.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nautiloop-system
+  labels:
+    app: nautiloop
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nautiloop-jobs
+  labels:
+    app: nautiloop

--- a/dev/k8s/01-storage.yaml
+++ b/dev/k8s/01-storage.yaml
@@ -1,0 +1,81 @@
+# Postgres data: RWO, local-path (k3d default)
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nautiloop-postgres-data
+  namespace: nautiloop-system
+spec:
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 5Gi
+---
+# Bare repo: shared between nautiloop-system and nautiloop-jobs via hostPath PVs.
+# k3d is single-node so both PVs can point at the same host directory.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: nautiloop-bare-repo-system
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes: ["ReadWriteOnce"]
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: manual
+  hostPath:
+    path: /tmp/nautiloop-dev/bare-repo
+    type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nautiloop-bare-repo
+  namespace: nautiloop-system
+spec:
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: manual
+  volumeName: nautiloop-bare-repo-system
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: nautiloop-bare-repo-jobs
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes: ["ReadWriteOnce"]
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: manual
+  hostPath:
+    path: /tmp/nautiloop-dev/bare-repo
+    type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nautiloop-bare-repo
+  namespace: nautiloop-jobs
+spec:
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: manual
+  volumeName: nautiloop-bare-repo-jobs
+  resources:
+    requests:
+      storage: 10Gi
+---
+# Sessions: RWO in nautiloop-jobs
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nautiloop-sessions
+  namespace: nautiloop-jobs
+spec:
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 2Gi

--- a/dev/k8s/02-rbac.yaml
+++ b/dev/k8s/02-rbac.yaml
@@ -1,0 +1,74 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nautiloop-loop-engine
+  namespace: nautiloop-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nautiloop-api-server
+  namespace: nautiloop-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: nautiloop-loop-engine
+  namespace: nautiloop-jobs
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create", "delete", "list", "watch", "get"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list", "get"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "update", "get"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create", "update", "get"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: nautiloop-loop-engine
+  namespace: nautiloop-jobs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nautiloop-loop-engine
+subjects:
+  - kind: ServiceAccount
+    name: nautiloop-loop-engine
+    namespace: nautiloop-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: nautiloop-api-server
+  namespace: nautiloop-jobs
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "update", "get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: nautiloop-api-server
+  namespace: nautiloop-jobs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nautiloop-api-server
+subjects:
+  - kind: ServiceAccount
+    name: nautiloop-api-server
+    namespace: nautiloop-system

--- a/dev/k8s/03-postgres.yaml
+++ b/dev/k8s/03-postgres.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nautiloop-postgres
+  namespace: nautiloop-system
+  labels:
+    app: nautiloop-postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nautiloop-postgres
+  template:
+    metadata:
+      labels:
+        app: nautiloop-postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_DB
+              value: nautiloop
+            - name: POSTGRES_USER
+              value: nautiloop
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: nautiloop-postgres-credentials
+                  key: password
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "nautiloop"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+      volumes:
+        - name: postgres-data
+          persistentVolumeClaim:
+            claimName: nautiloop-postgres-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nautiloop-postgres
+  namespace: nautiloop-system
+spec:
+  selector:
+    app: nautiloop-postgres
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/dev/k8s/04-config.yaml
+++ b/dev/k8s/04-config.yaml
@@ -1,0 +1,43 @@
+# nautiloop-config is created/updated by setup.sh with the correct database URL,
+# git_repo_url, and image references. This placeholder ensures the ConfigMap
+# exists so the control plane manifests can reference it before setup.sh runs.
+# setup.sh will overwrite this with the real values.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nautiloop-config
+  namespace: nautiloop-system
+data:
+  nemo.toml: |
+    [cluster]
+    git_repo_url = ""
+    agent_image = "k3d-nautiloop-registry:5001/nautiloop-agent-base:dev"
+    sidecar_image = "k3d-nautiloop-registry:5001/nautiloop-sidecar:dev"
+    skip_iptables = true
+---
+# SSH known_hosts ConfigMaps — populated by setup.sh via ssh-keyscan.
+# These placeholder entries exist so the control plane can start without waiting
+# for setup.sh to complete the keyscan. They are overwritten by setup.sh.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nautiloop-ssh-known-hosts
+  namespace: nautiloop-system
+data:
+  known_hosts: |
+    # Populated by dev/setup.sh via ssh-keyscan
+    github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
+    github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
+    github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SLeEgdzV3tMF/GRpVLvkfv96yRMXgGKfat2M8ZEBcO/k0MCO42kABSQz7S6crVmXJMriMilFMr2bN5LjOP/2cSBHvU9n/uR5oFGO2Bt7j9sEusFnbNDEwDNbqfkXxFWcvbXpoxC5exWJMKtdoJC+gVK7YNv3qGpMv7TWPJ8m0Aq/wGH3MTVF5J/Cq1EE=
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nautiloop-ssh-known-hosts
+  namespace: nautiloop-jobs
+data:
+  known_hosts: |
+    # Populated by dev/setup.sh via ssh-keyscan
+    github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
+    github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
+    github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SLeEgdzV3tMF/GRpVLvkfv96yRMXgGKfat2M8ZEBcO/k0MCO42kABSQz7S6crVmXJMriMilFMr2bN5LjOP/2cSBHvU9n/uR5oFGO2Bt7j9sEusFnbNDEwDNbqfkXxFWcvbXpoxC5exWJMKtdoJC+gVK7YNv3qGpMv7TWPJ8m0Aq/wGH3MTVF5J/Cq1EE=

--- a/dev/k8s/05-control-plane.yaml
+++ b/dev/k8s/05-control-plane.yaml
@@ -1,0 +1,182 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nautiloop-api-server
+  namespace: nautiloop-system
+  labels:
+    app: nautiloop-api-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nautiloop-api-server
+  template:
+    metadata:
+      labels:
+        app: nautiloop-api-server
+    spec:
+      serviceAccountName: nautiloop-api-server
+      securityContext:
+        fsGroup: 1000
+      containers:
+        - name: api-server
+          image: k3d-nautiloop-registry:5001/nautiloop-control-plane:dev
+          args: ["api-server"]
+          ports:
+            - containerPort: 8080
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: nautiloop-postgres-credentials
+                  key: DATABASE_URL
+            - name: NAUTILOOP_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: nautiloop-api-key
+                  key: NAUTILOOP_API_KEY
+            - name: GIT_HOST_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: nautiloop-git-host-token
+                  key: GIT_HOST_TOKEN
+            - name: BARE_REPO_PATH
+              value: /bare-repo
+            - name: GIT_SSH_COMMAND
+              value: "ssh -i /etc/git-ssh/id_ed25519 -o UserKnownHostsFile=/etc/git-ssh-known-hosts/known_hosts -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes"
+            - name: NAUTILOOP_CONFIG_PATH
+              value: /etc/nautiloop/nemo.toml
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          volumeMounts:
+            - name: bare-repo
+              mountPath: /bare-repo
+            - name: nautiloop-config
+              mountPath: /etc/nautiloop
+              readOnly: true
+            - name: git-ssh-key
+              mountPath: /etc/git-ssh
+              readOnly: true
+            - name: git-ssh-known-hosts
+              mountPath: /etc/git-ssh-known-hosts
+              readOnly: true
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            failureThreshold: 30
+            periodSeconds: 2
+            timeoutSeconds: 3
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            periodSeconds: 15
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            periodSeconds: 10
+            timeoutSeconds: 3
+      volumes:
+        - name: bare-repo
+          persistentVolumeClaim:
+            claimName: nautiloop-bare-repo
+        - name: nautiloop-config
+          configMap:
+            name: nautiloop-config
+        - name: git-ssh-key
+          secret:
+            secretName: nautiloop-repo-ssh-key
+            defaultMode: 0400
+        - name: git-ssh-known-hosts
+          configMap:
+            name: nautiloop-ssh-known-hosts
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nautiloop-loop-engine
+  namespace: nautiloop-system
+  labels:
+    app: nautiloop-loop-engine
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nautiloop-loop-engine
+  template:
+    metadata:
+      labels:
+        app: nautiloop-loop-engine
+    spec:
+      serviceAccountName: nautiloop-loop-engine
+      securityContext:
+        fsGroup: 1000
+      containers:
+        - name: loop-engine
+          image: k3d-nautiloop-registry:5001/nautiloop-control-plane:dev
+          args: ["loop-engine"]
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: nautiloop-postgres-credentials
+                  key: DATABASE_URL
+            - name: GIT_HOST_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: nautiloop-git-host-token
+                  key: GIT_HOST_TOKEN
+            - name: BARE_REPO_PATH
+              value: /bare-repo
+            - name: AGENT_IMAGE
+              value: k3d-nautiloop-registry:5001/nautiloop-agent-base:dev
+            - name: GIT_SSH_COMMAND
+              value: "ssh -i /etc/git-ssh/id_ed25519 -o UserKnownHostsFile=/etc/git-ssh-known-hosts/known_hosts -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes"
+            - name: NAUTILOOP_CONFIG_PATH
+              value: /etc/nautiloop/nemo.toml
+          volumeMounts:
+            - name: bare-repo
+              mountPath: /bare-repo
+            - name: nautiloop-config
+              mountPath: /etc/nautiloop
+              readOnly: true
+            - name: git-ssh-key
+              mountPath: /etc/git-ssh
+              readOnly: true
+            - name: git-ssh-known-hosts
+              mountPath: /etc/git-ssh-known-hosts
+              readOnly: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          livenessProbe:
+            exec:
+              command: ["kill", "-0", "1"]
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 3
+      volumes:
+        - name: bare-repo
+          persistentVolumeClaim:
+            claimName: nautiloop-bare-repo
+        - name: nautiloop-config
+          configMap:
+            name: nautiloop-config
+        - name: git-ssh-key
+          secret:
+            secretName: nautiloop-repo-ssh-key
+            defaultMode: 0400
+        - name: git-ssh-known-hosts
+          configMap:
+            name: nautiloop-ssh-known-hosts

--- a/dev/k8s/06-service.yaml
+++ b/dev/k8s/06-service.yaml
@@ -1,0 +1,30 @@
+# ClusterIP service for internal traffic between components
+apiVersion: v1
+kind: Service
+metadata:
+  name: nautiloop-api-server
+  namespace: nautiloop-system
+spec:
+  selector:
+    app: nautiloop-api-server
+  ports:
+    - port: 8080
+      targetPort: 8080
+---
+# LoadBalancer service to expose the API server on the host.
+# k3d maps host port 18080 to the load balancer on port 80,
+# so the nemo CLI can reach the server at http://localhost:18080.
+# k3d routes LoadBalancer port 80 to this service's port 80.
+apiVersion: v1
+kind: Service
+metadata:
+  name: nautiloop-api-server-lb
+  namespace: nautiloop-system
+spec:
+  type: LoadBalancer
+  selector:
+    app: nautiloop-api-server
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080

--- a/dev/setup.sh
+++ b/dev/setup.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# ── Prerequisites ──────────────────────────────────────────────────────────────
+
+check_tool() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "WARN: '$1' not found on PATH. ${2:-Install it before continuing.}"
+    fi
+}
+
+check_tool k3d    "See https://k3d.io/"
+check_tool kubectl "See https://kubernetes.io/docs/tasks/tools/"
+check_tool docker  "See https://docs.docker.com/get-docker/"
+check_tool cargo   "See https://www.rust-lang.org/tools/install"
+check_tool nemo    "Run: cargo install --path ${REPO_ROOT}/cli"
+
+# ── Required env vars ─────────────────────────────────────────────────────────
+
+NAUTILOOP_GIT_REPO_URL="${NAUTILOOP_GIT_REPO_URL:-}"
+NAUTILOOP_GITHUB_TOKEN="${NAUTILOOP_GITHUB_TOKEN:-}"
+NAUTILOOP_ENGINEER="${NAUTILOOP_ENGINEER:-dev}"
+NAUTILOOP_SSH_PRIVATE_KEY_PATH="${NAUTILOOP_SSH_PRIVATE_KEY_PATH:-${HOME}/.ssh/id_ed25519}"
+NAUTILOOP_OPENAI_KEY="${NAUTILOOP_OPENAI_KEY:-}"
+NAUTILOOP_ANTHROPIC_KEY="${NAUTILOOP_ANTHROPIC_KEY:-}"
+
+MISSING=false
+if [ -z "$NAUTILOOP_GIT_REPO_URL" ]; then
+    echo "ERROR: NAUTILOOP_GIT_REPO_URL is not set (e.g. git@github.com:org/repo.git)"
+    MISSING=true
+fi
+if [ -z "$NAUTILOOP_GITHUB_TOKEN" ]; then
+    echo "ERROR: NAUTILOOP_GITHUB_TOKEN is not set (GitHub PAT for PR operations)"
+    MISSING=true
+fi
+if [ ! -f "$NAUTILOOP_SSH_PRIVATE_KEY_PATH" ]; then
+    echo "ERROR: SSH private key not found at ${NAUTILOOP_SSH_PRIVATE_KEY_PATH}"
+    echo "       Set NAUTILOOP_SSH_PRIVATE_KEY_PATH to the path of your SSH key."
+    MISSING=true
+fi
+if "$MISSING"; then
+    exit 1
+fi
+
+if [ -z "$NAUTILOOP_OPENAI_KEY" ] && [ -z "$NAUTILOOP_ANTHROPIC_KEY" ]; then
+    echo "WARN: Neither NAUTILOOP_OPENAI_KEY nor NAUTILOOP_ANTHROPIC_KEY is set."
+    echo "      Agent jobs will fail at model calls. Set at least one."
+fi
+
+# ── k3d registry ──────────────────────────────────────────────────────────────
+
+if k3d registry list 2>/dev/null | grep -q "nautiloop-registry"; then
+    echo "==> Registry k3d-nautiloop-registry already exists, skipping."
+else
+    echo "==> Creating k3d registry nautiloop-registry on port 5001..."
+    k3d registry create nautiloop-registry --port 5001
+fi
+
+# ── k3d cluster ───────────────────────────────────────────────────────────────
+
+if k3d cluster list 2>/dev/null | grep -q "nautiloop-dev"; then
+    echo "==> Cluster nautiloop-dev already exists, skipping creation."
+else
+    echo "==> Creating k3d cluster nautiloop-dev..."
+    k3d cluster create nautiloop-dev \
+        --registry-use k3d-nautiloop-registry:5001 \
+        --k3s-arg "--disable=traefik@server:0" \
+        --agents 0 \
+        -p "18080:80@loadbalancer"
+fi
+
+# Make sure kubectl context is set to the dev cluster
+kubectl config use-context k3d-nautiloop-dev
+
+# ── Build and push images ─────────────────────────────────────────────────────
+
+echo "==> Building and pushing images..."
+"${SCRIPT_DIR}/build.sh"
+
+# ── Apply manifests ───────────────────────────────────────────────────────────
+
+echo "==> Applying Kubernetes manifests..."
+kubectl apply -f "${SCRIPT_DIR}/k8s/"
+
+# ── Secrets ───────────────────────────────────────────────────────────────────
+
+echo "==> Creating secrets..."
+
+# Postgres credentials — read existing secret if present (idempotent on re-runs).
+EXISTING_PG_PASSWORD="$(kubectl -n nautiloop-system get secret nautiloop-postgres-credentials \
+    -o jsonpath='{.data.password}' 2>/dev/null | base64 -d 2>/dev/null || true)"
+if [ -n "$EXISTING_PG_PASSWORD" ]; then
+    POSTGRES_PASSWORD="$EXISTING_PG_PASSWORD"
+    echo "    Using existing Postgres password from secret."
+else
+    POSTGRES_PASSWORD="nautiloop-dev-$(openssl rand -hex 8)"
+fi
+kubectl -n nautiloop-system create secret generic nautiloop-postgres-credentials \
+    --from-literal=password="${POSTGRES_PASSWORD}" \
+    --from-literal=DATABASE_URL="postgres://nautiloop:${POSTGRES_PASSWORD}@nautiloop-postgres:5432/nautiloop" \
+    --dry-run=client -o yaml | kubectl apply -f -
+
+# API key — read existing secret if present (idempotent on re-runs).
+EXISTING_API_KEY="$(kubectl -n nautiloop-system get secret nautiloop-api-key \
+    -o jsonpath='{.data.NAUTILOOP_API_KEY}' 2>/dev/null | base64 -d 2>/dev/null || true)"
+if [ -n "$EXISTING_API_KEY" ]; then
+    NAUTILOOP_API_KEY="$EXISTING_API_KEY"
+    echo "    Using existing API key from secret."
+else
+    NAUTILOOP_API_KEY="dev-api-key-$(openssl rand -hex 8)"
+fi
+kubectl -n nautiloop-system create secret generic nautiloop-api-key \
+    --from-literal=NAUTILOOP_API_KEY="${NAUTILOOP_API_KEY}" \
+    --dry-run=client -o yaml | kubectl apply -f -
+
+# Git host token
+kubectl -n nautiloop-system create secret generic nautiloop-git-host-token \
+    --from-literal=GIT_HOST_TOKEN="${NAUTILOOP_GITHUB_TOKEN}" \
+    --dry-run=client -o yaml | kubectl apply -f -
+
+# SSH key for repo access
+kubectl -n nautiloop-system create secret generic nautiloop-repo-ssh-key \
+    --from-file=id_ed25519="${NAUTILOOP_SSH_PRIVATE_KEY_PATH}" \
+    --dry-run=client -o yaml | kubectl apply -f -
+
+# Engineer credentials secret (for agent jobs)
+SAFE_ENGINEER="$(echo "${NAUTILOOP_ENGINEER}" | tr '[:upper:]' '[:lower:]' | tr '_' '-')"
+
+SSH_KEY_B64="$(base64 < "${NAUTILOOP_SSH_PRIVATE_KEY_PATH}")"
+CREDS_ARGS=(
+    "--from-literal=ssh=${SSH_KEY_B64}"
+)
+if [ -n "$NAUTILOOP_ANTHROPIC_KEY" ]; then
+    CREDS_ARGS+=("--from-literal=anthropic=${NAUTILOOP_ANTHROPIC_KEY}")
+fi
+if [ -n "$NAUTILOOP_OPENAI_KEY" ]; then
+    CREDS_ARGS+=("--from-literal=openai=${NAUTILOOP_OPENAI_KEY}")
+fi
+kubectl -n nautiloop-jobs create secret generic "nautiloop-creds-${SAFE_ENGINEER}" \
+    "${CREDS_ARGS[@]}" \
+    --dry-run=client -o yaml | kubectl apply -f -
+
+# ── Wait for Postgres ─────────────────────────────────────────────────────────
+
+echo "==> Waiting for Postgres to be ready..."
+kubectl rollout status deployment/nautiloop-postgres -n nautiloop-system --timeout=120s
+
+# ── Update ConfigMap with Postgres password ───────────────────────────────────
+
+echo "==> Updating nemo.toml ConfigMap..."
+kubectl -n nautiloop-system create configmap nautiloop-config \
+    --from-literal=nemo.toml="$(cat <<TOML
+[cluster]
+git_repo_url = "${NAUTILOOP_GIT_REPO_URL}"
+agent_image = "k3d-nautiloop-registry:5001/nautiloop-agent-base:dev"
+sidecar_image = "k3d-nautiloop-registry:5001/nautiloop-sidecar:dev"
+skip_iptables = true
+database_url = "postgres://nautiloop:${POSTGRES_PASSWORD}@nautiloop-postgres:5432/nautiloop"
+TOML
+)" \
+    --dry-run=client -o yaml | kubectl apply -f -
+
+# ── Repo init job ─────────────────────────────────────────────────────────────
+
+echo "==> Running repo-init job..."
+
+# Run ssh-keyscan to get known_hosts for the git host
+GIT_HOST="$(echo "${NAUTILOOP_GIT_REPO_URL}" | sed -E 's/.*@([^:]+):.*/\1/' | sed -E 's|https?://([^/]+).*|\1|')"
+KNOWN_HOSTS="$(ssh-keyscan "${GIT_HOST}" 2>/dev/null)"
+if [ -z "$KNOWN_HOSTS" ]; then
+    echo "WARN: ssh-keyscan returned empty for ${GIT_HOST}. Known-hosts will not be set."
+fi
+
+for NS in nautiloop-system nautiloop-jobs; do
+    kubectl -n "${NS}" create configmap nautiloop-ssh-known-hosts \
+        --from-literal=known_hosts="${KNOWN_HOSTS}" \
+        --dry-run=client -o yaml | kubectl apply -f -
+done
+
+kubectl -n nautiloop-system delete job nautiloop-repo-init --ignore-not-found
+kubectl -n nautiloop-system apply -f - <<EOF
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nautiloop-repo-init
+  namespace: nautiloop-system
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: repo-init
+          image: alpine/git:latest
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              if [ ! -e /bare-repo/HEAD ]; then
+                git init --bare /bare-repo
+              fi
+              git -C /bare-repo remote remove origin 2>/dev/null || true
+              git -C /bare-repo remote add origin "\${GIT_REPO_URL}"
+              mkdir -p "\${HOME}/.ssh"
+              cp /secrets/ssh-key/id_ed25519 "\${HOME}/.ssh/id_ed25519"
+              chmod 600 "\${HOME}/.ssh/id_ed25519"
+              cp /secrets/ssh-known-hosts/known_hosts "\${HOME}/.ssh/known_hosts"
+              git -C /bare-repo fetch --all || echo "WARN: git fetch failed (deploy key may not be configured yet)"
+          env:
+            - name: HOME
+              value: /tmp
+            - name: GIT_REPO_URL
+              value: "${NAUTILOOP_GIT_REPO_URL}"
+          volumeMounts:
+            - name: bare-repo
+              mountPath: /bare-repo
+            - name: ssh-key
+              mountPath: /secrets/ssh-key
+              readOnly: true
+            - name: ssh-known-hosts
+              mountPath: /secrets/ssh-known-hosts
+              readOnly: true
+      volumes:
+        - name: bare-repo
+          persistentVolumeClaim:
+            claimName: nautiloop-bare-repo
+        - name: ssh-key
+          secret:
+            secretName: nautiloop-repo-ssh-key
+            defaultMode: 0400
+        - name: ssh-known-hosts
+          configMap:
+            name: nautiloop-ssh-known-hosts
+      restartPolicy: OnFailure
+EOF
+
+kubectl -n nautiloop-system wait --for=condition=complete job/nautiloop-repo-init --timeout=300s || {
+    echo "ERROR: repo-init job failed. Logs:"
+    kubectl -n nautiloop-system logs -l job-name=nautiloop-repo-init
+    exit 1
+}
+
+# ── Restart control plane to pick up updated secrets and config ───────────────
+
+echo "==> Restarting control plane deployments..."
+kubectl rollout restart deployment/nautiloop-api-server deployment/nautiloop-loop-engine \
+    -n nautiloop-system
+
+# ── Wait for control plane ────────────────────────────────────────────────────
+
+echo "==> Waiting for control plane to be ready..."
+kubectl rollout status deployment/nautiloop-api-server -n nautiloop-system --timeout=300s
+kubectl rollout status deployment/nautiloop-loop-engine -n nautiloop-system --timeout=300s
+
+# ── Configure nemo CLI ────────────────────────────────────────────────────────
+
+echo "==> Configuring nemo CLI..."
+nemo config --set server_url=http://localhost:18080
+nemo config --set engineer="${NAUTILOOP_ENGINEER}"
+nemo config --set api_key="${NAUTILOOP_API_KEY}"
+
+# ── Done ──────────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Nautiloop dev cluster is ready."
+echo ""
+echo "  API server:  http://localhost:18080"
+echo "  Engineer:    ${NAUTILOOP_ENGINEER}"
+echo "  API key:     ${NAUTILOOP_API_KEY}"
+echo ""
+echo "Run a smoke test:"
+echo "  ./dev/smoke-test.sh"
+echo ""
+echo "Tear down when done:"
+echo "  ./dev/teardown.sh"

--- a/dev/smoke-test.sh
+++ b/dev/smoke-test.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAUTILOOP_SERVER="${NAUTILOOP_SERVER:-http://localhost:18080}"
+ENGINEER="${NAUTILOOP_ENGINEER:-dev}"
+SPEC="${1:-$(dirname "$0")/test-spec.md}"
+
+if [ ! -f "$SPEC" ]; then
+    echo "ERROR: Spec file not found: ${SPEC}"
+    exit 1
+fi
+
+echo "==> Submitting harden job for: ${SPEC}"
+echo "    Server:   ${NAUTILOOP_SERVER}"
+echo "    Engineer: ${ENGINEER}"
+echo ""
+
+# nemo harden prints:
+#   Started loop <uuid>
+#     Branch: <branch>
+#     State:  PENDING
+#
+# Capture the loop_id from the first line.
+OUTPUT="$(nemo harden "$SPEC" --server "${NAUTILOOP_SERVER}")"
+echo "$OUTPUT"
+echo ""
+
+LOOP_ID="$(echo "$OUTPUT" | grep '^Started loop ' | awk '{print $3}')"
+if [ -z "$LOOP_ID" ]; then
+    echo "ERROR: Could not parse loop_id from nemo harden output."
+    exit 1
+fi
+
+echo "==> Loop ID: ${LOOP_ID}"
+echo "==> Streaming logs (Ctrl-C to stop)..."
+echo ""
+
+nemo logs "$LOOP_ID" --server "${NAUTILOOP_SERVER}"

--- a/dev/teardown.sh
+++ b/dev/teardown.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "==> Deleting k3d cluster nautiloop-dev..."
+k3d cluster delete nautiloop-dev 2>/dev/null || echo "    (cluster not found, skipping)"
+
+echo "==> Deleting k3d registry nautiloop-registry..."
+k3d registry delete nautiloop-registry 2>/dev/null || echo "    (registry not found, skipping)"
+
+echo "==> Teardown complete."

--- a/dev/test-spec.md
+++ b/dev/test-spec.md
@@ -1,0 +1,18 @@
+# Test: Hello World Function
+
+## Goal
+
+Add a `hello_world()` function to the codebase that returns the string `"hello, world"`.
+
+Place the function in a new file `hello_world.rs` (or equivalent for the project's primary language) at a sensible location in the repo. If the project is a Rust workspace, add it as a public function in a suitable existing crate or a new module.
+
+## Acceptance Criteria
+
+- A function named `hello_world` exists and returns the string `"hello, world"` (exact value, lowercase, with comma and space).
+- At least one test calls `hello_world()` and asserts the return value equals `"hello, world"`.
+- All existing tests continue to pass.
+- No existing files are removed or broken.
+
+## Notes
+
+This spec is intentionally trivial. Its purpose is to exercise the full nautiloop pipeline (implement, review, test stages) end-to-end without making meaningful changes to the codebase.


### PR DESCRIPTION
## Summary

- `dev/setup.sh` — one command to create a k3d cluster, build all 3 images, apply manifests, seed secrets from env vars, init the bare repo, and configure the nemo CLI. Idempotent (safe to run twice).
- `dev/build.sh` — builds control-plane, sidecar, and agent-base images and pushes to the local k3d registry. Accepts `--control-plane`, `--sidecar`, `--agent-base` flags to rebuild selectively.
- `dev/smoke-test.sh` — submits `nemo harden` with a trivial spec and streams logs until completion.
- `dev/teardown.sh` — deletes the cluster and registry.
- `dev/k8s/` — namespaces, hostPath PVs (shared bare-repo across namespaces on single node), Postgres, RBAC, ConfigMaps, control-plane deployments, LoadBalancer service on port 18080.
- `skip_iptables: bool` added to `ClusterConfig` and `JobBuildConfig` — when true, the `init-iptables` init container is omitted. Set to `true` in the dev nemo.toml so k3d doesn't need NET_ADMIN privileged init containers.

## Quick start
```sh
export NAUTILOOP_GIT_REPO_URL=git@github.com:org/repo.git
export NAUTILOOP_GITHUB_TOKEN=ghp_...
export NAUTILOOP_ANTHROPIC_KEY=sk-ant-...
./dev/setup.sh
./dev/smoke-test.sh
```