### PR TITLE
fix(git): skip spec commit when it would be a no-op

### DIFF
--- a/control-plane/src/git/mod.rs
+++ b/control-plane/src/git/mod.rs
@@ -196,6 +196,23 @@ pub mod bare {
                 )));
             }
 
+            // If nothing is staged (spec content is identical to what's already in the
+            // branch), skip the commit entirely. This happens when an engineer submits a
+            // spec that already exists on main unchanged — the branch already has the
+            // content, no-op commit would exit non-zero with an empty stderr.
+            let diff_check = Command::new("git")
+                .args(["diff", "--cached", "--quiet"])
+                .current_dir(worktree_dir)
+                .status()
+                .await
+                .map_err(|e| {
+                    crate::error::NautiloopError::Git(format!("git diff --cached spawn failed: {e}"))
+                })?;
+            if diff_check.success() {
+                // Exit 0 from `git diff --cached --quiet` means no staged changes.
+                return Ok(());
+            }
+
             let user_name_arg = format!("user.name={author_name}");
             let user_email_arg = format!("user.email={author_email}");
             let commit = Command::new("git")


### PR DESCRIPTION
When `nemo start` is invoked with a spec that already exists on main with identical content, the local-spec-upload flow tries to commit the unchanged content and `git commit` exits non-zero with empty stderr. Guard with `git diff --cached --quiet` — if nothing staged, skip commit cleanly. Caught by smoke test on v0.5.0.