### PR TITLE
fix(state): update_loop persists max_rounds

### DIFF
--- a/control-plane/src/state/postgres.rs
+++ b/control-plane/src/state/postgres.rs
@@ -506,6 +506,7 @@ impl StateStore for PgStateStore {
                 merge_sha = $15, merged_at = $16,
                 hardened_spec_path = $17, spec_pr_url = $18,
                 failed_from_state = $19::loop_state,
+                max_rounds = $20,
                 updated_at = NOW()
             WHERE id = $1
             "#,
@@ -529,6 +530,7 @@ impl StateStore for PgStateStore {
         .bind(&record.hardened_spec_path)
         .bind(&record.spec_pr_url)
         .bind(record.failed_from_state.map(loop_state_str))
+        .bind(record.max_rounds)
         .execute(&self.pool)
         .await?;
         Ok(())


### PR DESCRIPTION
update_loop's UPDATE SQL omitted the max_rounds column. nemo extend set updated.max_rounds in memory, called update_loop, and the column was never written. Result: extend returned '10 → 20' but the DB stayed at 10, so the loop hit the old cap on its very next round-boundary check.

Observed twice today (mobile-dash, llm-cli). Confirmed via direct psql query — max_rounds=10 on both after extend commands reported success.

Adds `max_rounds = $20` to the UPDATE clause + binds record.max_rounds.