### PR TITLE
fix(cli): nemo auth --claude prefers fresh keychain over stale disk

### DIFF
--- a/cli/src/claude_creds.rs
+++ b/cli/src/claude_creds.rs
@@ -98,7 +98,7 @@ pub fn is_stale(path: &Path, now_ms: u64) -> bool {
 /// Decide whether a raw Claude credential JSON string represents a
 /// stale bundle. Shared between disk and keychain checks so both
 /// sources apply the same freshness rule.
-fn is_bundle_stale(contents: &str, now_ms: u64) -> bool {
+pub fn is_bundle_stale(contents: &str, now_ms: u64) -> bool {
     let Ok(parsed) = serde_json::from_str::<ClaudeCredentialsShape>(contents) else {
         return true;
     };
@@ -109,7 +109,7 @@ fn is_bundle_stale(contents: &str, now_ms: u64) -> bool {
     expires_at.saturating_sub(buffer_ms) <= now_ms
 }
 
-fn now_ms() -> u64 {
+pub fn now_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
@@ -120,7 +120,7 @@ fn now_ms() -> u64 {
 /// Returns None on non-macOS platforms or when the keychain entry
 /// isn't present.
 #[cfg(target_os = "macos")]
-fn extract_from_keychain() -> Option<String> {
+pub fn extract_from_keychain() -> Option<String> {
     let output = std::process::Command::new("security")
         .args([
             "find-generic-password",
@@ -143,7 +143,7 @@ fn extract_from_keychain() -> Option<String> {
 }
 
 #[cfg(not(target_os = "macos"))]
-fn extract_from_keychain() -> Option<String> {
+pub fn extract_from_keychain() -> Option<String> {
     None
 }
 

--- a/cli/src/commands/auth.rs
+++ b/cli/src/commands/auth.rs
@@ -108,13 +108,51 @@ pub async fn run(
             continue;
         }
 
-        // Read the credential file
-        let content = match std::fs::read_to_string(&cred_path) {
-            Ok(c) => c,
-            Err(e) => {
-                eprintln!("Warning: could not read {provider} credentials at {cred_path}: {e}");
-                any_error = true;
-                continue;
+        // Read the credential file. For Claude on macOS, prefer a fresh
+        // keychain entry over a stale disk file — Claude Code 2.x updates the
+        // macOS keychain as its OAuth refreshes, but writes the disk file
+        // less eagerly. Without this fallback, `nemo auth --claude` pushes
+        // an expired disk token while a fresh keychain token is sitting right
+        // there, and every loop immediately hits AWAITING_REAUTH.
+        let content = {
+            let file_content = std::fs::read_to_string(&cred_path);
+            if *provider == "claude" {
+                let now = crate::claude_creds::now_ms();
+                let file_stale = match &file_content {
+                    Ok(c) => crate::claude_creds::is_bundle_stale(c, now),
+                    Err(_) => true,
+                };
+                if file_stale {
+                    match crate::claude_creds::extract_from_keychain() {
+                        Some(kc) if !crate::claude_creds::is_bundle_stale(&kc, now) => {
+                            eprintln!(
+                                "Note: disk credentials at {cred_path} are stale; using fresh keychain entry."
+                            );
+                            kc
+                        }
+                        _ => match file_content {
+                            Ok(c) => c,
+                            Err(e) => {
+                                eprintln!(
+                                    "Warning: could not read claude credentials at {cred_path} and keychain has no fresh entry: {e}"
+                                );
+                                any_error = true;
+                                continue;
+                            }
+                        },
+                    }
+                } else {
+                    file_content.unwrap()
+                }
+            } else {
+                match file_content {
+                    Ok(c) => c,
+                    Err(e) => {
+                        eprintln!("Warning: could not read {provider} credentials at {cred_path}: {e}");
+                        any_error = true;
+                        continue;
+                    }
+                }
             }
         };
 


### PR DESCRIPTION
nemo auth --claude was reading ~/.claude/.credentials.json unconditionally. Claude Code 2.x refreshes its OAuth in the macOS keychain but writes the disk file less eagerly — so `nemo auth --claude` pushed an expired token while a fresh keychain entry sat right there, and every loop immediately hit AWAITING_REAUTH.

Now: on macOS, if the disk file is stale, fall back to the keychain when it has a fresh entry. Emits 'Note: disk credentials stale; using fresh keychain entry.' so the behavior is visible. Non-claude providers unchanged; non-macOS platforms unchanged.