### PR TITLE
docs(spec): dashboard CTO kit (FR-9 through FR-14)

### DIFF
--- a/specs/mobile-dashboard.md
+++ b/specs/mobile-dashboard.md
@@ -147,7 +147,93 @@ Chips are independent: selecting `Active` + `alice` shows Alice's active loops. 
 
 **FR-8c.** `/dashboard/state` is auth-protected same as other `/dashboard/*` routes.
 
-## Non-Functional Requirements
+### FR-9: CTO kit — fleet summary header
+
+**FR-9a.** Top of the dashboard (above the card grid) renders a single-line **fleet summary**, always visible:
+
+```
+This week · 47 loops · $12.40 · 82% converged · avg 4.2 rounds · top: alice ($4.80)
+```
+
+Aggregates all non-terminal + terminal loops in the rolling 7-day window. Fields:
+- `N loops` — total loops created in window
+- `$X.XX` — total token cost (summed from per-round `token_usage` × `[pricing]`)
+- `X% converged` — (CONVERGED + HARDENED + SHIPPED) / total_terminal. Excludes still-active loops from the denominator.
+- `avg N.N rounds` — mean rounds-to-termination across terminal loops
+- `top: <engineer> ($X.XX)` — highest-spender this window
+
+**FR-9b.** A subtle trend indicator after each numeric field when a prior-period comparison is available: `82% ↑8% converged` means 8 percentage points higher than the prior 7-day window. First week of data has no trend; don't render the arrow.
+
+**FR-9c.** Tapping any field of the summary navigates to `/dashboard/stats` (FR-12) with that field pre-focused.
+
+### FR-10: Kill switch
+
+**FR-10a.** A hidden-by-default `⋯` menu in the header has a destructive `Cancel all active loops` item. Tapping opens a modal: `Cancel N active loops? This cannot be undone.` Two buttons: `Cancel` (aborts) / `Confirm cancel all` (proceeds).
+
+**FR-10b.** On confirm, the dashboard issues `DELETE /cancel/:id` for every active (non-terminal) loop in parallel. Reports `Cancelled N/M loops` in the status bar; failures (rare — usually a race with a loop terminating naturally) are listed with their reasons.
+
+**FR-10c.** Rationale: the dashboard exists precisely because the CTO is AFK. If cost is spiking, credentials are suspected compromised, or a bug is producing runaway loops, the kill switch needs to be one tap from the phone. No new server endpoint; the dashboard fans out to the existing per-loop cancel.
+
+**FR-10d.** The kill switch is gated behind the `team` toggle (only visible when viewing team mode, NOT in `Mine`). Prevents muscle-memory mis-taps when browsing one's own loops.
+
+### FR-11: Judge reasoning pane
+
+**FR-11a.** Once the orchestrator-judge feature (#128) is implemented and `judge_decisions` rows exist, the loop detail view surfaces them inline:
+
+- In the rounds table (FR-4a), any round where the judge fired gets a small gavel icon (`⚖`) in the Verdict column.
+- Tapping the icon opens a detail drawer showing: `decision`, `confidence`, `reasoning` (human-readable), and (if set) the `hint` that was injected into the next round's feedback.
+- A dedicated `/dashboard/loops/:id/judge` tab (or accordion) shows the full sequence of judge decisions for the loop end-to-end.
+
+**FR-11b.** If `judge_decisions` is empty or the feature isn't yet shipped, the gavel icon + tab simply aren't rendered. No error, no placeholder — the UI degrades silently, so this spec can land before or after #128 without a sequencing constraint.
+
+**FR-11c.** Critical for CTO trust: when the judge overrides a reviewer's "not clean" with `exit_clean`, the CTO should be able to tap through to the reasoning in two taps. Opaque ML decisions are the fastest way to lose stakeholder confidence in an autonomous loop.
+
+### FR-12: Notification feed
+
+**FR-12a.** New route `/dashboard/feed` renders a chronological, reverse-time list of terminal events across all loops:
+
+```
+15:47 · alice · health-json-body      CONVERGED  PR #147  2 rounds  $0.18
+14:23 · bob   · schema-migration      FAILED     max rounds  15 rounds  $1.24
+13:05 · alice · helm-tui-phase2       CONVERGED  PR #145  4 rounds  $0.42
+12:40 · dev   · orchestrator-judge-v2 CONVERGED  PR #144  15 rounds  $3.10 [extended ×1]
+```
+
+Each row is tappable → navigates to the loop detail page.
+
+**FR-12b.** Filters at the top: `All events` / `Converged only` / `Failed only` / per-engineer. Persists selection in localStorage across visits.
+
+**FR-12c.** Pagination: loads the 50 most recent; `Load more` button at the bottom fetches the next 50. Backed by a new endpoint `GET /dashboard/feed?cursor=<timestamp>&limit=50` that returns terminal loops ordered by `updated_at DESC`.
+
+**FR-12d.** This is the CTO's morning-coffee surface: skim, see what shipped overnight, note what failed, close the tab. Must load in under a second on a mobile connection.
+
+### FR-13: Per-spec history
+
+**FR-13a.** In the loop detail view, the spec filename is a link. Tapping navigates to `/dashboard/specs/<path>` which shows all past loops that ran on that spec:
+
+| Date | Engineer | Result | Rounds | Cost | Branch |
+|---|---|---|---|---|---|
+| 2026-04-18 15:47 | alice | CONVERGED | 2 | $0.18 | agent/alice/health-json-body-a1b2c3d4 |
+| 2026-04-18 11:05 | dev | FAILED | 15 | $1.24 | agent/dev/health-json-body-e5f6g7h8 |
+| 2026-04-17 22:21 | dev | CONVERGED | 15 | $3.10 | agent/dev/health-json-body-db6530fc |
+
+Plus aggregates at the top: `3 runs · 67% converge rate · avg 10.7 rounds · total cost $4.52`.
+
+**FR-13b.** Backed by a new endpoint `GET /dashboard/specs?path=<>&limit=50` returning loops filtered by `spec_path`. Existing schema already has `spec_path`, no migration.
+
+**FR-13c.** Use case: a spec that fails 3x in a row or consistently takes 15 rounds is a spec-quality problem, not an implementor problem. Visibility surfaces this. Helps engineers tighten specs before submitting again.
+
+### FR-14: Stats deep-dive page
+
+**FR-14a.** `/dashboard/stats` — a single page with the expanded view of the FR-9 summary:
+- **Headline cards**: total loops, total cost, converge rate, avg rounds — for the current window (7d default, toggleable: 24h / 7d / 30d).
+- **Per-engineer table**: engineer, loops, cost, converge rate.
+- **Per-spec table**: top 10 most-run specs with their aggregate metrics.
+- **Time series**: daily count of loops started vs terminal outcomes, rendered as simple CSS-width bars (no chart library — consistent with FR-7b).
+
+**FR-14b.** Backed by a single aggregation endpoint `GET /dashboard/stats?window=7d` returning a structured JSON that the template consumes. No new DB migrations; all data derivable from existing `loops` + `rounds` tables.
+
+**FR-14c.** Cache-friendly: the aggregation is expensive relative to the rest of the dashboard, so the endpoint caches results for 60s server-side (the time-window granularity makes this trivially safe).
 
 ### NFR-1: Security inherits from deployment
 
@@ -188,6 +274,12 @@ A reviewer can verify by:
 7. Leave dashboard open, switch apps, come back. Polling resumed, state is current.
 8. Toggle device to dark mode. Dashboard flips palette.
 9. Curl `/dashboard` with no cookie → 302 to login. With a bad cookie → login with error. With a good cookie → 200 HTML.
+10. Fleet summary (FR-9) at top shows a single-line this-week roll-up; numbers reconcile with manually-computed aggregates from `/inspect` on each loop in window.
+11. `⋯` menu → `Cancel all active loops` (FR-10). Modal confirms; on proceed, N cancel requests fire and complete within 10s. Hidden in `Mine` mode.
+12. For any loop where the judge fired (post-#128), rounds table shows ⚖ icon on those rows (FR-11). Tapping opens reasoning drawer.
+13. `/dashboard/feed` (FR-12) shows chronological terminal events with engineer + outcome + cost. Filter chips work. `Load more` paginates.
+14. Tap a spec filename on any loop detail page → `/dashboard/specs/<path>` (FR-13). Shows all past runs + aggregate metrics.
+15. `/dashboard/stats?window=30d` (FR-14) renders per-engineer + per-spec tables + daily time-series bars. Subsequent loads within 60s hit the cache (observe response time).
 
 ## Out of Scope
 
@@ -195,7 +287,8 @@ A reviewer can verify by:
 - **User accounts with password / SSO / SAML.** Not in v1. Tailscale + shared API key is the model.
 - **Push notifications** (web push, SMS, Slack). Future spec; dashboard v1 is a pull-to-refresh world.
 - **Spec editor / upload via web.** Specs live in the repo; the dashboard is observation + light actions.
-- **Historical analytics** (convergence over time, cost per engineer per week). Separate spec once the data is accumulated.
+<!-- Historical analytics now IN scope via FR-14 stats deep-dive. -->
+- **Anomaly detection / alerting** (auto-page on-call when cost spikes or convergence rate drops). Out of v1; FR-12 feed covers the manual-pull version.
 - **WebSocket upgrade for general state** (beyond the existing SSE for logs). Polling is sufficient and simpler.
 - **Fancy charts / D3 / visualization libraries.** One optional bar chart (token/cost breakdown), rendered as plain `<div>` bars with CSS widths. No chart library.
 - **Offline support / PWA / service worker.** Maybe later; not required.
@@ -208,7 +301,10 @@ A reviewer can verify by:
 - `control-plane/src/api/dashboard/mod.rs` — new module.
 - `control-plane/src/api/dashboard/handlers.rs` — per-route handlers.
 - `control-plane/src/api/dashboard/auth.rs` — cookie middleware.
-- `control-plane/src/api/dashboard/aggregate.rs` — `/dashboard/state` roll-up builder.
+- `control-plane/src/api/dashboard/aggregate.rs` — `/dashboard/state` roll-up + FR-9 fleet summary + FR-14 stats aggregator (with 60s cache).
+- `control-plane/src/api/dashboard/feed.rs` — FR-12 notification feed endpoint.
+- `control-plane/src/api/dashboard/specs.rs` — FR-13 per-spec history endpoint.
+- `control-plane/src/api/dashboard/kill_switch.rs` — FR-10 fan-out cancel helper.
 - `control-plane/src/api/dashboard/templates/` — new dir, Askama `.html` templates (or `maud!{}` macros in `.rs` files).
 - `control-plane/assets/dashboard.css` — embedded via `include_str!`.
 - `control-plane/assets/dashboard.js` — embedded via `include_str!`.


### PR DESCRIPTION
Adds 6 new FRs to the mobile dashboard spec. Fleet summary header (FR-9), kill switch gated to team mode (FR-10), judge reasoning pane graceful-degrading until #128 lands (FR-11), notification feed for async catch-up (FR-12), per-spec history for churn detection (FR-13), stats deep-dive at /dashboard/stats (FR-14). Makes the dashboard actually useful for a CTO's birds-eye-view-on-the-go workflow rather than just an alternate rendering of nemo helm.