### PR TITLE
feat: stricter reviewer + nemo extend + default max_rounds 20

### DIFF
--- a/.nautiloop/prompts/review.md
+++ b/.nautiloop/prompts/review.md
@@ -52,10 +52,14 @@ Your final output MUST be valid JSON matching this schema exactly:
 ```
 
 Field definitions:
-- `clean` (bool): true if no issues found, false otherwise
+- `clean` (bool): true ONLY IF there are zero issues at severity `critical`, `high`, or `medium`. Low-severity issues (style nits, cosmetic suggestions) do NOT block clean — list them anyway so they're visible, but set `clean: true`. If ANY issue is at severity `medium` or higher, `clean` MUST be `false`. Do not set `clean: true` while simultaneously listing medium+ issues — that is self-contradictory and will be treated as a reviewer error.
 - `confidence` (float): 0.0-1.0, your confidence in the review
-- `issues` (array): list of issues found
-  - `severity`: one of "critical", "high", "medium", "low"
+- `issues` (array): list of ALL issues found, regardless of severity (visibility matters even for low-severity)
+  - `severity`: one of
+    - `critical` — data loss, security, or broken core path; blocks ship
+    - `high` — clear correctness bug or spec violation
+    - `medium` — edge-case bug, missing test coverage for a spec requirement, or missing error handling for a spec-mandated failure mode
+    - `low` — style, nit, cosmetic suggestion that does not affect correctness (does NOT block clean)
   - `category` (optional): one of "correctness", "security", "performance", "style"
   - `file`: file path where issue was found
   - `line` (optional): line number

--- a/.nautiloop/prompts/spec-audit.md
+++ b/.nautiloop/prompts/spec-audit.md
@@ -45,10 +45,14 @@ Your final output MUST be valid JSON matching this schema exactly:
 ```
 
 Field definitions:
-- `clean` (bool): true if spec is ready for implementation, false otherwise
+- `clean` (bool): true ONLY IF there are zero issues at severity `critical`, `high`, or `medium`. Low-severity suggestions (polish, optional rewordings) do NOT block clean — list them anyway so they're visible, but set `clean: true`. If ANY issue is at severity `medium` or higher, `clean` MUST be `false`. Do not set `clean: true` while simultaneously listing medium+ issues — that is self-contradictory.
 - `confidence` (float): 0.0-1.0, your confidence in the audit
-- `issues` (array): list of spec issues found
-  - `severity`: one of "critical", "high", "medium", "low"
+- `issues` (array): list of ALL spec issues found, regardless of severity
+  - `severity`: one of
+    - `critical` — spec cannot be implemented as written (missing information makes it impossible)
+    - `high` — spec contradicts itself, or a functional requirement is ambiguous in a way that would produce a wrong implementation
+    - `medium` — missing acceptance criterion, missing edge-case handling, or a requirement that could be interpreted two different ways
+    - `low` — polish, wording suggestion, or optional rewording that does NOT affect implementation correctness (does NOT block clean)
   - `category` (optional): one of "completeness", "clarity", "correctness", "consistency"
   - `file`: spec file path
   - `line` (optional): line number in spec

--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -1,0 +1,115 @@
+{
+  "name": ".opencode",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@opencode-ai/plugin": "1.3.17"
+      }
+    },
+    "node_modules/@opencode-ai/plugin": {
+      "version": "1.3.17",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.3.17.tgz",
+      "integrity": "sha512-N5lckFtYvEu2R8K1um//MIOTHsJHniF2kHoPIWPCrxKG5Jpismt1ISGzIiU3aKI2ht/9VgcqKPC5oZFLdmpxPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@opencode-ai/sdk": "1.3.17",
+        "zod": "4.1.8"
+      },
+      "peerDependencies": {
+        "@opentui/core": ">=0.1.96",
+        "@opentui/solid": ">=0.1.96"
+      },
+      "peerDependenciesMeta": {
+        "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/solid": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.3.17",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.3.17.tgz",
+      "integrity": "sha512-2+MGgu7wynqTBwxezR01VAGhILXlpcHDY/pF7SWB87WOgLt3kD55HjKHNj6PWxyY8n575AZolR95VUC3gtwfmA==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "7.0.6"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.8",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/cli/src/commands/extend.rs
+++ b/cli/src/commands/extend.rs
@@ -1,0 +1,29 @@
+use anyhow::Result;
+
+use crate::client::NemoClient;
+
+#[derive(serde::Deserialize)]
+struct ExtendResponse {
+    loop_id: uuid::Uuid,
+    prior_max_rounds: u32,
+    new_max_rounds: u32,
+    resumed_to_state: String,
+}
+
+pub async fn run(client: &NemoClient, loop_id: &str, add_rounds: u32) -> Result<()> {
+    let resp: ExtendResponse = client
+        .post(
+            &format!("/extend/{loop_id}"),
+            &serde_json::json!({ "add_rounds": add_rounds }),
+        )
+        .await?;
+
+    println!("Extended loop {}", resp.loop_id);
+    println!(
+        "  max_rounds: {} -> {} (+{})",
+        resp.prior_max_rounds, resp.new_max_rounds, add_rounds
+    );
+    println!("  Resuming at: {}", resp.resumed_to_state);
+    println!("  Loop will continue on next reconciliation tick.");
+    Ok(())
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod approve;
 pub mod auth;
 pub mod cancel;
 pub mod config;
+pub mod extend;
 pub mod helm;
 pub mod init;
 pub mod inspect;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -151,6 +151,15 @@ enum Commands {
         loop_id: String,
     },
 
+    /// Extend a FAILED loop's max_rounds and resume it from the last stage
+    Extend {
+        /// Loop ID
+        loop_id: String,
+        /// Number of rounds to add to max_rounds
+        #[arg(long, default_value_t = 5)]
+        add: u32,
+    },
+
     /// Scan monorepo, generate nemo.toml
     Init {
         /// Overwrite existing nemo.toml
@@ -400,6 +409,9 @@ async fn main() -> anyhow::Result<()> {
         }
         Commands::Resume { loop_id } => {
             commands::resume::run(&http_client, &loop_id).await?;
+        }
+        Commands::Extend { loop_id, add } => {
+            commands::extend::run(&http_client, &loop_id, add).await?;
         }
         Commands::Init { .. } => {
             // Handled above before config loading

--- a/control-plane/src/api/handlers.rs
+++ b/control-plane/src/api/handlers.rs
@@ -8,8 +8,9 @@ use super::AppState;
 use crate::error::NautiloopError;
 use crate::state::LoopFlag;
 use crate::types::api::{
-    ApproveResponse, CancelResponse, CredentialRequest, InspectResponse, LogsQuery, LoopSummary,
-    ResumeResponse, RoundSummary, StartRequest, StartResponse, StatusQuery, StatusResponse,
+    ApproveResponse, CancelResponse, CredentialRequest, ExtendRequest, ExtendResponse,
+    InspectResponse, LogsQuery, LoopSummary, ResumeResponse, RoundSummary, StartRequest,
+    StartResponse, StatusQuery, StatusResponse,
 };
 use crate::types::{LoopKind, LoopRecord, LoopState, generate_branch_name};
 
@@ -626,6 +627,85 @@ pub async fn resume(
         loop_id: id,
         state: record.state,
         resume_requested: true,
+    }))
+}
+
+/// POST /extend/:id - Extend a FAILED loop's max_rounds and resume it.
+///
+/// Only permitted on loops in FAILED state with a `failed_from_state` set
+/// (transient or max-rounds failures — logical failures with no prior stage
+/// are rejected the same way resume rejects them).
+///
+/// Bumps `max_rounds` by `add_rounds`, clears `failure_reason`, and flags
+/// the resume so the reconciler picks up where the loop left off.
+pub async fn extend(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    Json(req): Json<ExtendRequest>,
+) -> Result<Json<ExtendResponse>, NautiloopError> {
+    if req.add_rounds == 0 {
+        return Err(NautiloopError::BadRequest(
+            "add_rounds must be > 0".to_string(),
+        ));
+    }
+
+    let record = state
+        .store
+        .get_loop(id)
+        .await?
+        .ok_or(NautiloopError::LoopNotFound { id })?;
+
+    if record.state != LoopState::Failed {
+        return Err(NautiloopError::InvalidStateTransition {
+            action: "extend".to_string(),
+            state: record.state.to_string(),
+            expected: "FAILED".to_string(),
+        });
+    }
+
+    let Some(resume_state) = record.failed_from_state else {
+        return Err(NautiloopError::InvalidStateTransition {
+            action: "extend".to_string(),
+            state: record.state.to_string(),
+            expected:
+                "FAILED loop with a preserved failed_from_state (older failures without this metadata are not extendable — start a fresh loop)"
+                    .to_string(),
+        });
+    };
+
+    // Same safety check as resume: if another loop has taken over this branch,
+    // refuse. The worktree contents no longer correspond to this row.
+    if let Some(other) = state.store.get_loop_by_branch_any(&record.branch).await?
+        && other.id != record.id
+        && other.updated_at > record.updated_at
+    {
+        return Err(NautiloopError::InvalidStateTransition {
+            action: "extend".to_string(),
+            state: record.state.to_string(),
+            expected: format!(
+                "branch {} was taken over by a newer loop {} (state {}) — start a fresh loop instead",
+                record.branch, other.id, other.state
+            ),
+        });
+    }
+
+    let prior_max = record.max_rounds as u32;
+    let new_max = prior_max + req.add_rounds;
+
+    let mut updated = record.clone();
+    updated.max_rounds = new_max as i32;
+    updated.failure_reason = None;
+    state.store.update_loop(&updated).await?;
+    state
+        .store
+        .set_loop_flag(id, LoopFlag::Resume, true)
+        .await?;
+
+    Ok(Json(ExtendResponse {
+        loop_id: id,
+        prior_max_rounds: prior_max,
+        new_max_rounds: new_max,
+        resumed_to_state: resume_state,
     }))
 }
 

--- a/control-plane/src/api/mod.rs
+++ b/control-plane/src/api/mod.rs
@@ -60,6 +60,7 @@ fn build_routes(_state: AppState) -> Router<AppState> {
         .route("/cancel/{id}", delete(handlers::cancel))
         .route("/approve/{id}", post(handlers::approve))
         .route("/resume/{id}", post(handlers::resume))
+        .route("/extend/{id}", post(handlers::extend))
         .route("/inspect", get(handlers::inspect))
         .route("/credentials", get(handlers::list_credentials))
         .route("/credentials", post(handlers::upsert_credentials))

--- a/control-plane/src/api/sse.rs
+++ b/control-plane/src/api/sse.rs
@@ -22,7 +22,7 @@ pub async fn stream_logs(
     stage: Option<String>,
 ) -> Sse<impl Stream<Item = Result<Event, std::convert::Infallible>>> {
     let stream = async_stream::stream! {
-        let mut cursor_timestamp = chrono::DateTime::<chrono::Utc>::MIN_UTC;
+        let mut cursor_timestamp = chrono::DateTime::<chrono::Utc>::UNIX_EPOCH;
         let mut seen_ids: HashSet<Uuid> = HashSet::new();
         let poll_interval = Duration::from_millis(500);
 

--- a/control-plane/src/config/merged.rs
+++ b/control-plane/src/config/merged.rs
@@ -147,7 +147,7 @@ impl MergedConfig {
         let max_rounds_implement = engineer_limits
             .and_then(|l| l.max_rounds_implement)
             .or_else(|| repo.limits.as_ref().and_then(|l| l.max_rounds_implement))
-            .unwrap_or(15);
+            .unwrap_or(20);
 
         // Services: deep merge. Repo defines; engineer can add but not override.
         let services = repo.services.clone();
@@ -339,7 +339,7 @@ mod tests {
 
         let result = MergedConfig::merge(&cluster, &repo, None).unwrap();
         assert_eq!(result.config.max_rounds_harden, 10);
-        assert_eq!(result.config.max_rounds_implement, 15);
+        assert_eq!(result.config.max_rounds_implement, 20);
         assert!(!result.config.ship_allowed);
         assert!(result.config.ship_require_passing_ci);
         assert_eq!(result.config.ship_merge_strategy, "squash");

--- a/control-plane/src/git/mod.rs
+++ b/control-plane/src/git/mod.rs
@@ -143,7 +143,7 @@ pub mod bare {
             })?;
 
             let add = Command::new("git")
-                .args(["add", path])
+                .args(["add", "-f", path])
                 .current_dir(worktree_dir)
                 .output()
                 .await

--- a/control-plane/src/k8s/job_builder.rs
+++ b/control-plane/src/k8s/job_builder.rs
@@ -71,7 +71,7 @@ pub fn build_job(ctx: &LoopContext, stage: &StageConfig, cfg: &JobBuildConfig) -
     let is_test = matches!(parsed_stage, Some(Stage::Test));
 
     // FR-27: Environment variables on the agent container
-    let agent_env = build_agent_env_vars(ctx, stage, is_test);
+    let agent_env = build_agent_env_vars(ctx, stage, is_test, is_implement_or_revise);
 
     // Build volumes (FR-25, FR-26, FR-30)
     let mut volumes = build_volumes(
@@ -276,7 +276,12 @@ pub fn build_job(ctx: &LoopContext, stage: &StageConfig, cfg: &JobBuildConfig) -
 }
 
 /// Build all environment variables for the agent container (FR-27, FR-8, FR-9, FR-10, FR-11).
-fn build_agent_env_vars(ctx: &LoopContext, stage: &StageConfig, is_test: bool) -> Vec<EnvVar> {
+fn build_agent_env_vars(
+    ctx: &LoopContext,
+    stage: &StageConfig,
+    is_test: bool,
+    is_implement_or_revise: bool,
+) -> Vec<EnvVar> {
     let mut env = vec![
         // FR-27: Core env vars
         env_var("STAGE", &stage.name),
@@ -392,6 +397,19 @@ fn build_agent_env_vars(ctx: &LoopContext, stage: &StageConfig, is_test: bool) -
         }
     }
 
+    // Spec #130: sccache env for implement/revise so rustc invocations hit the
+    // shared compiler cache at /cache/sccache (PVC mount). Claude will pick
+    // RUSTC_WRAPPER up through cargo automatically. SCCACHE_CACHE_SIZE caps
+    // on-disk cache; LRU eviction by sccache itself. SCCACHE_IDLE_TIMEOUT=0
+    // keeps the daemon alive for the duration of the pod (otherwise it exits
+    // after 10 minutes and cold-starts for each new invocation).
+    if is_implement_or_revise {
+        env.push(env_var("RUSTC_WRAPPER", "sccache"));
+        env.push(env_var("SCCACHE_DIR", "/cache/sccache"));
+        env.push(env_var("SCCACHE_CACHE_SIZE", "15G"));
+        env.push(env_var("SCCACHE_IDLE_TIMEOUT", "0"));
+    }
+
     // Credentials are NOT injected as env vars — they go through the sidecar only.
     // This prevents untrusted agent code from reading secrets directly.
 
@@ -423,6 +441,17 @@ fn build_volumes(
             name: "sessions".to_string(),
             persistent_volume_claim: Some(PersistentVolumeClaimVolumeSource {
                 claim_name: sessions_pvc.to_string(),
+                read_only: Some(false),
+            }),
+            ..Default::default()
+        },
+        // Spec #130: Shared sccache compiler cache (RWO PVC, safe for concurrent
+        // agent pods via sccache's internal file locking). Mounted only on
+        // implement/revise stages via build_agent_mounts.
+        Volume {
+            name: "cargo-cache".to_string(),
+            persistent_volume_claim: Some(PersistentVolumeClaimVolumeSource {
+                claim_name: "nautiloop-cargo-cache".to_string(),
                 read_only: Some(false),
             }),
             ..Default::default()
@@ -544,6 +573,17 @@ fn build_agent_mounts(
             ..Default::default()
         },
     ];
+
+    // Spec #130: Mount shared sccache cache for IMPLEMENT/REVISE only.
+    // Review/audit are read-only stages that don't invoke cargo. Test is
+    // per-service and handled by the repo's nemo.toml test commands.
+    if is_implement_or_revise {
+        mounts.push(VolumeMount {
+            name: "cargo-cache".to_string(),
+            mount_path: "/cache/sccache".to_string(),
+            ..Default::default()
+        });
+    }
 
     // FR-25b: Mount Claude credentials for IMPLEMENT/REVISE/REVIEW/AUDIT stages.
     // Mounted at /secrets/claude-creds/ (read-only), NOT at ~/.claude directly.
@@ -1241,7 +1281,7 @@ mod tests {
         let cfg = test_cfg();
         let job = build_job(&ctx, &stage, &cfg);
         let volumes = job.spec.unwrap().template.spec.unwrap().volumes.unwrap();
-        // worktree, sessions, output, shared, tmpdir, home, model-credentials, ssh-key, ssh-known-hosts, claude-session (implement stage)
-        assert_eq!(volumes.len(), 10);
+        // worktree, sessions, cargo-cache, output, shared, tmpdir, home, model-credentials, ssh-key, ssh-known-hosts, claude-session (implement stage)
+        assert_eq!(volumes.len(), 11);
     }
 }

--- a/control-plane/src/k8s/job_builder.rs
+++ b/control-plane/src/k8s/job_builder.rs
@@ -507,6 +507,17 @@ fn build_agent_mounts(
             read_only: Some(is_review_or_audit), // FR-6: Read-only for REVIEW/AUDIT
             ..Default::default()
         },
+        // Mount the whole bare-repo PVC (no subPath) at /bare-repo so the
+        // worktree's .git pointer file can resolve `gitdir: /bare-repo/worktrees/<name>`.
+        // Without this, /work/.git points at a path outside the subPath mount, git
+        // fails, and the agent runs `git init` creating a disjoint repo whose commits
+        // never reach the bare repo's branch ref.
+        VolumeMount {
+            name: "worktree".to_string(),
+            mount_path: "/bare-repo".to_string(),
+            read_only: Some(is_review_or_audit),
+            ..Default::default()
+        },
         VolumeMount {
             name: "sessions".to_string(),
             mount_path: "/sessions".to_string(),

--- a/control-plane/src/k8s/job_builder.rs
+++ b/control-plane/src/k8s/job_builder.rs
@@ -534,11 +534,14 @@ fn build_agent_mounts(
         },
     ];
 
-    // FR-25b: Mount Claude session directory for IMPLEMENT/REVISE/REVIEW/AUDIT stages
+    // FR-25b: Mount Claude credentials for IMPLEMENT/REVISE/REVIEW/AUDIT stages.
+    // Mounted at /secrets/claude-creds/ (read-only), NOT at ~/.claude directly.
+    // The entrypoint copies .credentials.json to the writable ~/.claude/ so that
+    // Claude Code can create session-env/ and other runtime directories there.
     if is_implement_or_revise || is_review_or_audit {
         mounts.push(VolumeMount {
             name: "claude-session".to_string(),
-            mount_path: "/home/agent/.claude".to_string(),
+            mount_path: "/secrets/claude-creds".to_string(),
             read_only: Some(true),
             ..Default::default()
         });
@@ -1043,7 +1046,7 @@ mod tests {
 
     #[test]
     fn test_build_job_implement_has_claude_session() {
-        // FR-25b: Claude session mounted for implement stage
+        // FR-25b: Claude credentials mounted at /secrets/claude-creds for implement stage
         let ctx = test_ctx();
         let stage = test_stage(); // implement
         let cfg = test_cfg();
@@ -1052,23 +1055,22 @@ mod tests {
         let mounts = agent.volume_mounts.as_ref().unwrap();
         let claude_mount = mounts
             .iter()
-            .find(|m| m.mount_path == "/home/agent/.claude");
+            .find(|m| m.mount_path == "/secrets/claude-creds");
         assert!(
             claude_mount.is_some(),
-            "Claude session should be mounted for implement"
+            "Claude credentials should be mounted at /secrets/claude-creds for implement"
         );
         assert_eq!(claude_mount.unwrap().read_only, Some(true));
-        // No /secrets or model-credentials in agent
+        // ~/.claude is NOT mounted directly (entrypoint copies from /secrets/claude-creds)
         assert!(
-            !mounts
-                .iter()
-                .any(|m| m.mount_path.contains("/secrets") || m.mount_path.contains("credential"))
+            !mounts.iter().any(|m| m.mount_path == "/home/agent/.claude"),
+            "~/.claude should not be directly mounted; credentials are copied by entrypoint"
         );
     }
 
     #[test]
     fn test_build_job_review_has_claude_session() {
-        // Claude session IS mounted for review stage (review may use claude CLI)
+        // Claude credentials are mounted at /secrets/claude-creds for review stage
         let ctx = test_ctx();
         let stage = StageConfig {
             name: "review".to_string(),
@@ -1079,7 +1081,7 @@ mod tests {
         let job = build_job(&ctx, &stage, &cfg);
         let agent = &job.spec.unwrap().template.spec.unwrap().containers[0];
         let mounts = agent.volume_mounts.as_ref().unwrap();
-        assert!(mounts.iter().any(|m| m.mount_path == "/home/agent/.claude"));
+        assert!(mounts.iter().any(|m| m.mount_path == "/secrets/claude-creds"));
     }
 
     #[test]
@@ -1119,13 +1121,14 @@ mod tests {
                 .any(|m| m.mount_path == "/secrets/ssh-key")
         );
 
-        // Agent does NOT have /secrets/ mounts (FR-26)
+        // Agent does NOT have model-credentials or ssh-key mounts (FR-26).
+        // /secrets/claude-creds is allowed (read-only Claude credentials for the agent).
         let pod_spec = job.spec.unwrap().template.spec.unwrap();
         let agent_mounts = pod_spec.containers[0].volume_mounts.as_ref().unwrap();
         assert!(
             !agent_mounts
                 .iter()
-                .any(|m| m.mount_path.starts_with("/secrets"))
+                .any(|m| m.mount_path == "/secrets/model-credentials" || m.mount_path == "/secrets/ssh-key")
         );
     }
 

--- a/control-plane/src/k8s/job_builder.rs
+++ b/control-plane/src/k8s/job_builder.rs
@@ -81,8 +81,9 @@ pub fn build_job(ctx: &LoopContext, stage: &StageConfig, cfg: &JobBuildConfig) -
         &cfg.ssh_known_hosts_configmap,
     );
 
-    // FR-25b: Claude session volume for IMPLEMENT/REVISE stages
-    if is_implement_or_revise {
+    // FR-25b: Claude session volume for IMPLEMENT/REVISE/REVIEW/AUDIT stages
+    // (review/audit may also use claude CLI when model-review is a claude-* model)
+    if is_implement_or_revise || is_review_or_audit {
         let safe_engineer: String = ctx.engineer.to_lowercase().replace('_', "-");
         volumes.push(Volume {
             name: "claude-session".to_string(),
@@ -533,8 +534,8 @@ fn build_agent_mounts(
         },
     ];
 
-    // FR-25b: Mount Claude session directory for IMPLEMENT/REVISE stages
-    if is_implement_or_revise {
+    // FR-25b: Mount Claude session directory for IMPLEMENT/REVISE/REVIEW/AUDIT stages
+    if is_implement_or_revise || is_review_or_audit {
         mounts.push(VolumeMount {
             name: "claude-session".to_string(),
             mount_path: "/home/agent/.claude".to_string(),
@@ -1066,8 +1067,8 @@ mod tests {
     }
 
     #[test]
-    fn test_build_job_review_no_claude_session() {
-        // Claude session NOT mounted for review stage
+    fn test_build_job_review_has_claude_session() {
+        // Claude session IS mounted for review stage (review may use claude CLI)
         let ctx = test_ctx();
         let stage = StageConfig {
             name: "review".to_string(),
@@ -1078,7 +1079,7 @@ mod tests {
         let job = build_job(&ctx, &stage, &cfg);
         let agent = &job.spec.unwrap().template.spec.unwrap().containers[0];
         let mounts = agent.volume_mounts.as_ref().unwrap();
-        assert!(mounts.iter().all(|m| m.mount_path != "/home/agent/.claude"));
+        assert!(mounts.iter().any(|m| m.mount_path == "/home/agent/.claude"));
     }
 
     #[test]

--- a/control-plane/src/loop_engine/driver.rs
+++ b/control-plane/src/loop_engine/driver.rs
@@ -710,6 +710,8 @@ impl ConvergentLoopDriver {
                         record.max_rounds
                     ));
                     record.active_job_name = None;
+                    // Preserve the pre-failure state so `nemo extend` can resume here.
+                    record.failed_from_state = Some(LoopState::Hardening);
                     self.store.update_loop(record).await?;
                     return Ok(LoopState::Failed);
                 }
@@ -831,6 +833,8 @@ impl ConvergentLoopDriver {
                         record.max_rounds
                     ));
                     record.active_job_name = None;
+                    // Preserve the pre-failure state so `nemo extend` can resume here.
+                    record.failed_from_state = Some(LoopState::Implementing);
                     self.store.update_loop(record).await?;
                     return Ok(LoopState::Failed);
                 }
@@ -1078,6 +1082,8 @@ impl ConvergentLoopDriver {
                         record.max_rounds
                     ));
                     record.active_job_name = None;
+                    // Preserve the pre-failure state so `nemo extend` can resume here.
+                    record.failed_from_state = Some(LoopState::Implementing);
                     self.store.update_loop(record).await?;
                     return Ok(LoopState::Failed);
                 }

--- a/control-plane/src/loop_engine/driver.rs
+++ b/control-plane/src/loop_engine/driver.rs
@@ -506,7 +506,7 @@ impl ConvergentLoopDriver {
         let new_lines: Vec<String> = logs
             .lines()
             .map(str::trim_end)
-            .filter(|line| !line.is_empty() && !line.starts_with("NAUTILOOP_RESULT:"))
+            .filter(|line| !line.is_empty())
             .map(ToOwned::to_owned)
             .collect();
 
@@ -571,6 +571,28 @@ impl ConvergentLoopDriver {
                     Some(v) if v.clean => {
                         // Audit passed
                         if record.harden_only {
+                            // Check if the branch has any commits ahead of the default branch.
+                            // If the spec was already clean on round 1 (no revise ran), the
+                            // branch has no new commits and GitHub will reject PR creation.
+                            let default_branch = self.default_branch_for(record);
+                            let branch_sha = self.git.get_branch_sha(&record.branch).await?;
+                            // Compare against origin/<default_branch> since the bare repo
+                            // uses remote-tracking refs, not local branch refs, for main.
+                            let remote_ref = format!("origin/{default_branch}");
+                            let default_sha = self.git.get_branch_sha(&remote_ref).await?;
+                            let has_commits = branch_sha != default_sha;
+
+                            if !has_commits {
+                                // Spec was already clean — no revisions needed, no PR to create.
+                                record.state = LoopState::Hardened;
+                                record.sub_state = None;
+                                record.active_job_name = None;
+                                record.hardened_spec_path = Some(record.spec_path.clone());
+                                self.store.update_loop(record).await?;
+                                tracing::info!(loop_id = %record.id, "Harden loop HARDENED (spec already clean, no PR needed)");
+                                return Ok(LoopState::Hardened);
+                            }
+
                             // Clean up .agent/ artifacts before PR creation
                             if let Err(e) = self.git.remove_path(&record.branch, ".agent").await {
                                 tracing::warn!(loop_id = %record.id, error = %e, "Failed to clean up .agent/ artifacts, proceeding with PR");
@@ -591,7 +613,7 @@ impl ConvergentLoopDriver {
                                     &record.branch,
                                     &pr_title,
                                     &pr_body,
-                                    &self.default_branch_for(record),
+                                    &default_branch,
                                 )
                                 .await?;
                             record.spec_pr_url = Some(pr_url);
@@ -602,7 +624,7 @@ impl ConvergentLoopDriver {
                                     .merge_pr(
                                         &record.branch,
                                         &self.config.harden.merge_strategy,
-                                        &self.default_branch_for(record),
+                                        &default_branch,
                                     )
                                     .await?;
                                 record.merge_sha = Some(merge_sha);

--- a/control-plane/src/loop_engine/driver.rs
+++ b/control-plane/src/loop_engine/driver.rs
@@ -639,9 +639,9 @@ impl ConvergentLoopDriver {
                             Ok(LoopState::AwaitingApproval)
                         }
                     }
-                    Some(_v) => {
-                        // Audit found issues: dispatch revise
-                        self.dispatch_revise(record).await
+                    Some(v) => {
+                        // Audit found issues: dispatch revise with findings as feedback
+                        self.dispatch_revise(record, &v).await
                     }
                     None => {
                         // Verdict parse failure: retry per FR-9
@@ -1535,9 +1535,34 @@ impl ConvergentLoopDriver {
     }
 
     /// Dispatch a revise job (harden loop).
-    async fn dispatch_revise(&self, record: &mut LoopRecord) -> Result<LoopState> {
+    async fn dispatch_revise(
+        &self,
+        record: &mut LoopRecord,
+        audit_verdict: &AuditVerdict,
+    ) -> Result<LoopState> {
         record.sub_state = Some(SubState::Dispatched);
         record.retry_count = 0;
+
+        // Write audit findings as a feedback file so the revise agent
+        // receives the {{FEEDBACK}} substitution in spec-revise.md.
+        let feedback = FeedbackFile {
+            round: record.round as u32,
+            source: FeedbackSource::Audit,
+            issues: Some(audit_verdict.issues.clone()),
+            failures: None,
+        };
+        let feedback_path = format!(".agent/audit-feedback-round-{}.json", record.round);
+        let feedback_json = serde_json::to_string_pretty(&feedback).map_err(|e| {
+            crate::error::NautiloopError::Internal(format!(
+                "Failed to serialize audit feedback: {e}"
+            ))
+        })?;
+        self.git
+            .write_file(&record.branch, &feedback_path, &feedback_json)
+            .await?;
+        if let Some(new_sha) = self.git.get_branch_sha(&record.branch).await? {
+            record.current_sha = Some(new_sha);
+        }
 
         // #98: Claude credential preflight. If it blocks, write a
         // sentinel `revise` round record ONLY in that case so that
@@ -1561,9 +1586,17 @@ impl ConvergentLoopDriver {
         let stage_config = self.revise_stage_config(record);
         let mut ctx = self.build_context(record).await?;
         ctx.session_id = Self::session_id_for_stage(record, "revise");
+        ctx.feedback_path = Some(feedback_path.clone());
         let job = job_builder::build_job(&ctx, &stage_config, &self.job_build_config());
         self.persist_then_dispatch(record, "revise", &job).await?;
 
+        tracing::info!(
+            loop_id = %record.id,
+            round = record.round,
+            feedback = %feedback_path,
+            issues = audit_verdict.issues.len(),
+            "Dispatching revise with audit feedback"
+        );
         Ok(LoopState::Hardening)
     }
 

--- a/control-plane/src/loop_engine/driver.rs
+++ b/control-plane/src/loop_engine/driver.rs
@@ -904,6 +904,39 @@ impl ConvergentLoopDriver {
 
         match verdict {
             Some(v) if v.clean => {
+                // Guard: review verdict clean but branch has no commits vs. main.
+                // Means the implementor never actually committed (e.g. it emitted a
+                // fake SHA in NAUTILOOP_RESULT, or the agent image lacked build tools
+                // and bailed). Without this guard, the driver retries create_pr every
+                // tick with "No commits between main and branch" and the loop is stuck
+                // forever. Transition to FAILED with a clear reason instead.
+                let default_branch = self.default_branch_for(record);
+                let branch_sha = self.git.get_branch_sha(&record.branch).await?;
+                let default_sha = self
+                    .git
+                    .get_branch_sha(&format!("origin/{default_branch}"))
+                    .await?;
+                if branch_sha.is_some() && branch_sha == default_sha {
+                    tracing::warn!(
+                        loop_id = %record.id,
+                        branch = %record.branch,
+                        "Review verdict clean but branch has no commits vs. {}; marking FAILED",
+                        default_branch
+                    );
+                    record.state = LoopState::Failed;
+                    record.sub_state = None;
+                    record.active_job_name = None;
+                    record.failure_reason = Some(format!(
+                        "Review returned clean={} but agent branch has no commits against {}. \
+                         Likely cause: implementor produced output but did not commit (missing \
+                         build tooling in the agent image, or agent emitted a synthetic SHA). \
+                         Check implement stage logs.",
+                        v.clean, default_branch
+                    ));
+                    self.store.update_loop(record).await?;
+                    return Ok(LoopState::Failed);
+                }
+
                 // Create PR if not already created (idempotent across ticks)
                 if record.spec_pr_url.is_none() {
                     if let Err(e) = self.git.remove_path(&record.branch, ".agent").await {
@@ -922,7 +955,7 @@ impl ConvergentLoopDriver {
                             &record.branch,
                             &pr_title,
                             &pr_body,
-                            &self.default_branch_for(record),
+                            &default_branch,
                         )
                         .await?;
                     record.spec_pr_url = Some(pr_url);

--- a/control-plane/src/loop_engine/driver.rs
+++ b/control-plane/src/loop_engine/driver.rs
@@ -729,9 +729,19 @@ impl ConvergentLoopDriver {
 
         let stage_config = self.test_stage_config();
         let mut ctx = self.build_context(record).await?;
+        self.inject_test_services(record, &mut ctx).await;
 
-        // Inject affected_services for the TEST stage (FR-42a).
-        // Compute from git diff: only services whose path prefix matches changed files.
+        let job = job_builder::build_job(&ctx, &stage_config, &self.job_build_config());
+        self.persist_then_dispatch(record, "test", &job).await?;
+
+        tracing::info!(loop_id = %record.id, round = record.round, "IMPLEMENTING -> TESTING/DISPATCHED");
+        Ok(LoopState::Testing)
+    }
+
+    /// Compute affected services from git diff and inject AFFECTED_SERVICES +
+    /// service_tags into the loop context credentials for the TEST stage.
+    /// Called from both advance_to_testing and redispatch_current_stage.
+    async fn inject_test_services(&self, record: &LoopRecord, ctx: &mut LoopContext) {
         let diff_files = self
             .git
             .changed_files(&record.branch, &self.default_branch_for(record))
@@ -739,16 +749,12 @@ impl ConvergentLoopDriver {
             .unwrap_or_default();
 
         let affected: Vec<String> = if diff_files.is_empty() {
-            // Can't determine diff — test all services
             self.config.services.keys().cloned().collect()
         } else {
             self.config
                 .services
                 .iter()
                 .filter(|(_, svc)| {
-                    // Use path + "/" for prefix matching to prevent false positives
-                    // (e.g., "cli" matching "client", "api" matching "api-gateway").
-                    // Root service (".") matches everything.
                     let prefix = if svc.path == "." {
                         String::new()
                     } else if svc.path.ends_with('/') {
@@ -764,8 +770,7 @@ impl ConvergentLoopDriver {
                 .collect()
         };
 
-        // If no services matched, still test all (safety net)
-        let service_names = if affected.is_empty() {
+        let service_names: Vec<String> = if affected.is_empty() {
             self.config.services.keys().cloned().collect()
         } else {
             affected
@@ -776,7 +781,6 @@ impl ConvergentLoopDriver {
         ctx.credentials
             .push(("affected_services".to_string(), services_json));
 
-        // Inject service_tags for JVM resource escalation (FR-28) — only from affected services
         let all_tags: Vec<String> = self
             .config
             .services
@@ -789,12 +793,6 @@ impl ConvergentLoopDriver {
             ctx.credentials
                 .push(("service_tags".to_string(), tags_json));
         }
-
-        let job = job_builder::build_job(&ctx, &stage_config, &self.job_build_config());
-        self.persist_then_dispatch(record, "test", &job).await?;
-
-        tracing::info!(loop_id = %record.id, round = record.round, "IMPLEMENTING -> TESTING/DISPATCHED");
-        Ok(LoopState::Testing)
     }
 
     /// Evaluate test stage output.
@@ -1760,6 +1758,11 @@ impl ConvergentLoopDriver {
 
         let mut ctx = self.build_context(&updated).await?;
         ctx.session_id = Self::session_id_for_stage(record, stage_name);
+
+        // Inject affected_services for test stage retries (same as advance_to_testing)
+        if stage_name == "test" {
+            self.inject_test_services(record, &mut ctx).await;
+        }
 
         // Restore feedback_path for implementing redispatch (N30):
         // look at the prior round's stage to determine review vs test feedback

--- a/control-plane/src/types/api.rs
+++ b/control-plane/src/types/api.rs
@@ -117,6 +117,22 @@ pub struct ResumeResponse {
     pub resume_requested: bool,
 }
 
+/// POST /extend/:id request body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExtendRequest {
+    /// Number of rounds to add to the loop's current max_rounds.
+    pub add_rounds: u32,
+}
+
+/// POST /extend/:id response body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExtendResponse {
+    pub loop_id: Uuid,
+    pub prior_max_rounds: u32,
+    pub new_max_rounds: u32,
+    pub resumed_to_state: LoopState,
+}
+
 /// GET /inspect?branch=... response body.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InspectResponse {

--- a/dev/build.sh
+++ b/dev/build.sh
@@ -46,8 +46,9 @@ if "$BUILD_SIDECAR"; then
 fi
 
 if "$BUILD_AGENT_BASE"; then
-    echo "==> Building agent-base image..."
+    echo "==> Building agent-base image (dev: includes Rust toolchain for dogfooding)..."
     docker build \
+        --build-arg INCLUDE_RUST=true \
         -f "${CONTEXT}/images/base/Dockerfile" \
         -t "nautiloop-agent-base:dev" \
         "${CONTEXT}"

--- a/dev/build.sh
+++ b/dev/build.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REGISTRY="localhost:5001"
 CONTEXT="$(cd "$(dirname "$0")/.." && pwd)"
 
 BUILD_CONTROL_PLANE=false
@@ -28,30 +27,33 @@ if "$BUILD_CONTROL_PLANE"; then
     echo "==> Building control-plane image..."
     docker build \
         -f "${CONTEXT}/images/control-plane/Dockerfile" \
-        -t "${REGISTRY}/nautiloop-control-plane:dev" \
+        -t "nautiloop-control-plane:dev" \
         "${CONTEXT}"
-    docker push "${REGISTRY}/nautiloop-control-plane:dev"
-    echo "    Pushed ${REGISTRY}/nautiloop-control-plane:dev"
+    echo "==> Importing nautiloop-control-plane:dev into k3d cluster..."
+    k3d image import nautiloop-control-plane:dev -c nautiloop-dev
+    echo "    Done."
 fi
 
 if "$BUILD_SIDECAR"; then
     echo "==> Building sidecar image..."
     docker build \
         -f "${CONTEXT}/sidecar/Dockerfile" \
-        -t "${REGISTRY}/nautiloop-sidecar:dev" \
+        -t "nautiloop-sidecar:dev" \
         "${CONTEXT}"
-    docker push "${REGISTRY}/nautiloop-sidecar:dev"
-    echo "    Pushed ${REGISTRY}/nautiloop-sidecar:dev"
+    echo "==> Importing nautiloop-sidecar:dev into k3d cluster..."
+    k3d image import nautiloop-sidecar:dev -c nautiloop-dev
+    echo "    Done."
 fi
 
 if "$BUILD_AGENT_BASE"; then
     echo "==> Building agent-base image..."
     docker build \
         -f "${CONTEXT}/images/base/Dockerfile" \
-        -t "${REGISTRY}/nautiloop-agent-base:dev" \
+        -t "nautiloop-agent-base:dev" \
         "${CONTEXT}"
-    docker push "${REGISTRY}/nautiloop-agent-base:dev"
-    echo "    Pushed ${REGISTRY}/nautiloop-agent-base:dev"
+    echo "==> Importing nautiloop-agent-base:dev into k3d cluster..."
+    k3d image import nautiloop-agent-base:dev -c nautiloop-dev
+    echo "    Done."
 fi
 
 echo "==> Build complete."

--- a/dev/k8s/01-storage.yaml
+++ b/dev/k8s/01-storage.yaml
@@ -79,3 +79,18 @@ spec:
   resources:
     requests:
       storage: 2Gi
+---
+# Shared sccache compiler cache across all agent pods (spec #130).
+# RWO works for dev k3d since all agent pods land on the single node.
+# Prod multi-node needs RWX or sccache's S3 backend.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nautiloop-cargo-cache
+  namespace: nautiloop-jobs
+spec:
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 20Gi

--- a/dev/k8s/02-rbac.yaml
+++ b/dev/k8s/02-rbac.yaml
@@ -58,6 +58,12 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["create", "update", "get"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list", "get"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/dev/k8s/05-control-plane.yaml
+++ b/dev/k8s/05-control-plane.yaml
@@ -48,6 +48,11 @@ spec:
                 secretKeyRef:
                   name: nautiloop-git-host-token
                   key: GIT_HOST_TOKEN
+            - name: GH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: nautiloop-git-host-token
+                  key: GIT_HOST_TOKEN
             - name: BARE_REPO_PATH
               value: /bare-repo
             - name: GIT_SSH_COMMAND
@@ -151,6 +156,11 @@ spec:
                   name: nautiloop-postgres-credentials
                   key: DATABASE_URL
             - name: GIT_HOST_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: nautiloop-git-host-token
+                  key: GIT_HOST_TOKEN
+            - name: GH_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: nautiloop-git-host-token

--- a/dev/k8s/05-control-plane.yaml
+++ b/dev/k8s/05-control-plane.yaml
@@ -20,7 +20,8 @@ spec:
         fsGroup: 1000
       containers:
         - name: api-server
-          image: k3d-nautiloop-registry:5001/nautiloop-control-plane:dev
+          image: nautiloop-control-plane:dev
+          imagePullPolicy: Never
           args: ["api-server"]
           ports:
             - containerPort: 8080
@@ -120,7 +121,8 @@ spec:
         fsGroup: 1000
       containers:
         - name: loop-engine
-          image: k3d-nautiloop-registry:5001/nautiloop-control-plane:dev
+          image: nautiloop-control-plane:dev
+          imagePullPolicy: Never
           args: ["loop-engine"]
           env:
             - name: DATABASE_URL
@@ -136,7 +138,7 @@ spec:
             - name: BARE_REPO_PATH
               value: /bare-repo
             - name: AGENT_IMAGE
-              value: k3d-nautiloop-registry:5001/nautiloop-agent-base:dev
+              value: nautiloop-agent-base:dev
             - name: GIT_SSH_COMMAND
               value: "ssh -i /etc/git-ssh/id_ed25519 -o UserKnownHostsFile=/etc/git-ssh-known-hosts/known_hosts -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes"
             - name: NAUTILOOP_CONFIG_PATH
@@ -160,12 +162,6 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
-          livenessProbe:
-            exec:
-              command: ["kill", "-0", "1"]
-            initialDelaySeconds: 15
-            periodSeconds: 30
-            timeoutSeconds: 3
       volumes:
         - name: bare-repo
           persistentVolumeClaim:

--- a/dev/k8s/05-control-plane.yaml
+++ b/dev/k8s/05-control-plane.yaml
@@ -18,6 +18,13 @@ spec:
       serviceAccountName: nautiloop-api-server
       securityContext:
         fsGroup: 1000
+      initContainers:
+        - name: fix-bare-repo-perms
+          image: busybox:latest
+          command: ["sh", "-c", "chown -R 1000:1000 /bare-repo"]
+          volumeMounts:
+            - name: bare-repo
+              mountPath: /bare-repo
       containers:
         - name: api-server
           image: nautiloop-control-plane:dev
@@ -47,6 +54,12 @@ spec:
               value: "ssh -i /etc/git-ssh/id_ed25519 -o UserKnownHostsFile=/etc/git-ssh-known-hosts/known_hosts -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes"
             - name: NAUTILOOP_CONFIG_PATH
               value: /etc/nautiloop/nemo.toml
+            - name: GIT_CONFIG_COUNT
+              value: "1"
+            - name: GIT_CONFIG_KEY_0
+              value: safe.directory
+            - name: GIT_CONFIG_VALUE_0
+              value: /bare-repo
           resources:
             requests:
               cpu: 100m
@@ -119,6 +132,13 @@ spec:
       serviceAccountName: nautiloop-loop-engine
       securityContext:
         fsGroup: 1000
+      initContainers:
+        - name: fix-bare-repo-perms
+          image: busybox:latest
+          command: ["sh", "-c", "chown -R 1000:1000 /bare-repo"]
+          volumeMounts:
+            - name: bare-repo
+              mountPath: /bare-repo
       containers:
         - name: loop-engine
           image: nautiloop-control-plane:dev
@@ -143,6 +163,12 @@ spec:
               value: "ssh -i /etc/git-ssh/id_ed25519 -o UserKnownHostsFile=/etc/git-ssh-known-hosts/known_hosts -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes"
             - name: NAUTILOOP_CONFIG_PATH
               value: /etc/nautiloop/nemo.toml
+            - name: GIT_CONFIG_COUNT
+              value: "1"
+            - name: GIT_CONFIG_KEY_0
+              value: safe.directory
+            - name: GIT_CONFIG_VALUE_0
+              value: /bare-repo
           volumeMounts:
             - name: bare-repo
               mountPath: /bare-repo

--- a/dev/setup.sh
+++ b/dev/setup.sh
@@ -154,6 +154,9 @@ database_url = "postgres://nautiloop:${POSTGRES_PASSWORD}@nautiloop-postgres:543
 [models]
 implementor = "${NAUTILOOP_IMPL_MODEL:-claude-opus-4-6}"
 reviewer = "${NAUTILOOP_REVIEW_MODEL:-claude-opus-4-6}"
+
+[harden]
+auto_merge_spec_pr = false
 TOML
 )" \
     --dry-run=client -o yaml | kubectl apply -f -

--- a/dev/setup.sh
+++ b/dev/setup.sh
@@ -155,6 +155,12 @@ database_url = "postgres://nautiloop:${POSTGRES_PASSWORD}@nautiloop-postgres:543
 implementor = "${NAUTILOOP_IMPL_MODEL:-claude-opus-4-6}"
 reviewer = "${NAUTILOOP_REVIEW_MODEL:-claude-opus-4-6}"
 
+[timeouts]
+# Cold Rust compile of the nautiloop workspace can exceed the 30m default
+# when target/ is empty. Bump to 60m so the initial run completes; subsequent
+# rounds reuse the warm target cache and are much faster.
+implement_secs = 3600
+
 [harden]
 auto_merge_spec_pr = false
 TOML

--- a/dev/setup.sh
+++ b/dev/setup.sh
@@ -50,15 +50,6 @@ if [ -z "$NAUTILOOP_OPENAI_KEY" ] && [ -z "$NAUTILOOP_ANTHROPIC_KEY" ]; then
     echo "      Agent jobs will fail at model calls. Set at least one."
 fi
 
-# ── k3d registry ──────────────────────────────────────────────────────────────
-
-if k3d registry list 2>/dev/null | grep -q "nautiloop-registry"; then
-    echo "==> Registry k3d-nautiloop-registry already exists, skipping."
-else
-    echo "==> Creating k3d registry nautiloop-registry on port 5001..."
-    k3d registry create nautiloop-registry --port 5001
-fi
-
 # ── k3d cluster ───────────────────────────────────────────────────────────────
 
 if k3d cluster list 2>/dev/null | grep -q "nautiloop-dev"; then
@@ -66,7 +57,6 @@ if k3d cluster list 2>/dev/null | grep -q "nautiloop-dev"; then
 else
     echo "==> Creating k3d cluster nautiloop-dev..."
     k3d cluster create nautiloop-dev \
-        --registry-use k3d-nautiloop-registry:5001 \
         --k3s-arg "--disable=traefik@server:0" \
         --agents 0 \
         -p "18080:80@loadbalancer"
@@ -155,8 +145,8 @@ kubectl -n nautiloop-system create configmap nautiloop-config \
     --from-literal=nemo.toml="$(cat <<TOML
 [cluster]
 git_repo_url = "${NAUTILOOP_GIT_REPO_URL}"
-agent_image = "k3d-nautiloop-registry:5001/nautiloop-agent-base:dev"
-sidecar_image = "k3d-nautiloop-registry:5001/nautiloop-sidecar:dev"
+agent_image = "nautiloop-agent-base:dev"
+sidecar_image = "nautiloop-sidecar:dev"
 skip_iptables = true
 database_url = "postgres://nautiloop:${POSTGRES_PASSWORD}@nautiloop-postgres:5432/nautiloop"
 TOML
@@ -188,13 +178,9 @@ metadata:
   name: nautiloop-repo-init
   namespace: nautiloop-system
 spec:
-  backoffLimit: 3
+  backoffLimit: 0
   template:
     spec:
-      securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
       containers:
         - name: repo-init
           image: alpine/git:latest
@@ -207,16 +193,15 @@ spec:
               fi
               git -C /bare-repo remote remove origin 2>/dev/null || true
               git -C /bare-repo remote add origin "\${GIT_REPO_URL}"
-              mkdir -p "\${HOME}/.ssh"
-              cp /secrets/ssh-key/id_ed25519 "\${HOME}/.ssh/id_ed25519"
-              chmod 600 "\${HOME}/.ssh/id_ed25519"
-              cp /secrets/ssh-known-hosts/known_hosts "\${HOME}/.ssh/known_hosts"
+              cp /secrets/ssh-key/id_ed25519 /tmp/id_ed25519
+              chmod 600 /tmp/id_ed25519
               git -C /bare-repo fetch --all || echo "WARN: git fetch failed (deploy key may not be configured yet)"
+              echo "repo-init complete"
           env:
-            - name: HOME
-              value: /tmp
             - name: GIT_REPO_URL
               value: "${NAUTILOOP_GIT_REPO_URL}"
+            - name: GIT_SSH_COMMAND
+              value: "ssh -i /tmp/id_ed25519 -o UserKnownHostsFile=/secrets/ssh-known-hosts/known_hosts -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes"
           volumeMounts:
             - name: bare-repo
               mountPath: /bare-repo
@@ -237,7 +222,7 @@ spec:
         - name: ssh-known-hosts
           configMap:
             name: nautiloop-ssh-known-hosts
-      restartPolicy: OnFailure
+      restartPolicy: Never
 EOF
 
 kubectl -n nautiloop-system wait --for=condition=complete job/nautiloop-repo-init --timeout=300s || {

--- a/dev/setup.sh
+++ b/dev/setup.sh
@@ -150,6 +150,10 @@ agent_image = "nautiloop-agent-base:dev"
 sidecar_image = "nautiloop-sidecar:dev"
 skip_iptables = true
 database_url = "postgres://nautiloop:${POSTGRES_PASSWORD}@nautiloop-postgres:5432/nautiloop"
+
+[models]
+implementor = "${NAUTILOOP_IMPL_MODEL:-claude-opus-4-6}"
+reviewer = "${NAUTILOOP_REVIEW_MODEL:-claude-opus-4-6}"
 TOML
 )" \
     --dry-run=client -o yaml | kubectl apply -f -

--- a/dev/setup.sh
+++ b/dev/setup.sh
@@ -55,8 +55,9 @@ fi
 if k3d cluster list 2>/dev/null | grep -q "nautiloop-dev"; then
     echo "==> Cluster nautiloop-dev already exists, skipping creation."
 else
-    echo "==> Creating k3d cluster nautiloop-dev..."
+    echo "==> Creating k3d cluster nautiloop-dev (k3s v1.30 for native sidecar support)..."
     k3d cluster create nautiloop-dev \
+        --image rancher/k3s:v1.30.4-k3s1 \
         --k3s-arg "--disable=traefik@server:0" \
         --agents 0 \
         -p "18080:80@loadbalancer"
@@ -202,6 +203,12 @@ spec:
               value: "${NAUTILOOP_GIT_REPO_URL}"
             - name: GIT_SSH_COMMAND
               value: "ssh -i /tmp/id_ed25519 -o UserKnownHostsFile=/secrets/ssh-known-hosts/known_hosts -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes"
+            - name: GIT_CONFIG_COUNT
+              value: "1"
+            - name: GIT_CONFIG_KEY_0
+              value: safe.directory
+            - name: GIT_CONFIG_VALUE_0
+              value: "*"
           volumeMounts:
             - name: bare-repo
               mountPath: /bare-repo
@@ -231,7 +238,7 @@ kubectl -n nautiloop-system wait --for=condition=complete job/nautiloop-repo-ini
     exit 1
 }
 
-# ── Restart control plane to pick up updated secrets and config ───────────────
+# ── Restart control plane (re-runs chown init container after repo-init) ─────
 
 echo "==> Restarting control plane deployments..."
 kubectl rollout restart deployment/nautiloop-api-server deployment/nautiloop-loop-engine \

--- a/dev/smoke-test.sh
+++ b/dev/smoke-test.sh
@@ -3,12 +3,9 @@ set -euo pipefail
 
 NAUTILOOP_SERVER="${NAUTILOOP_SERVER:-http://localhost:18080}"
 ENGINEER="${NAUTILOOP_ENGINEER:-dev}"
-SPEC="${1:-$(dirname "$0")/test-spec.md}"
-
-if [ ! -f "$SPEC" ]; then
-    echo "ERROR: Spec file not found: ${SPEC}"
-    exit 1
-fi
+# SPEC is a repo-relative path read by the server from origin/main.
+# Default to the sidecar-followups spec which exists on main.
+SPEC="${1:-specs/sidecar-followups.md}"
 
 echo "==> Submitting harden job for: ${SPEC}"
 echo "    Server:   ${NAUTILOOP_SERVER}"

--- a/dev/test-spec.md
+++ b/dev/test-spec.md
@@ -1,18 +1,15 @@
-# Test: Hello World Function
+# Dev Smoke Test Spec
 
-## Goal
+## Overview
 
-Add a `hello_world()` function to the codebase that returns the string `"hello, world"`.
+Minimal spec for verifying the local dev environment end-to-end.
 
-Place the function in a new file `hello_world.rs` (or equivalent for the project's primary language) at a sensible location in the repo. If the project is a Rust workspace, add it as a public function in a suitable existing crate or a new module.
+## Task
+
+Add a comment to `dev/smoke-test.sh` explaining that it is a smoke test script.
+The comment should be on the second line of the file (after the shebang).
 
 ## Acceptance Criteria
 
-- A function named `hello_world` exists and returns the string `"hello, world"` (exact value, lowercase, with comma and space).
-- At least one test calls `hello_world()` and asserts the return value equals `"hello, world"`.
-- All existing tests continue to pass.
-- No existing files are removed or broken.
-
-## Notes
-
-This spec is intentionally trivial. Its purpose is to exercise the full nautiloop pipeline (implement, review, test stages) end-to-end without making meaningful changes to the codebase.
+- `dev/smoke-test.sh` has a comment on line 2: `# Smoke test for the local dev environment.`
+- All existing smoke test functionality is preserved.

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -82,6 +82,21 @@ RUN npm install -g @anthropic-ai/claude-code@2.1.87
 COPY --from=opencode-src /opt/opencode/opencode /usr/local/bin/opencode
 RUN chmod +x /usr/local/bin/opencode && /usr/local/bin/opencode --version
 
+# Optional: Rust toolchain for Rust-targeted repos (e.g. nautiloop itself).
+# Off by default to keep the base image lean (~200MB saved). Enable per-build
+# with `--build-arg INCLUDE_RUST=true`. Production release workflow leaves it off
+# and publishes slim; dev builds enable it so Claude can verify + commit Rust code.
+ARG INCLUDE_RUST=false
+ENV CARGO_HOME=/usr/local/cargo
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV PATH=/usr/local/cargo/bin:$PATH
+RUN if [ "$INCLUDE_RUST" = "true" ]; then \
+        set -eux; \
+        curl -fsSL https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal --no-modify-path --component clippy --component rustfmt; \
+        chmod -R a+rX "$CARGO_HOME" "$RUSTUP_HOME"; \
+        rustc --version; cargo --version; cargo clippy --version; \
+    fi
+
 # FR-4: Entrypoint script
 COPY images/base/nautiloop-agent-entry /usr/local/bin/nautiloop-agent-entry
 RUN chmod +x /usr/local/bin/nautiloop-agent-entry

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -97,6 +97,29 @@ RUN if [ "$INCLUDE_RUST" = "true" ]; then \
         rustc --version; cargo --version; cargo clippy --version; \
     fi
 
+# Spec #130: Install sccache (Rust compilation cache) alongside the Rust toolchain.
+# sccache is compiled independently by upstream as a musl binary, so it's portable.
+# With RUSTC_WRAPPER=sccache + SCCACHE_DIR=/cache/sccache, rustc outputs are cached
+# across agent pods via a shared PVC, killing the cold-compile wall (~25min → ~2min).
+ARG SCCACHE_VERSION=v0.10.0
+ARG SCCACHE_SHA256_AMD64=cf3370c249a717164a4f4e6a2b3e0da7fa41e40770cba2d4cf95f2fde6aeef4b
+ARG SCCACHE_SHA256_ARM64=f1d62a17ea091d0f34e7ee0cfed2b5d67d2c29ccd33acbad80a0af83e7b27e8f
+RUN if [ "$INCLUDE_RUST" = "true" ]; then \
+        set -eux; \
+        case "$(uname -m)" in \
+          x86_64)  arch=x86_64-unknown-linux-musl;  expected="$SCCACHE_SHA256_AMD64" ;; \
+          aarch64) arch=aarch64-unknown-linux-musl; expected="$SCCACHE_SHA256_ARM64" ;; \
+          *)       echo "Unsupported arch for sccache: $(uname -m)" >&2; exit 1 ;; \
+        esac; \
+        curl -fsSL -o /tmp/sccache.tar.gz \
+          "https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-${arch}.tar.gz"; \
+        tar -xzf /tmp/sccache.tar.gz -C /tmp; \
+        mv "/tmp/sccache-${SCCACHE_VERSION}-${arch}/sccache" /usr/local/bin/sccache; \
+        chmod +x /usr/local/bin/sccache; \
+        rm -rf /tmp/sccache.tar.gz "/tmp/sccache-${SCCACHE_VERSION}-${arch}"; \
+        /usr/local/bin/sccache --version; \
+    fi
+
 # FR-4: Entrypoint script
 COPY images/base/nautiloop-agent-entry /usr/local/bin/nautiloop-agent-entry
 RUN chmod +x /usr/local/bin/nautiloop-agent-entry

--- a/images/base/nautiloop-agent-entry
+++ b/images/base/nautiloop-agent-entry
@@ -392,6 +392,7 @@ case "$STAGE" in
         # K8s job to hit BackoffLimitExceeded. Each implement/revise pod
         # starts a fresh Claude session. Session persistence via PVC is a
         # future enhancement tracked separately.
+        echo "[${STAGE}/r${ROUND}] Starting ${STAGE} (loop ${LOOP_ID}, branch ${BRANCH})"
         STDIN_FILE="$PROMPT_FILE" run_and_emit_result "$STAGE" claude "${CLAUDE_ARGS[@]}"
         ;;
 
@@ -406,6 +407,7 @@ case "$STAGE" in
                 CLAUDE_ARGS+=(--model "$REVIEW_MODEL")
                 # No --resume: same reason as implement/revise — claude sessions
                 # live in the pod's emptyDir and don't survive across pods.
+                echo "[${STAGE}/r${ROUND}] Starting ${STAGE} with claude (loop ${LOOP_ID})"
                 STDIN_FILE="$PROMPT_FILE" run_and_emit_result "$STAGE" claude "${CLAUDE_ARGS[@]}"
                 ;;
             *)

--- a/images/base/nautiloop-agent-entry
+++ b/images/base/nautiloop-agent-entry
@@ -384,27 +384,14 @@ case "$STAGE" in
         if [ -n "${MODEL:-}" ]; then
             CLAUDE_ARGS+=(--model "$MODEL")
         fi
-        # Session IDs do not cross tool boundaries. opencode emits
-        # `ses_<20-char>` IDs; Claude Code v2.x requires UUIDs. When the
-        # loop transitions audit (opencode) -> revise (claude) and
-        # the loop engine dispatches with SESSION_ID still pointing at
-        # the audit's opencode ID, claude rejects it with:
-        #
-        #   Error: --resume requires a valid session ID when used with
-        #   --print. Session IDs must be in UUID format
-        #   (e.g., 550e8400-e29b-41d4-a716-446655440000).
-        #   Provided value "ses_28dede965ffejFSu1XlxxAiqx0" is not a
-        #   valid UUID
-        #
-        # exit 1, revise does zero work, three retries, BackoffLimitExceeded.
-        # Only pass --resume when SESSION_ID is a valid UUID (previous
-        # claude session); silently drop otherwise so the revise starts
-        # a fresh claude session, which is the right behavior for the
-        # first claude stage after an audit.
-        if [ -n "${SESSION_ID:-}" ] && \
-           printf '%s' "$SESSION_ID" | grep -Eq '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'; then
-            CLAUDE_ARGS+=(--resume "$SESSION_ID")
-        fi
+        # NOTE: We intentionally do NOT pass --resume here.
+        # Claude Code sessions are stored in the container's emptyDir volume
+        # (/home/agent/.claude) which is NOT persistent across pod boundaries.
+        # Passing --resume <uuid> from a previous pod always fails with
+        # "No conversation found with session ID: <uuid>" which causes the
+        # K8s job to hit BackoffLimitExceeded. Each implement/revise pod
+        # starts a fresh Claude session. Session persistence via PVC is a
+        # future enhancement tracked separately.
         STDIN_FILE="$PROMPT_FILE" run_and_emit_result "$STAGE" claude "${CLAUDE_ARGS[@]}"
         ;;
 
@@ -417,11 +404,8 @@ case "$STAGE" in
                 # Use Claude Code CLI for Claude models (same as implement/revise).
                 CLAUDE_ARGS=(--print --output-format stream-json --verbose --dangerously-skip-permissions)
                 CLAUDE_ARGS+=(--model "$REVIEW_MODEL")
-                # Only resume a Claude UUID session, not an opencode ses_ ID.
-                if [ -n "${SESSION_ID:-}" ] && \
-                   printf '%s' "$SESSION_ID" | grep -Eq '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'; then
-                    CLAUDE_ARGS+=(--resume "$SESSION_ID")
-                fi
+                # No --resume: same reason as implement/revise — claude sessions
+                # live in the pod's emptyDir and don't survive across pods.
                 STDIN_FILE="$PROMPT_FILE" run_and_emit_result "$STAGE" claude "${CLAUDE_ARGS[@]}"
                 ;;
             *)

--- a/images/base/nautiloop-agent-entry
+++ b/images/base/nautiloop-agent-entry
@@ -226,47 +226,53 @@ run_and_emit_result() {
             '{stage: $stage, data: $data}')
     elif [ "$cli_cmd" = "claude" ]; then
         # Claude stream-json for review/audit with a claude-* model.
-        # The audit/review prompts instruct the model to output ONLY the
-        # verdict JSON as its final message. Extract it from the last
-        # assistant event that has a text content block (skips tool_use
-        # events which also appear as type=="assistant"), pull token_usage
-        # from the final `result` event, and wrap in the ReviewResultData
-        # envelope that the loop engine parses via serde_json::from_value.
         #
-        # The text may be wrapped in markdown fences (```json ... ```)
-        # even though the prompt says not to — strip them defensively.
+        # Claude Code emits the model's final text response in the
+        # `result` event's `result` field (type=="result", subtype=="success"),
+        # not as a separate assistant text-content block. The prompt instructs
+        # the model to output only the verdict JSON, but in practice Claude
+        # often adds a preamble sentence and wraps the JSON in a markdown
+        # code fence (```json ... ```) even when told not to.
+        #
+        # Extraction strategy: find the first `{` and last `}` in the
+        # result string — this reliably isolates the JSON object regardless
+        # of surrounding text or fence wrapping.
         result=$(jq -nc \
             --arg stage "$stage_name" \
             --argjson exit_code "$exit_code" \
             --slurpfile events "$cli_stdout" \
             '
-              def strip_fences:
-                ltrimstr("```json\n") | ltrimstr("```\n") | ltrimstr("```")
-                | if endswith("```") then .[:-3] else . end
-                | ltrimstr("\n") | rtrimstr("\n");
+              def extract_json_from_result:
+                # The result field may contain preamble text + the JSON in a
+                # ```json...``` fence, or just the raw JSON object. Use split
+                # on the fence markers (not character-position arithmetic,
+                # which has jq-version-specific bugs with unicode strings).
+                if contains("```json\n") then
+                    split("```json\n")[1] |
+                    if contains("\n```") then split("\n```")[0] else . end
+                elif (contains("```\n") and contains("\n```")) then
+                    split("```\n")[1] | split("\n```")[0]
+                else
+                    ltrimstr("\n") | ltrimstr(" ")
+                end |
+                ltrimstr("\n") | rtrimstr("\n") |
+                fromjson;
 
               ($events
-                | map(select(
-                    .type == "assistant" and
-                    (.message.content | map(select(.type == "text")) | length > 0)
-                  ))
+                | map(select(.type == "result" and .subtype == "success"))
                 | last
-                | .message.content
-                | map(select(.type == "text"))
-                | last
-                | .text
-                | strip_fences
-                | fromjson
+                | .result
+                | extract_json_from_result
               ) as $verdict
               |
               ($events
-                | map(select(.type == "result"))
+                | map(select(.type == "result" and .subtype == "success"))
                 | last
                 | .usage // {}
               ) as $usage
               |
               ($events
-                | map(select(.type == "result"))
+                | map(select(.type == "result" and .subtype == "success"))
                 | last
                 | .session_id // ""
               ) as $session_id

--- a/images/base/nautiloop-agent-entry
+++ b/images/base/nautiloop-agent-entry
@@ -341,6 +341,15 @@ run_and_emit_result() {
     echo "NAUTILOOP_RESULT:$result"
 }
 
+# --- Copy Claude credentials to writable ~/.claude/ ---
+# Credentials are mounted read-only at /secrets/claude-creds/.credentials.json.
+# Claude Code (v2.x+) needs to write session-env/ and other runtime directories
+# under ~/.claude/, so we copy the credentials file into the writable home EmptyDir.
+if [ -f "/secrets/claude-creds/.credentials.json" ]; then
+    mkdir -p "${HOME}/.claude"
+    cp /secrets/claude-creds/.credentials.json "${HOME}/.claude/.credentials.json"
+fi
+
 # --- FR-4: Stage dispatch ---
 case "$STAGE" in
     implement|revise)

--- a/images/base/nautiloop-agent-entry
+++ b/images/base/nautiloop-agent-entry
@@ -336,54 +336,52 @@ case "$STAGE" in
         ;;
 
     review|audit)
-        # FR-6, FR-7: OpenCode for review/audit (read-only)
-        export OPENCODE_PERMISSIONS='{"edit":"deny","bash":"deny","read":"allow"}'
-        # Prevent opencode from auto-upgrading its binary at runtime. The image
-        # pins a specific opencode version; a self-upgrade would replace it with
-        # an untested version and void our SHA256 verification at build time.
-        # Also disable the models.dev fetch — the sidecar egress logger showed
-        # this as a ~168KB outbound call that isn't needed for headless operation.
-        export OPENCODE_DISABLE_AUTOUPDATE=1
-        export OPENCODE_DISABLE_MODELS_FETCH=1
+        # FR-6, FR-7: Cross-model review for review/audit (read-only).
+        # Route to claude CLI for claude-* models, opencode for OpenAI models.
+        REVIEW_MODEL="${MODEL:-gpt-4o-mini}"
+        case "$REVIEW_MODEL" in
+            claude-*)
+                # Use Claude Code CLI for Claude models (same as implement/revise).
+                CLAUDE_ARGS=(--print --output-format stream-json --verbose --dangerously-skip-permissions)
+                CLAUDE_ARGS+=(--model "$REVIEW_MODEL")
+                # Only resume a Claude UUID session, not an opencode ses_ ID.
+                if [ -n "${SESSION_ID:-}" ] && \
+                   printf '%s' "$SESSION_ID" | grep -Eq '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'; then
+                    CLAUDE_ARGS+=(--resume "$SESSION_ID")
+                fi
+                STDIN_FILE="$PROMPT_FILE" run_and_emit_result "$STAGE" claude "${CLAUDE_ARGS[@]}"
+                ;;
+            *)
+                # Use OpenCode for OpenAI (and other) models.
+                export OPENCODE_PERMISSIONS='{"edit":"deny","bash":"deny","read":"allow"}'
+                export OPENCODE_DISABLE_AUTOUPDATE=1
+                export OPENCODE_DISABLE_MODELS_FETCH=1
 
-        # Pin the provider to `openai` so opencode routes through the sidecar
-        # model proxy (OPENAI_BASE_URL=http://localhost:9090/openai) instead
-        # of falling back to its built-in `opencode/*` models that go to the
-        # opencode.ai hosted backend with unknown billing. See issue #62.
-        #
-        # opencode expects `-m provider/model`. If MODEL is unset or doesn't
-        # contain a provider prefix, we prepend `openai/`. If it already has
-        # a prefix (e.g. user explicitly set `anthropic/...`), pass through.
-        # If MODEL is entirely unset, default to a cheap OpenAI model so the
-        # reviewer doesn't silently fall back to a nondeterministic default.
-        OPENCODE_MODEL="${MODEL:-gpt-4o-mini}"
-        case "$OPENCODE_MODEL" in
-            */*) ;;                                          # already has provider prefix
-            claude-*) OPENCODE_MODEL="anthropic/$OPENCODE_MODEL" ;;  # Anthropic models
-            *) OPENCODE_MODEL="openai/$OPENCODE_MODEL" ;;            # default: OpenAI
-        esac
+                # Pin the provider to `openai` so opencode routes through the sidecar
+                # model proxy (OPENAI_BASE_URL=http://localhost:9090/openai) instead
+                # of falling back to its built-in `opencode/*` models that go to the
+                # opencode.ai hosted backend with unknown billing. See issue #62.
+                case "$REVIEW_MODEL" in
+                    */*) OPENCODE_MODEL="$REVIEW_MODEL" ;;
+                    *) OPENCODE_MODEL="openai/$REVIEW_MODEL" ;;
+                esac
 
-        # opencode v1.3+ removed --prompt-file; the message must be passed as a
-        # positional arg. opencode run does NOT accept piped input via stdin.
-        # We read the prompt file and pass it as the message argument.
-        # Truncate to ~100KB to avoid ARG_MAX issues (opencode has limits anyway).
-        OPENCODE_ARGS=(run --format json -m "$OPENCODE_MODEL")
-        # Symmetric with the claude branch: only resume when SESSION_ID
-        # looks like an opencode session (`ses_<chars>`), not a claude
-        # UUID carried over from a previous revise. See the matching
-        # comment in the implement|revise branch.
-        if [ -n "${SESSION_ID:-}" ] && \
-           printf '%s' "$SESSION_ID" | grep -Eq '^ses_[a-zA-Z0-9]+$'; then
-            OPENCODE_ARGS+=(-s "$SESSION_ID")
-        fi
-        # Read prompt and truncate if extremely large to avoid ARG_MAX
-        PROMPT_CONTENT=$(cat "$PROMPT_FILE")
-        if [ "${#PROMPT_CONTENT}" -gt 100000 ]; then
-            PROMPT_CONTENT="${PROMPT_CONTENT:0:100000}
+                OPENCODE_ARGS=(run --format json -m "$OPENCODE_MODEL")
+                # Only resume an opencode ses_ session, not a Claude UUID.
+                if [ -n "${SESSION_ID:-}" ] && \
+                   printf '%s' "$SESSION_ID" | grep -Eq '^ses_[a-zA-Z0-9]+$'; then
+                    OPENCODE_ARGS+=(-s "$SESSION_ID")
+                fi
+                # Read prompt and truncate if extremely large to avoid ARG_MAX
+                PROMPT_CONTENT=$(cat "$PROMPT_FILE")
+                if [ "${#PROMPT_CONTENT}" -gt 100000 ]; then
+                    PROMPT_CONTENT="${PROMPT_CONTENT:0:100000}
 
 ...[truncated: prompt exceeded 100KB limit]"
-        fi
-        run_and_emit_result "$STAGE" opencode "${OPENCODE_ARGS[@]}" "$PROMPT_CONTENT"
+                fi
+                run_and_emit_result "$STAGE" opencode "${OPENCODE_ARGS[@]}" "$PROMPT_CONTENT"
+                ;;
+        esac
         ;;
 
     test)

--- a/images/base/nautiloop-agent-entry
+++ b/images/base/nautiloop-agent-entry
@@ -450,6 +450,15 @@ case "$STAGE" in
             exit 1
         fi
 
+        # If no services to test (empty array), emit a passed result immediately.
+        # This handles repos with no [services] configured in nemo.toml.
+        if [ "$(echo "$AFFECTED_SERVICES" | jq 'length')" -eq 0 ]; then
+            RESULT_ENVELOPE='{"stage":"test","data":{"services":[],"all_passed":true,"ci_status":"passed","token_usage":{"input":0,"output":0}}}'
+            echo "$RESULT_ENVELOPE" > /output/result.json
+            echo "NAUTILOOP_RESULT:$RESULT_ENVELOPE"
+            exit 0
+        fi
+
         # FR-42b: Read test commands from nemo.toml
         TOML_FILE="/work/nemo.toml"
         if [ ! -f "$TOML_FILE" ]; then

--- a/images/base/nautiloop-agent-entry
+++ b/images/base/nautiloop-agent-entry
@@ -114,6 +114,7 @@ check_sidecar() {
 run_and_emit_result() {
     local stage_name="$1"
     shift
+    local cli_cmd="$1"  # claude or opencode — used for extraction dispatch below
     local cli_stdout="/tmp/cli-stdout-$$"
     local cli_stderr="/tmp/cli-stderr-$$"
     local exit_code=0
@@ -213,6 +214,7 @@ run_and_emit_result() {
     # engine logs "No NAUTILOOP_RESULT line found in pod logs" and retries.
     local result
     if [ "$stage_name" = "implement" ] || [ "$stage_name" = "revise" ]; then
+        # Claude stream-json: keep the last assistant event object as data.
         result=$(jq -nc \
             --arg stage "$stage_name" \
             --slurpfile events "$cli_stdout" \
@@ -222,7 +224,72 @@ run_and_emit_result() {
             --arg stage "$stage_name" \
             --rawfile data "$cli_stdout" \
             '{stage: $stage, data: $data}')
+    elif [ "$cli_cmd" = "claude" ]; then
+        # Claude stream-json for review/audit with a claude-* model.
+        # The audit/review prompts instruct the model to output ONLY the
+        # verdict JSON as its final message. Extract it from the last
+        # assistant event that has a text content block (skips tool_use
+        # events which also appear as type=="assistant"), pull token_usage
+        # from the final `result` event, and wrap in the ReviewResultData
+        # envelope that the loop engine parses via serde_json::from_value.
+        #
+        # The text may be wrapped in markdown fences (```json ... ```)
+        # even though the prompt says not to — strip them defensively.
+        result=$(jq -nc \
+            --arg stage "$stage_name" \
+            --argjson exit_code "$exit_code" \
+            --slurpfile events "$cli_stdout" \
+            '
+              def strip_fences:
+                ltrimstr("```json\n") | ltrimstr("```\n") | ltrimstr("```")
+                | if endswith("```") then .[:-3] else . end
+                | ltrimstr("\n") | rtrimstr("\n");
+
+              ($events
+                | map(select(
+                    .type == "assistant" and
+                    (.message.content | map(select(.type == "text")) | length > 0)
+                  ))
+                | last
+                | .message.content
+                | map(select(.type == "text"))
+                | last
+                | .text
+                | strip_fences
+                | fromjson
+              ) as $verdict
+              |
+              ($events
+                | map(select(.type == "result"))
+                | last
+                | .usage // {}
+              ) as $usage
+              |
+              ($events
+                | map(select(.type == "result"))
+                | last
+                | .session_id // ""
+              ) as $session_id
+              |
+              {
+                stage: $stage,
+                data: {
+                  verdict: $verdict,
+                  token_usage: {
+                    input:  ($usage.input_tokens  // 0),
+                    output: ($usage.output_tokens // 0)
+                  },
+                  exit_code: $exit_code,
+                  session_id: $session_id
+                }
+              }
+            ' 2>/dev/null) || \
+        result=$(jq -nc \
+            --arg stage "$stage_name" \
+            --rawfile data "$cli_stdout" \
+            '{stage: $stage, data: $data}')
     else
+        # OpenCode streaming JSON for review/audit with an OpenAI model.
         result=$(jq -nc \
             --arg stage "$stage_name" \
             --argjson exit_code "$exit_code" \

--- a/terraform/modules/nautiloop/.terraform.lock.hcl
+++ b/terraform/modules/nautiloop/.terraform.lock.hcl
@@ -1,0 +1,82 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.8.0"
+  constraints = "~> 2.4"
+  hashes = [
+    "h1:3jWHVwO5QUIS9V1NsK10ZzdpkK2ABuB4G+UIWrVeGp4=",
+    "zh:05f18164beab4a84753e5fedf463771ee0c6eca8e90346b8766f1e1c186dec1e",
+    "zh:563a0702e3711e25ba8930120899b681378b50cbb957fd204b37745c7c9b5f40",
+    "zh:5b56ab2ed70ed92721febb4a070af0837f1084c44825c18e4b95f7efb1d45d26",
+    "zh:6cbedc09b67a5cdb9501ff1b18a315fa46a38e0530424cab1c7f4b3acc75f489",
+    "zh:71b3bd50f89fb385a42a436ba2ce2b8e00f9de53535ce956deff1477b0b117dc",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9d45ac0a00b85cabdd398b859349d17f124c598b6e6bf272f1bb01321ce708a8",
+    "zh:a453efe8641a8f31fe806b597bf2b34d7b78b971a8e3919061ea89d61fda7b8d",
+    "zh:ac692bacb8c3dca8b5b37e5383168aca1f87d3cd7b40615efd300defb76494f5",
+    "zh:bda9e90c8547d90c9c573206985c5675cc1406047605af037a5069942c3c5966",
+    "zh:c30a1967de040d00f5038086dd53cdbfb78cc05d1dbc75037410f011bf2a20d8",
+    "zh:c80bbd1c3f56b3c836d80cf93ac0e8809305c2642f0c98b54bf5d05d3b12718c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.2.4"
+  constraints = "~> 3.2"
+  hashes = [
+    "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
+    "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",
+    "zh:7b9c7b16f118fbc2b05a983817b8ce2f86df125857966ad356353baf4bff5c0a",
+    "zh:85e33ab43e0e1726e5f97a874b8e24820b6565ff8076523cc2922ba671492991",
+    "zh:9d32ac3619cfc93eb3c4f423492a8e0f79db05fec58e449dee9b2d5873d5f69f",
+    "zh:9e15c3c9dd8e0d1e3731841d44c34571b6c97f5b95e8296a45318b94e5287a6e",
+    "zh:b4c2ab35d1b7696c30b64bf2c0f3a62329107bd1a9121ce70683dec58af19615",
+    "zh:c43723e8cc65bcdf5e0c92581dcbbdcbdcf18b8d2037406a5f2033b1e22de442",
+    "zh:ceb5495d9c31bfb299d246ab333f08c7fb0d67a4f82681fbf47f2a21c3e11ab5",
+    "zh:e171026b3659305c558d9804062762d168f50ba02b88b231d20ec99578a6233f",
+    "zh:ed0fe2acdb61330b01841fa790be00ec6beaac91d41f311fb8254f74eb6a711f",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.8.1"
+  constraints = "~> 3.6"
+  hashes = [
+    "h1:u8AKlWVDTH5r9YLSeswoVEjiY72Rt4/ch7U+61ZDkiQ=",
+    "zh:08dd03b918c7b55713026037c5400c48af5b9f468f483463321bd18e17b907b4",
+    "zh:0eee654a5542dc1d41920bbf2419032d6f0d5625b03bd81339e5b33394a3e0ae",
+    "zh:229665ddf060aa0ed315597908483eee5b818a17d09b6417a0f52fd9405c4f57",
+    "zh:2469d2e48f28076254a2a3fc327f184914566d9e40c5780b8d96ebf7205f8bc0",
+    "zh:37d7eb334d9561f335e748280f5535a384a88675af9a9eac439d4cfd663bcb66",
+    "zh:741101426a2f2c52dee37122f0f4a2f2d6af6d852cb1db634480a86398fa3511",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a902473f08ef8df62cfe6116bd6c157070a93f66622384300de235a533e9d4a9",
+    "zh:b85c511a23e57a2147355932b3b6dce2a11e856b941165793a0c3d7578d94d05",
+    "zh:c5172226d18eaac95b1daac80172287b69d4ce32750c82ad77fa0768be4ea4b8",
+    "zh:dab4434dba34aad569b0bc243c2d3f3ff86dd7740def373f2a49816bd2ff819b",
+    "zh:f49fd62aa8c5525a5c17abd51e27ca5e213881d58882fd42fec4a545b53c9699",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.2.1"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:akFNuHwvrtnYMBofieoeXhPJDhYZzJVu/Q/BgZK2fgg=",
+    "zh:0d1e7d07ac973b97fa228f46596c800de830820506ee145626f079dd6bbf8d8a",
+    "zh:5c7e3d4348cb4861ab812973ef493814a4b224bdd3e9d534a7c8a7c992382b86",
+    "zh:7c6d4a86cd7a4e9c1025c6b3a3a6a45dea202af85d870cddbab455fb1bd568ad",
+    "zh:7d0864755ba093664c4b2c07c045d3f5e3d7c799dda1a3ef33d17ed1ac563191",
+    "zh:83734f57950ab67c0d6a87babdb3f13c908cbe0a48949333f489698532e1391b",
+    "zh:951e3c285218ebca0cf20eaa4265020b4ef042fea9c6ade115ad1558cfe459e5",
+    "zh:b9543955b4297e1d93b85900854891c0e645d936d8285a190030475379c5c635",
+    "zh:bb1bd9e86c003d08c30c1b00d44118ed5bbbf6b1d2d6f7eaac4fa5c6ebea5933",
+    "zh:c9477bfe00653629cd77ddac3968475f7ad93ac3ca8bc45b56d1d9efb25e4a6e",
+    "zh:d4cfda8687f736d0cba664c22ec49dae1188289e214ef57f5afe6a7217854fed",
+    "zh:dc77ee066cf96532a48f0578c35b1eaf6dc4d8ddd0e3ae8e029a3b10676dd5d3",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform/modules/nautiloop/k8s.tf
+++ b/terraform/modules/nautiloop/k8s.tf
@@ -100,6 +100,20 @@ spec:
     requests:
       storage: 10Gi
 ---
+# Spec #130: Shared sccache compiler cache across all agent pods.
+# Single-node self-hosted clusters use RWO; multi-node needs RWX
+# (or sccache's S3 backend, not yet implemented).
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nautiloop-cargo-cache
+  namespace: nautiloop-jobs
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: ${var.cargo_cache_volume_size}Gi
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/terraform/modules/nautiloop/variables.tf
+++ b/terraform/modules/nautiloop/variables.tf
@@ -131,6 +131,12 @@ variable "postgres_volume_size" {
   default     = 20
 }
 
+variable "cargo_cache_volume_size" {
+  description = "Size of the shared sccache compiler cache volume in Gi (spec #130). Larger than sccache max-size for headroom."
+  type        = number
+  default     = 50
+}
+
 variable "kubeconfig_output_path" {
   description = "Path to write the generated kubeconfig. If null, writes to <module>/.state/kubeconfig.yaml."
   type        = string


### PR DESCRIPTION
## Summary

Three related convergence-robustness changes bundled:

1. **Reviewer/auditor prompts tightened** — `clean: true` requires no critical/high/medium issues. Low severity is explicitly allowed (lists nits visibly without blocking). Fixes the self-contradictory "clean with 2 medium issues" pattern observed in PR #134.

2. **`nemo extend` command** — when a loop hits `Max rounds exceeded` FAILED state, `nemo extend <id> --add 10` bumps max_rounds and resumes the loop from the stage it was on. No more restart-from-scratch pain. Driver now sets `failed_from_state` on max_rounds failures so the resume path works.

3. **Default `max_rounds_implement` bumped 15 → 20** — matches observed practice. Repos can still override in nemo.toml.

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (142+ tests)
- [ ] Manually: `nemo extend <failed-loop-id> --add 5` bumps max_rounds and the loop resumes at the last stage
- [ ] New loops default to max_rounds_implement=20 without any nemo.toml change