### PR TITLE
chore: release 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-control-plane"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2353,7 +2353,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-sidecar"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2413,7 +2413,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-cli"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["control-plane", "cli", "sidecar", "sidecar/tests/parity"]
 
 [workspace.package]
-version = "0.4.9"
+version = "0.5.0"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -57,9 +57,9 @@ module "nautiloop" {
   acme_email = "me@mydomain.com"     # required if domain is set
 
   # Optional: images (defaults to latest public GHCR)
-  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.9"
-  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.9"
-  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.9"
+  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.5.0"
+  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.5.0"
+  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.5.0"
 }
 ```
 
@@ -75,9 +75,9 @@ module "nautiloop" {
 | `repo_ssh_private_key` | no | auto-generated | SSH deploy key. If null, generates ED25519 |
 | `domain` | no | `null` | Domain for TLS. null = HTTP on raw IP:8080 |
 | `acme_email` | no | `null` | Let's Encrypt email. Required if domain is set |
-| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.9` | Control plane image |
-| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.9` | Agent base image |
-| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.9` | Auth sidecar image |
+| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.5.0` | Control plane image |
+| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.5.0` | Agent base image |
+| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.5.0` | Auth sidecar image |
 | `k3s_version` | no | `v1.32.13+k3s1` | k3s version (v1.32+ required) |
 | `postgres_password` | no | auto-generated | Postgres password |
 | `postgres_volume_size` | no | `20` | Postgres volume size (Gi) |
@@ -175,9 +175,9 @@ nemo auth                    # pushes credentials (Claude, OpenAI, SSH) to clust
 ```bash
 ./build-images.sh --tag 0.2.0
 terraform apply \
-  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.9" \
-  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.9" \
-  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.9"
+  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.5.0" \
+  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.5.0" \
+  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.5.0"
 ```
 
 All three images must be updated together to avoid version skew.

--- a/terraform/examples/existing-server/variables.tf
+++ b/terraform/examples/existing-server/variables.tf
@@ -50,17 +50,17 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.9"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.5.0"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.9"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.5.0"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.9"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.5.0"
 }

--- a/terraform/examples/hetzner/variables.tf
+++ b/terraform/examples/hetzner/variables.tf
@@ -77,19 +77,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.9"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.5.0"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.9"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.5.0"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.9"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.5.0"
 }
 
 variable "k3s_version" {

--- a/terraform/modules/nautiloop/variables.tf
+++ b/terraform/modules/nautiloop/variables.tf
@@ -79,19 +79,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.9"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.5.0"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.9"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.5.0"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.9"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.5.0"
 }
 
 # --- Optional: tuning ---

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -71,19 +71,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.4.9"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.5.0"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.4.9"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.5.0"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.4.9"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.5.0"
 }
 
 variable "k3s_version" {


### PR DESCRIPTION
## Summary

Major session shipping the dogfood loop end-to-end. Nautiloop produced its own first convergent PRs against its own codebase, validating the full implement → test → review → clean → PR path.

## Infrastructure / core fixes

- **SSE log stream:** `UNIX_EPOCH` cursor fixes "timestamp out of range" reconnect loops — `nemo helm` and `nemo logs` now stream live
- **Claude credentials:** mounted at `/secrets/claude-creds/` (read-only), entrypoint copies to writable `~/.claude/` so Claude Code can create `session-env/`
- **Test stage:** `AFFECTED_SERVICES` injected on retries via `redispatch_current_stage`; skips nemo.toml check when repo has no services
- **Empty-commit PR guard** on review convergence path — catches fake-SHA outputs and fails cleanly instead of retrying forever
- **Agent pod:** full bare-repo mounted at `/bare-repo` so the worktree `.git` pointer file can resolve `gitdir:` path
- **Rust toolchain** gated in agent image via `INCLUDE_RUST=true` build-arg; dev builds opt in, prod stays lean

## Features

- **Local dev environment** on k3d with full quickstart guide (#132, #133)
- **Shared sccache** compiler cache PVC + terraform variable — cold Rust compile ~25min → warm ~2min (#132)
- **`nemo extend`** — bump max_rounds on FAILED loops, resume at last stage (#135)
- **Stricter reviewer prompts** — `clean: true` requires no critical/high/medium issues (#135)
- **Default `max_rounds_implement`** bumped 15 → 20 (#135)

## Specs implemented by nautiloop-on-nautiloop

Four specs dogfooded through the convergence loop today, each producing a real PR against this repo:

- #131 — Health JSON body (first successful convergence, 2 rounds)
- #134 — Helm TUI polish: scrollback, compressed summaries, timestamps (5 rounds)
- #136 — Local spec upload: draft locally without pre-merging to main (12 rounds)
- #137 — Pod live introspection: `nemo ps` + helm pane + `/pod-introspect` endpoint (15 rounds)

## Specs landed on main for future work

- #128 Orchestrator judge (re-run post-merge because of rebase conflicts)
- #139 Helm TUI phase 2: cost/header/actions/diff/themes

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (180+ tests)
- [x] Full end-to-end convergence verified against own codebase (4 specs, PRs #134/#136/#137/#138)
- [x] Release workflow triggers container + binary builds on tag push