### PR TITLE
feat(agent): mobile-dashboard (salvaged — loop stopped on infra, not convergence)

### DIFF
--- a/.agent/audit-feedback-round-1.json
+++ b/.agent/audit-feedback-round-1.json
@@ -1,0 +1,90 @@
+{
+  "round": 1,
+  "source": "audit",
+  "issues": [
+    {
+      "severity": "critical",
+      "category": "correctness",
+      "file": "specs/mobile-dashboard.md",
+      "description": "FR-2a specifies the cookie as HttpOnly, but also says dashboard JS should derive a Bearer header from the auth cookie. HttpOnly cookies are inaccessible to JavaScript by definition — this is a direct contradiction. JS fetch calls cannot read the cookie value to construct an Authorization header.",
+      "suggestion": "Pick one strategy: (a) drop HttpOnly and let JS read the cookie to build Bearer headers (weaker XSS defense), (b) keep HttpOnly and have JS rely on the cookie being sent automatically with same-origin fetch (no Bearer header needed — axum middleware checks cookie OR Bearer), or (c) store the API key in a non-HttpOnly cookie or sessionStorage alongside the HttpOnly cookie. Option (b) is simplest: the auth middleware already exists and can be extended to check cookies; JS never touches the key directly."
+    },
+    {
+      "severity": "high",
+      "category": "completeness",
+      "file": "specs/mobile-dashboard.md",
+      "description": "FR-3e defines a 'Mine' filter 'derived from API-key → engineer mapping', but the codebase uses a single shared API key (NAUTILOOP_API_KEY) with no per-engineer identity. FR-3g acknowledges the shared key but never resolves how the dashboard determines the current viewer's engineer name. Without this, 'Mine' cannot filter.",
+      "suggestion": "Add an explicit mechanism: either (a) the login form collects both api_key AND engineer_name, storing the engineer name in a second cookie or in the auth cookie payload, or (b) the dashboard prompts for engineer name on first visit and stores it in localStorage. Option (a) is better since it travels with the session. Update FR-2b to reflect the additional field."
+    },
+    {
+      "severity": "high",
+      "category": "completeness",
+      "file": "specs/mobile-dashboard.md",
+      "description": "Cost/pricing data is referenced throughout (FR-3b metrics row '$0.18', FR-4a token/cost breakdown, FR-9 total cost + top spender, FR-12 cost per event, FR-13 cost per run, FR-14 total cost + per-engineer cost) but the codebase has NO pricing configuration. TokenUsage (input/output token counts) exists per stage in round output JSONB, but there is no pricing model to convert token counts to dollar amounts. Every cost figure in the spec is unfeasible without a pricing implementation.",
+      "suggestion": "Either (a) add a prerequisite: define a `[pricing]` config section in nemo.toml mapping model names to per-token costs, plus a helper function to compute cost from TokenUsage, OR (b) scope v1 to showing raw token counts only and mark cost display as a follow-up. If (a), specify where the pricing config lives and how it handles multiple models (the codebase supports model_implementor and model_reviewer which may differ)."
+    },
+    {
+      "severity": "medium",
+      "category": "clarity",
+      "file": "specs/mobile-dashboard.md",
+      "description": "FR-12c and FR-13b contain '{{SPEC}}' in query string URLs (e.g., '/dashboard/feed?cursor=<timestamp>{{SPEC}}limit=50'). This appears to be a template rendering artifact — should be '&' to separate query parameters.",
+      "suggestion": "Replace '{{SPEC}}' with '&' in both URLs: '/dashboard/feed?cursor=<timestamp>&limit=50' and '/dashboard/specs?path=<>&limit=50'."
+    },
+    {
+      "severity": "medium",
+      "category": "completeness",
+      "file": "specs/mobile-dashboard.md",
+      "description": "FR-1a lists '/dashboard/stream/:id' as 'Existing /logs/:id SSE, re-exposed under dashboard namespace', but the existing /logs/:id handler returns JSON (full log dump) for terminal loops and SSE for active loops. FR-4a's live log pane says 'SSE stream for active loops; static dump for terminal loops'. The stream route table entry doesn't reflect this dual behavior — an implementor might only wire SSE.",
+      "suggestion": "Clarify in FR-1a that '/dashboard/stream/:id' mirrors the existing /logs/:id behavior: SSE for active loops, JSON array for terminal loops. Or split into two routes if the semantics should differ from the original."
+    },
+    {
+      "severity": "medium",
+      "category": "completeness",
+      "file": "specs/mobile-dashboard.md",
+      "description": "FR-4a references 'Token/cost breakdown: per-stage, per-round (bar chart optional; data table mandatory)' but token_usage is stored inside the JSONB output column of the rounds table, nested within stage-specific verdict structs (ReviewResultData, ImplResultData, etc.). The spec doesn't specify how to extract and aggregate this data — each stage struct has a different shape, and not all stages may include token_usage.",
+      "suggestion": "Specify that the aggregation endpoint should parse the JSONB output field per stage type, extract token_usage where present, and sum across stages within a round. Define fallback behavior when token_usage is missing from a stage output (display '—' or 0)."
+    },
+    {
+      "severity": "medium",
+      "category": "completeness",
+      "file": "specs/mobile-dashboard.md",
+      "description": "FR-8b defines '/dashboard/state' as a roll-up of all active loops, but doesn't specify whether it includes terminal loops. FR-3d says the card grid polls this endpoint, but FR-3e's filter chips include 'Converged' and 'Failed' (terminal states). If /dashboard/state only returns active loops, terminal loops won't appear in the grid after a refresh.",
+      "suggestion": "Clarify that '/dashboard/state' returns both active and recently-terminal loops (e.g., terminal within the last 24h or the current session), plus the aggregates. Alternatively, specify a query parameter to control inclusion of terminal loops."
+    },
+    {
+      "severity": "medium",
+      "category": "clarity",
+      "file": "specs/mobile-dashboard.md",
+      "description": "FR-10b says results are reported 'in the status bar' but no status bar component is defined anywhere in the spec. It's unclear what UI element this refers to.",
+      "suggestion": "Define what the status bar is (e.g., a toast notification, a banner at the top of the page, or an inline result below the modal) or replace with a concrete UI element like 'a dismissible toast notification'."
+    },
+    {
+      "severity": "medium",
+      "category": "completeness",
+      "file": "specs/mobile-dashboard.md",
+      "description": "FR-2b says login validates the key by 'making an internal /status call; if 200, sets the cookie'. But the existing auth middleware compares against NAUTILOOP_API_KEY env var — an internal /status call would require constructing an HTTP request to itself with the candidate key as Bearer. This is awkward and creates a localhost loopback dependency. A direct comparison against the env var (same logic as auth middleware) is simpler and more reliable.",
+      "suggestion": "Specify that validation uses the same constant-time comparison logic as the existing auth middleware (compare against NAUTILOOP_API_KEY), not an internal HTTP call. This avoids the self-request pattern and is consistent with existing code."
+    },
+    {
+      "severity": "low",
+      "category": "completeness",
+      "file": "specs/mobile-dashboard.md",
+      "description": "NFR-4 says 'No htmx/hyperscript/alpine.js' but the spec requires significant client-side interactivity: polling + diff re-render, SSE subscriptions, action button fetch, tab title updates, web audio, filter chip state, localStorage persistence, confirm modals, and fan-out cancel. Implementing all of this in a single <10KB vanilla JS file is feasible but aggressive. The spec doesn't prioritize which JS behaviors are mandatory v1 vs nice-to-have.",
+      "suggestion": "Consider tiering the JS features: mandatory (polling, action buttons, SSE log stream) vs progressive enhancement (tab title badge, web audio bell, animation transitions). This helps the implementor ship a working v1 without getting blocked on polish features."
+    },
+    {
+      "severity": "low",
+      "category": "clarity",
+      "file": "specs/mobile-dashboard.md",
+      "description": "FR-6b says the dashboard 'Inherits from [helm] theme in nemo.toml if set' but the dashboard is server-rendered HTML with CSS custom properties driven by prefers-color-scheme. The helm TUI theme is a terminal concept. It's unclear how a terminal theme setting would map to web CSS custom properties or who performs this mapping.",
+      "suggestion": "Either drop the nemo.toml theme inheritance (system preference is sufficient for v1) or specify exactly which nemo.toml values map to which CSS custom properties and where the mapping code lives (likely in the template rendering context)."
+    },
+    {
+      "severity": "low",
+      "category": "clarity",
+      "file": "specs/mobile-dashboard.md",
+      "description": "FR-9c says 'Tapping any field of the summary navigates to /dashboard/stats with that field pre-focused' but doesn't define what 'pre-focused' means for a stats page. Is it a scroll anchor? A highlighted card? A query parameter that expands a section?",
+      "suggestion": "Specify the mechanism: e.g., '/dashboard/stats?focus=converge_rate' scrolls to and highlights the relevant section, or use anchor links like '/dashboard/stats#converge-rate'."
+    }
+  ]
+}

--- a/.agent/audit-feedback-round-2.json
+++ b/.agent/audit-feedback-round-2.json
@@ -1,0 +1,94 @@
+{
+  "round": 2,
+  "source": "audit",
+  "issues": [
+    {
+      "severity": "high",
+      "category": "correctness",
+      "file": "specs/mobile-dashboard.md",
+      "line": 111,
+      "description": "FR-4a references a non-existent type `HardenResultData`. The codebase has: `ImplResultData`, `TestResultData`, `ReviewResultData`, `ReviseResultData`, and `AuditVerdict`. There is no `HardenResultData`. The spec also omits `TestResultData` and `ReviseResultData` from the list of stage types whose `token_usage` must be aggregated, which would cause under-counting.",
+      "suggestion": "Replace `HardenResultData` with the actual stage output types: `ImplResultData`, `TestResultData`, `ReviewResultData`, `ReviseResultData`, and `AuditVerdict`. List all five explicitly so the implementor doesn't miss any."
+    },
+    {
+      "severity": "high",
+      "category": "correctness",
+      "file": "specs/mobile-dashboard.md",
+      "line": 111,
+      "description": "FR-4a states each stage type embeds `token_usage` with fields `input_tokens` and `output_tokens`. The actual `TokenUsage` struct has fields `input: u64` and `output: u64` — no `_tokens` suffix. An implementor coding against the spec would write field accesses that don't compile.",
+      "suggestion": "Change `input_tokens` and `output_tokens` to `input` and `output` to match the actual `TokenUsage` struct in `control-plane/src/types/verdict.rs`."
+    },
+    {
+      "severity": "medium",
+      "category": "completeness",
+      "file": "specs/mobile-dashboard.md",
+      "line": 145,
+      "description": "FR-8b defines `/dashboard/state` as returning a 'single roll-up object' but provides no response schema. The implementor must guess the JSON shape for: loop summaries, aggregate counts per state, total tokens, total cost, engineer list, and fleet summary fields. Without a defined contract, the handler and the JS consumer will likely diverge.",
+      "suggestion": "Add a concrete JSON response schema (or at minimum, a TypeScript-style interface) for the `/dashboard/state` endpoint showing the exact fields, nesting, and types. Do the same for `/dashboard/stats`, `/dashboard/feed`, and `/dashboard/specs` endpoints."
+    },
+    {
+      "severity": "medium",
+      "category": "clarity",
+      "file": "specs/mobile-dashboard.md",
+      "line": 55,
+      "description": "FR-2b says `engineer_name` 'must match one of the engineer names present in loop data (or be accepted as free-text if no loops exist yet)'. This is ambiguous: if loops exist but the engineer is new to the system (first-time user), should they be rejected? The validation rule conflates 'no loops at all' with 'no loops for this engineer'.",
+      "suggestion": "Clarify: either (a) always accept free-text (the engineer name is self-declared, not validated against loop data), or (b) validate against a known-engineers list from the DB and provide a clear UX for new engineers. Option (a) is simpler and consistent with the CLI, which also accepts any engineer name on `nemo start`."
+    },
+    {
+      "severity": "medium",
+      "category": "consistency",
+      "file": "specs/mobile-dashboard.md",
+      "line": 31,
+      "description": "FR-1a defines a new route `/dashboard/stream/:id` that 'mirrors existing `/logs/:id` behavior'. Meanwhile, FR-4b says the existing API auth middleware is extended to accept cookies. If existing endpoints accept cookies, dashboard JS could call `/logs/:id` directly — making `/dashboard/stream/:id` redundant. Two endpoints serving identical data creates a maintenance burden and ambiguity about which to use.",
+      "suggestion": "Either (a) remove `/dashboard/stream/:id` and have dashboard JS call `/logs/:id` directly (since cookie auth is being added to the existing middleware), or (b) clarify what `/dashboard/stream/:id` does differently from `/logs/:id` (e.g., different format, last-200-lines only, HTML-formatted chunks)."
+    },
+    {
+      "severity": "medium",
+      "category": "completeness",
+      "file": "specs/mobile-dashboard.md",
+      "line": 68,
+      "description": "FR-3b lists state badge examples as 'IMPLEMENTING/REVIEWING/CONVERGED/FAILED/etc.' but the codebase has 13 states (Pending, Hardening, AwaitingApproval, Implementing, Testing, Reviewing, Converged, Failed, Cancelled, Paused, AwaitingReauth, Hardened, Shipped). The 'etc.' is too vague for a badge color mapping — the implementor needs to know the color for every state.",
+      "suggestion": "Enumerate all 13 states with their badge colors explicitly. At minimum, group them: green (Converged, Hardened, Shipped), red (Failed, Cancelled), amber (AwaitingApproval, Paused, AwaitingReauth), blue (Implementing, Testing, Reviewing, Hardening), gray (Pending)."
+    },
+    {
+      "severity": "medium",
+      "category": "completeness",
+      "file": "specs/mobile-dashboard.md",
+      "line": 68,
+      "description": "FR-3b pulse indicator fires 'if state is RUNNING'. But RUNNING is a SubState, not a LoopState. The top-level state would be Implementing/Testing/Reviewing/Hardening with sub_state=Running. The spec conflates the two levels of the state machine.",
+      "suggestion": "Change to: 'small animated dot if sub_state is RUNNING (i.e., the loop is in an active stage with a dispatched job currently executing), solid dot for all other states'."
+    },
+    {
+      "severity": "medium",
+      "category": "completeness",
+      "file": "specs/mobile-dashboard.md",
+      "line": 220,
+      "description": "FR-13a routes to `/dashboard/specs/<path>` where `<path>` is a spec filename. Spec paths can contain directory separators (e.g., `specs/mobile-dashboard.md`). The route pattern `<path>` as a single segment won't match multi-segment paths in axum without a wildcard. No URL encoding strategy is specified.",
+      "suggestion": "Either (a) use a wildcard route `/dashboard/specs/*path` and document that the path is the full relative spec path, or (b) use a query parameter `/dashboard/specs?path=<url-encoded-path>` (which FR-13b already uses for the backing endpoint). Recommend consistency: use the query-param form for both the page route and the API endpoint."
+    },
+    {
+      "severity": "low",
+      "category": "correctness",
+      "file": "specs/mobile-dashboard.md",
+      "line": 345,
+      "description": "Files Likely Touched section suggests `askama = \"0.12\"` in Cargo.toml. The current askama version on crates.io is 0.12.x but will likely be higher by implementation time. Pinning a specific version in a spec is fragile.",
+      "suggestion": "Change to `askama` (no version pin) or `askama = \"0.12\"` with a note that the implementor should use the latest compatible version."
+    },
+    {
+      "severity": "low",
+      "category": "completeness",
+      "file": "specs/mobile-dashboard.md",
+      "line": 43,
+      "description": "FR-2a specifies `Secure` flag on cookies, which prevents them from being sent over plain HTTP. During local development without TLS, authentication will silently fail. No development/testing workaround is mentioned.",
+      "suggestion": "Add a note: 'In development without TLS, the `Secure` flag may be conditionally omitted based on a config flag or the bind address being localhost. Production deployments MUST use `Secure`.' Or document that local dev requires a TLS terminator."
+    },
+    {
+      "severity": "low",
+      "category": "completeness",
+      "file": "specs/mobile-dashboard.md",
+      "line": 109,
+      "description": "FR-4a references 'FR-9 of the helm TUI phase 2 spec' for the rounds table format, but doesn't inline the column definitions. If that spec changes or the implementor doesn't have it, they can't build the rounds table correctly.",
+      "suggestion": "Inline the rounds table column definitions (round number, stage, verdict, issues count, confidence, tokens, cost, duration) directly in this spec rather than cross-referencing an external spec."
+    }
+  ]
+}

--- a/.agent/audit-feedback-round-3.json
+++ b/.agent/audit-feedback-round-3.json
@@ -1,0 +1,62 @@
+{
+  "round": 3,
+  "source": "audit",
+  "issues": [
+    {
+      "severity": "medium",
+      "category": "completeness",
+      "file": "specs/mobile-dashboard.md",
+      "description": "FR-1a route table is incomplete. It lists only /dashboard, /dashboard/login, /dashboard/logout, /dashboard/loops/:id, /dashboard/stream/:id, and /dashboard/static/*. Missing: /dashboard/state (FR-8b), /dashboard/feed (FR-12c), /dashboard/specs (FR-13b), /dashboard/stats (FR-14b). An implementor reading FR-1a as the canonical route list will miss four endpoints.",
+      "suggestion": "Add all dashboard routes to the FR-1a table: GET /dashboard/state, GET /dashboard/feed, GET /dashboard/specs, GET /dashboard/stats. Mark the FR-8/12/13/14 sections as defining the response schemas for those routes."
+    },
+    {
+      "severity": "medium",
+      "category": "clarity",
+      "file": "specs/mobile-dashboard.md",
+      "description": "FR-15b defines compute_cost(token_usage, model, pricing) but rounds don't store which model was used — only the loop-level model_implementor and model_reviewer fields exist. The spec doesn't define the stage→model mapping needed for per-round cost computation. For example: should implement and revise stages use model_implementor, review and audit stages use model_reviewer? What about test stages? What if the loop-level overrides are None and the model comes from config defaults?",
+      "suggestion": "Add an explicit mapping: implement/revise/test → model_implementor (or config default), review/audit → model_reviewer (or config default). State the fallback chain: loop field → NautiloopConfig.models default → return None."
+    },
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "specs/mobile-dashboard.md",
+      "description": "FR-6b says 'same palette as helm themes (dark/light/high-contrast)' but the helm TUI only defines a single hardcoded dark color palette (cli/src/commands/helm.rs). No light or high-contrast theme exists. An implementor cannot reference non-existent themes.",
+      "suggestion": "Change FR-6b to: 'CSS uses custom properties for all colors, inspired by the helm TUI dark palette (BG #0f0f0e, SURFACE #1a1918, TEAL #1b6b5a, AMBER #e8a838, GREEN #2d7a4f, RED #c4392d, BLUE #3b7bc0). Light mode inverts luminance. High-contrast is a follow-up.' Or simply state the dashboard defines its own light/dark palette."
+    },
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "specs/mobile-dashboard.md",
+      "description": "Template variable corruption: '{{SPEC}}' appears in multiple places where '&' was intended. Affected: FR-15b (compute_cost signature has {{SPEC}}TokenUsage, {{SPEC}}str, {{SPEC}}PricingConfig), FR-12c (cursor=<timestamp>{{SPEC}}limit=50), FR-13b (path=<>{{SPEC}}limit=50). An implementor may misread these parameter signatures.",
+      "suggestion": "Replace all '{{SPEC}}' occurrences with '&' — these are Rust reference parameters and URL query separators respectively."
+    },
+    {
+      "severity": "medium",
+      "category": "consistency",
+      "file": "specs/mobile-dashboard.md",
+      "description": "FR-1b says static assets must be '<50 KB gzipped'. NFR-2 says total page weight (HTML + CSS + JS + assets) must be '<100 KB uncompressed, <30 KB gzipped'. If the entire page including HTML must be <30 KB gzipped, then the assets-only budget of <50 KB gzipped is vacuous (assets are a subset of page weight and the superset has a tighter constraint). One of these numbers is wrong.",
+      "suggestion": "Reconcile: either FR-1b should say '<25 KB gzipped' (leaving headroom for HTML within the 30 KB NFR-2 budget), or NFR-2 should say '<50 KB gzipped' to match FR-1b. Pick one source of truth."
+    },
+    {
+      "severity": "low",
+      "category": "completeness",
+      "file": "specs/mobile-dashboard.md",
+      "description": "FR-4a rounds table includes a 'duration' column, but the existing /inspect endpoint returns RoundSummary with only stage JSONB outputs — it doesn't include started_at, completed_at, or duration_secs from the rounds table. The dashboard detail view will need to either extend /inspect or query rounds directly.",
+      "suggestion": "Note in FR-4a that the /dashboard/loops/:id handler queries rounds directly (not via /inspect) to access duration_secs, or add a note that /inspect should be extended."
+    },
+    {
+      "severity": "low",
+      "category": "clarity",
+      "file": "specs/mobile-dashboard.md",
+      "description": "FR-3d says card grid polls /status every 5s, but FR-8b introduces /dashboard/state specifically to avoid N+1 requests. FR-3d should reference /dashboard/state, not /status.",
+      "suggestion": "Change FR-3d to: 'Card grid auto-refreshes every 5s via a small vanilla-JS poll that fetches /dashboard/state and re-renders card fields in place.'"
+    },
+    {
+      "severity": "low",
+      "category": "completeness",
+      "file": "specs/mobile-dashboard.md",
+      "description": "FR-2a says the Secure flag is conditionally omitted for localhost. The spec doesn't define how the server determines it's in localhost mode — is it from the bind address in config, from an env var, or from the request Host header?",
+      "suggestion": "Clarify: 'When the configured bind address (from NautiloopConfig or NAUTILOOP_BIND_ADDR) is 127.0.0.1 or [::1], omit the Secure flag.'"
+    }
+  ]
+}

--- a/.agent/audit-feedback-round-4.json
+++ b/.agent/audit-feedback-round-4.json
@@ -1,0 +1,62 @@
+{
+  "round": 4,
+  "source": "audit",
+  "issues": [
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "specs/mobile-dashboard.md",
+      "description": "FR-4a lists 'AuditVerdict' as one of the five stage output types containing token_usage. In the codebase, the audit stage stores its output as ReviewResultData (same wrapper as the review stage), not AuditVerdict. AuditVerdict is the inner verdict struct embedded within ReviewResultData. An implementor reading this spec would try to deserialize audit round output as AuditVerdict directly and fail.",
+      "suggestion": "Replace 'AuditVerdict' with 'ReviewResultData (used for both review and audit stages)' in the FR-4a token data paragraph, or clarify that audit rounds use ReviewResultData containing an AuditVerdict inner struct."
+    },
+    {
+      "severity": "medium",
+      "category": "clarity",
+      "file": "specs/mobile-dashboard.md",
+      "description": "Multiple occurrences of '{{SPEC}}' appear in FR-12c, FR-13b, and FR-15b where '&' (ampersand) was intended. Examples: 'cursor=<timestamp>{{SPEC}}limit=50' should be 'cursor=<timestamp>&limit=50'; 'token_usage: {{SPEC}}TokenUsage, model: {{SPEC}}str' should be 'token_usage: &TokenUsage, model: &str'. This is a rendering/escaping artifact that makes the spec ambiguous for implementors.",
+      "suggestion": "Replace all '{{SPEC}}' occurrences with the intended '&' character. Ensure the markdown source uses HTML entity '&amp;' or escapes the ampersand properly to prevent future rendering issues."
+    },
+    {
+      "severity": "medium",
+      "category": "completeness",
+      "file": "specs/mobile-dashboard.md",
+      "description": "FR-8b's /dashboard/state response includes fleet_summary (7-day aggregation with trends) and is polled every 5 seconds (FR-3d). This is an expensive query scanning all loops and rounds within a 7-day window. FR-14c explicitly adds 60s caching for /dashboard/stats, but no caching strategy is specified for /dashboard/state despite it containing the same fleet_summary data and being polled 12x more frequently.",
+      "suggestion": "Either (a) add explicit caching guidance for fleet_summary within /dashboard/state (e.g., cache fleet_summary for 60s, refresh loop-level data on every poll), or (b) move fleet_summary out of /dashboard/state into a separate endpoint or into /dashboard/stats, and have the JS fetch it on a slower cadence (e.g., 60s)."
+    },
+    {
+      "severity": "medium",
+      "category": "consistency",
+      "file": "specs/mobile-dashboard.md",
+      "description": "FR-15b specifies the stage-to-model mapping as 'Implement, Revise, Test stages → model_implementor' and 'Review, Audit (Harden) stages → model_reviewer'. However, the codebase round stages are stored as strings: 'implement', 'test', 'review', 'audit', 'revise'. The spec uses mixed terminology — 'Audit (Harden)' conflates the round stage name ('audit') with the LoopState ('Hardening'). An implementor might look for a stage called 'harden' in the rounds table and find nothing.",
+      "suggestion": "Clarify that the stage names in the rounds table are lowercase strings: 'implement', 'test', 'review', 'audit', 'revise'. Map 'audit' → model_reviewer (this is the stage that runs during the Hardening LoopState). Drop the '(Harden)' parenthetical or rewrite as 'Review and Audit stages (stage field values \"review\" and \"audit\") → model_reviewer'."
+    },
+    {
+      "severity": "medium",
+      "category": "completeness",
+      "file": "specs/mobile-dashboard.md",
+      "description": "FR-2b sets nautiloop_engineer as an HttpOnly cookie, which means JavaScript cannot read it. FR-3e says the 'Mine' filter matches against this cookie value. While server-side filtering via /dashboard/state works (the server reads the cookie), the card grid JS poll (FR-3d) does a client-side re-render. If the JS needs to know the current engineer name for client-side filter chip rendering (e.g., highlighting 'Mine' as active, or knowing which cards are 'mine' when in team view with Mine selected), it cannot read the HttpOnly cookie. The spec doesn't clarify how the JS knows the current engineer identity.",
+      "suggestion": "Either (a) make nautiloop_engineer a non-HttpOnly cookie (it's not a secret — it's a self-declared name), or (b) have the server embed the engineer name in the initial HTML page (e.g., a data attribute or inline script variable), or (c) have /dashboard/state return a 'viewer' field identifying the requesting engineer. Option (c) is cleanest since the server already reads the cookie."
+    },
+    {
+      "severity": "low",
+      "category": "completeness",
+      "file": "specs/mobile-dashboard.md",
+      "description": "FR-3b pulse indicator specifies animation for sub_state 'Running' and solid dot for 'all other states'. SubState has three variants: Dispatched, Running, Completed. A 'Dispatched' state (job submitted but not yet running) could benefit from a distinct visual indicator (e.g., pulsing slower) to differentiate from 'Running' (actively executing). The current spec treats Dispatched the same as Completed (solid dot).",
+      "suggestion": "Consider adding a third visual state for Dispatched (e.g., slow pulse or hollow dot) to give operators better visibility into job lifecycle. Or explicitly note that Dispatched is intentionally shown as solid."
+    },
+    {
+      "severity": "low",
+      "category": "completeness",
+      "file": "specs/mobile-dashboard.md",
+      "description": "The NautiloopConfig struct in the codebase has no [pricing] section currently. FR-15 adds one, but the spec doesn't mention whether a database migration or config struct change is needed. Since this is a config-only addition (nemo.toml parsed by serde), no migration is needed, but the spec should note that NautiloopConfig and its serde deserialization need to be extended with an optional PricingConfig field.",
+      "suggestion": "Add a brief note in FR-15 or 'Files Likely Touched' that control-plane/src/config/mod.rs needs a new optional `pricing: Option<PricingConfig>` field added to NautiloopConfig, with PricingConfig and per-model cost structs defined there."
+    },
+    {
+      "severity": "low",
+      "category": "clarity",
+      "file": "specs/mobile-dashboard.md",
+      "description": "FR-4a rounds table says 'Tapping a row expands full verdict details inline' but doesn't specify which stages have expandable verdict details. Only review and audit stages produce ReviewVerdict/AuditVerdict with issues arrays. Implement, test, and revise stages have simpler output (SHA, exit code, test results). The expand behavior for non-verdict stages is unspecified.",
+      "suggestion": "Clarify that verdict expansion applies to review and audit stage rows (which contain issues arrays, confidence scores, and summaries). For other stages, either show the raw output fields (exit_code, new_sha, test results) or note that expansion is a no-op."
+    }
+  ]
+}

--- a/.agent/review-feedback-round-10.json
+++ b/.agent/review-feedback-round-10.json
@@ -1,0 +1,78 @@
+{
+  "round": 10,
+  "source": "review",
+  "issues": [
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/aggregate.rs",
+      "line": 432,
+      "description": "build_dashboard_state calls store.get_loops_for_engineer() which has a LIMIT 100 in the Postgres implementation. The card grid aggregates (counts_by_state, total_tokens, total_cost, total_loops) are computed from this truncated dataset. For team-mode deployments with >100 loops, filter chip counts will be silently incorrect. The trait comment explicitly says 'Limited to 100 results for CLI/UI display. For aggregation, use get_all_loops instead.' — but the dashboard aggregation still uses get_loops_for_engineer. Note: the MemoryStateStore has no such limit, so all tests pass despite this production bug.",
+      "suggestion": "Use get_all_loops(include_terminal, Some(cutoff_24h)) for computing aggregates. Continue using get_loops_for_engineer for the actual card list rendering (or apply a display limit after aggregation). Alternatively, add a get_loops_for_dashboard() method that computes aggregates server-side without the LIMIT."
+    },
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "control-plane/src/state/postgres.rs",
+      "line": 855,
+      "description": "get_terminal_loops interpolates `limit` directly into the SQL string via format!() instead of using a bind parameter: `LIMIT {limit}`. While usize prevents SQL injection, this violates the project guideline of 'Compile-time query checking where possible' and is inconsistent with other queries in the file that bind limit values as parameters (e.g., get_recent_logs uses .bind(limit as i64)).",
+      "suggestion": "Change to 'ORDER BY updated_at DESC, id DESC LIMIT ${param_idx}' and add q = q.bind(limit as i64) to the bind chain."
+    },
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "control-plane/src/state/postgres.rs",
+      "line": 462,
+      "description": "get_all_loops uses runtime sqlx::query() for all three query branches instead of compile-time sqlx::query!(). The (true, Some(cutoff)) branch has no LIMIT clause, meaning for a 14-day window with many loops, the result set is bounded only by the time filter. While the fleet_summary caches results for 60s, a cache miss still triggers this potentially expensive query. The project guidelines specify 'compile-time query checking where possible.'",
+      "suggestion": "Add a safety LIMIT (e.g., 50000) to the (true, Some(cutoff)) branch as a safeguard. Consider using sqlx::query!() with separate static queries for each branch where feasible."
+    },
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/handlers.rs",
+      "line": 256,
+      "description": "The dashboard_stream SSE handler for active loops sends an initial batch of recent logs, then tails new logs. But the initial batch and the tail use different cursor bases: the initial batch uses get_recent_logs (last 200 by timestamp DESC), and the tail starts from the last log's timestamp. If new logs arrive between the get_recent_logs call and the SSE stream starting, they could be missed (race window). Additionally, the seen_ids set from the initial batch is used for dedup, but if the initial 200 logs span many different timestamps, the seen_ids set could grow large.",
+      "suggestion": "This is a minor race window that's acceptable for a dashboard log tail. Document it as a known limitation. The dedup set size is bounded by the initial 200 logs, so it's not a memory concern."
+    },
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/aggregate.rs",
+      "line": 654,
+      "description": "build_feed_response passes since=None to get_terminal_loops, meaning no time bound on the query. While the SQL LIMIT prevents returning too many rows, the database still needs to scan and sort potentially thousands of terminal loops by updated_at DESC before applying the LIMIT. For long-lived deployments, this full-table scan runs on every feed page load.",
+      "suggestion": "Pass a reasonable default since value (e.g., 90 days) to bound the query. The feed is for recent terminal events; historical events older than 90 days are unlikely to be relevant."
+    },
+    {
+      "severity": "low",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/aggregate.rs",
+      "line": 625,
+      "description": "FeedResponse includes an 'engineers' field that is not in the spec's response schema for /dashboard/feed. While this field is necessary for rendering per-engineer filter chips (FR-12b), it's an undocumented deviation from the spec schema.",
+      "suggestion": "Update the spec's /dashboard/feed response schema to include the 'engineers' field, or document it as an implementation extension."
+    },
+    {
+      "severity": "low",
+      "category": "style",
+      "file": "control-plane/src/state/postgres.rs",
+      "line": 671,
+      "description": "get_rounds_batch uses runtime sqlx::query() instead of compile-time sqlx::query!(). The project guidelines say 'Compile-time query checking where possible.' However, since ANY($1) with a dynamic array makes compile-time checking awkward, runtime query is acceptable here.",
+      "suggestion": "Add a comment explaining why runtime query is used (dynamic array input)."
+    },
+    {
+      "severity": "low",
+      "category": "style",
+      "file": "control-plane/src/api/dashboard/templates.rs",
+      "line": 27,
+      "description": "The layout function uses format!() to build the outer HTML shell, bypassing maud's auto-escaping for the body content. While html_escape is applied to title and viewer, the extra_attrs parameter is not escaped — it's trusted to be safe because it's constructed from UUID strings and booleans. This pattern is fragile if future callers pass user-controlled data.",
+      "suggestion": "Add a comment documenting that extra_attrs must only contain trusted values, or validate/escape it."
+    },
+    {
+      "severity": "low",
+      "category": "correctness",
+      "file": "control-plane/assets/dashboard.js",
+      "line": 427,
+      "description": "restoreFeedFilter checks feedList.querySelectorAll('.feed-item').length === 0 to detect empty results when a stale filter is active. This correctly checks for .feed-item elements (not all children). However, the redirect to /dashboard/feed to clear the filter causes a full page reload, which could be jarring if the user intentionally set an engineer filter that has no results yet.",
+      "suggestion": "Consider only clearing the filter after the user has been on the page for a moment, or show a 'No results for this filter — clear?' prompt instead of auto-redirecting."
+    }
+  ]
+}

--- a/.agent/review-feedback-round-11.json
+++ b/.agent/review-feedback-round-11.json
@@ -1,0 +1,77 @@
+{
+  "round": 11,
+  "source": "review",
+  "issues": [
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "control-plane/src/state/postgres.rs",
+      "line": 470,
+      "description": "get_all_loops SQL uses `created_at > $1` to bound terminal loops, but build_dashboard_state needs loops that *terminated* recently (updated_at within 24h). A loop created 3 days ago that converged 2 hours ago has created_at outside the 24h cutoff and is terminal, so it's excluded by SQL — even though updated_at is within 24h. The Rust filter in build_dashboard_state checks `l.updated_at > cutoff` but never sees these loops because the SQL already dropped them. This causes recently-converged long-running loops to disappear from the Converged/Failed filter chips.",
+      "suggestion": "Change the SQL for (true, Some(cutoff)) to: `WHERE (created_at > $1 OR updated_at > $1) OR state NOT IN (terminal states) ORDER BY created_at DESC LIMIT 10000`. This catches terminal loops that finished recently regardless of when they were created."
+    },
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "control-plane/assets/dashboard.js",
+      "line": 271,
+      "description": "Acceptance Criteria #6 requires a confirm modal for the Extend +10 action: 'Tap a FAILED-max-rounds loop's Extend button. Confirm modal → +10 rounds → loop resumes.' The JS directly calls actionFetch without showing a confirm modal, unlike the Cancel action which correctly shows one.",
+      "suggestion": "Wrap the extend actionFetch in a showConfirmModal call: `showConfirmModal('Extend +10 rounds?', 'This will add 10 rounds and resume the loop.', function() { actionFetch(...) })`"
+    },
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "control-plane/src/state/postgres.rs",
+      "line": 830,
+      "description": "get_terminal_loops builds the cursor WHERE clause as `(updated_at < $N OR (updated_at = $N AND id < $N+1))` where $N is bound to cursor_ts. However, the parameter index variable `param_idx` is used for the LIMIT clause at the end. If the cursor is present, `param_idx` is incremented by 2 (for cursor_ts and cursor_id), but cursor_ts is referenced TWICE in the SQL ($N appears in both `<` and `=` comparisons). While PostgreSQL allows referencing the same $N multiple times, this pattern is fragile and should be verified — if a future refactor changes the bind order, it silently produces wrong results.",
+      "suggestion": "Add a comment documenting that $N is intentionally referenced twice in the cursor clause and that the bind order is: states, [since], [engineer], [cursor_ts, cursor_id], limit."
+    },
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/aggregate.rs",
+      "line": 656,
+      "description": "build_feed_response computes `extensions` as `((record.max_rounds - default_max) / 10).max(0)` but max_rounds and default_max are both i32. If max_rounds < default_max (e.g., if the config was changed to increase the default after the loop was created), the subtraction would be negative, and integer division of negative values in Rust rounds toward zero. The .max(0) handles this, but the division result could also be negative before .max(0). This is correct but worth noting.",
+      "suggestion": "No change needed — .max(0) handles the edge case correctly."
+    },
+    {
+      "severity": "medium",
+      "category": "performance",
+      "file": "control-plane/src/api/dashboard/aggregate.rs",
+      "line": 741,
+      "description": "build_specs_response calls get_loops_by_spec_path with a hardcoded limit of 10000, then iterates all results to compute aggregates. For specs with many historical runs, this loads up to 10000 LoopRecords into memory and fetches all their rounds via get_rounds_batch. While 10000 runs per spec is unlikely, the unbounded round fetch could be expensive if each loop has many rounds.",
+      "suggestion": "Consider adding a comment documenting the 10000 limit as a safety bound, or use a more targeted aggregate query that computes totals in SQL."
+    },
+    {
+      "severity": "low",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/aggregate.rs",
+      "line": 101,
+      "description": "FeedResponse includes an 'engineers' field that is not in the spec's /dashboard/feed response schema. While functionally needed for rendering per-engineer filter chips (FR-12b), it's an undocumented deviation from the specified JSON contract.",
+      "suggestion": "Update the spec's /dashboard/feed response schema to include the 'engineers' field, or document it as an implementation extension."
+    },
+    {
+      "severity": "low",
+      "category": "style",
+      "file": "control-plane/src/state/postgres.rs",
+      "line": 462,
+      "description": "get_all_loops, get_rounds_batch, get_recent_logs, get_loops_by_spec_path, and get_terminal_loops all use runtime sqlx::query() instead of compile-time sqlx::query!(). The project guidelines say 'Compile-time query checking where possible.' While acceptable given dynamic query conditions, this is a significant surface area without compile-time SQL validation.",
+      "suggestion": "Add inline comments on each runtime query explaining why compile-time checking is not feasible (dynamic array inputs, conditional WHERE clauses)."
+    },
+    {
+      "severity": "low",
+      "category": "correctness",
+      "file": "control-plane/assets/dashboard.js",
+      "line": 499,
+      "description": "Web audio bell on convergence (FR-7a) creates a new AudioContext on every bell event. Browsers limit the number of AudioContext instances (typically 6-8). If many loops converge in quick succession, new AudioContext creation will fail silently. While the try/catch handles this, it's wasteful.",
+      "suggestion": "Create a single AudioContext lazily on first use and reuse it for subsequent bell plays."
+    },
+    {
+      "severity": "low",
+      "category": "completeness",
+      "file": "control-plane/src/api/dashboard/templates.rs",
+      "description": "No docs/dashboard-setup.md was created. The spec's 'Files Likely Touched' section and FR-2d both reference this document for covering the security model (Tailscale as default, explicit warning about public exposure).",
+      "suggestion": "Create docs/dashboard-setup.md with security model documentation as specified in the spec."
+    }
+  ]
+}

--- a/.agent/review-feedback-round-5.json
+++ b/.agent/review-feedback-round-5.json
@@ -1,0 +1,116 @@
+{
+  "round": 5,
+  "source": "review",
+  "issues": [
+    {
+      "severity": "critical",
+      "category": "correctness",
+      "file": "control-plane/src/api/auth.rs",
+      "description": "FR-4b requires the existing API auth middleware to accept cookies in addition to Bearer headers so dashboard action buttons (Approve, Cancel, Resume, Extend) authenticate transparently. The existing auth middleware only accepts Bearer headers. Dashboard JS calls `/approve/:id`, `/cancel/:id`, `/resume/:id`, `/extend/:id` via same-origin fetch() which sends the HttpOnly cookie but NOT a Bearer header. These calls will all return 401 Unauthorized, making all action buttons non-functional.",
+      "suggestion": "Extend `auth_middleware` in `control-plane/src/api/auth.rs` to also check for the `nautiloop_api_key` cookie, matching the logic in `dashboard/auth.rs`. Use the same fallback: check cookie first, then Bearer header."
+    },
+    {
+      "severity": "high",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/templates.rs",
+      "description": "Kill switch button in `nav_bar` has `data-active-ids=\"\"` (always empty). The JS `cancel-all` action reads `btn.dataset.activeIds.split(',')` which yields `[\"\"]` — it tries to cancel a loop with empty-string ID. The active loop IDs are never populated into this attribute, neither in the initial server render nor in the JS poll update cycle.",
+      "suggestion": "Either (a) populate `data-active-ids` server-side from the active loops in the dashboard state, AND update it in the JS `updateGrid` function after each poll, or (b) have the JS cancel-all handler first fetch `/dashboard/state?team=true` to get active loop IDs, then fan out cancels."
+    },
+    {
+      "severity": "high",
+      "category": "security",
+      "file": "control-plane/src/api/dashboard/handlers.rs",
+      "line": 69,
+      "description": "Cookie value injection in `login_submit`: `form.engineer_name` is interpolated directly into the Set-Cookie header without encoding. An engineer name containing `;` (e.g., `alice; Domain=evil.com`) would corrupt the cookie attributes. Characters like `\\r\\n` could attempt header injection (mitigated by axum's header value parsing, but semicolons are not rejected).",
+      "suggestion": "URL-encode or percent-encode the engineer_name before embedding in the cookie value. Alternatively, validate that engineer_name contains only alphanumeric characters, hyphens, and underscores (matching typical engineer handle patterns)."
+    },
+    {
+      "severity": "high",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/aggregate.rs",
+      "line": 481,
+      "description": "In `build_feed_response`, the cursor filter uses `l.updated_at >= c` inside a let-chain with `if let Some(c) = cursor && l.updated_at >= c { return false; }`. This means ALL loops with `updated_at >= cursor` are excluded, but the cursor-based pagination expects to exclude only loops at or after the cursor. However, when the cursor is the `updated_at` of the last item, any loop with the exact same timestamp as the cursor is excluded — losing events that share a timestamp with the pagination boundary.",
+      "suggestion": "Use cursor-based pagination with a secondary sort key (e.g., loop ID) or use `>` instead of `>=` with a unique cursor value. Alternatively, the cursor should be the `updated_at` of the last returned item, and the next page should use `<` (strictly before) to avoid the boundary issue."
+    },
+    {
+      "severity": "medium",
+      "category": "performance",
+      "file": "control-plane/src/api/dashboard/aggregate.rs",
+      "line": 500,
+      "description": "In `build_specs_response`, rounds are fetched for each loop TWICE: once in the `runs` slice (first N loops) to compute cost, and again in the aggregates loop over ALL matching loops. For a spec with 50 runs, this means 100 round queries instead of 50.",
+      "suggestion": "Compute tokens/cost for all matching loops in a single pass, then split into the `runs` response slice and aggregate accumulators."
+    },
+    {
+      "severity": "medium",
+      "category": "performance",
+      "file": "control-plane/src/api/dashboard/aggregate.rs",
+      "line": 325,
+      "description": "N+1 query pattern: `build_dashboard_state` calls `store.get_rounds(record.id)` for every loop in the filtered set. With 50 active loops polled every 5 seconds, this is 50 DB queries every 5s just for the card grid poll. The fleet_summary additionally queries rounds for ALL loops in the 7-day window (potentially hundreds) on every cache miss.",
+      "suggestion": "Consider adding a batch `get_rounds_for_loops(ids: &[Uuid])` method to StateStore, or pre-compute token aggregates in the database (e.g., materialized columns on the loops table updated on round completion)."
+    },
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/aggregate.rs",
+      "line": 300,
+      "description": "In `compute_loop_totals`, the cost logic `if has_pricing || pricing.is_some()` returns `Some(0.0)` when pricing config exists but no rounds have token data. This means a loop with zero rounds (just created) would show `$0.00` instead of `—` when pricing is configured. The spec says cost should be computed from token counts; zero tokens should arguably show `$0.00` not `—`, but the inconsistency with how `None` is used elsewhere (no token data → `—`) could confuse users.",
+      "suggestion": "Only return `Some(total_cost)` when `has_pricing` is true (at least one round had computable cost). Return `None` when pricing is configured but no rounds have token data yet."
+    },
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/templates.rs",
+      "line": 164,
+      "description": "The initial server-rendered card grid only renders non-terminal loops (`!is_terminal_state(&loop_item.state)`), but the filter chips show counts for ALL states including terminal. On first page load before JS takes over, a user sees chip counts for Converged/Failed loops they can't see in the grid. The spec default is `Active + Mine` so active-only is correct, but the 'All' chip count includes loops that aren't rendered.",
+      "suggestion": "This is acceptable since JS polling starts immediately and replaces the grid content. However, for the no-JS fallback (FR-7c graceful degradation), the grid should show loops matching the default filter or the counts should only reflect what's visible."
+    },
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/templates.rs",
+      "line": 370,
+      "description": "In `render_round_detail` for 'implement' stage, the code tries to deserialize as `ImplResultData` first, then falls through. For 'revise' stage, it tries `ImplResultData` first (which will fail) before trying `ReviseResultData`. This is harmless (both attempts are in the same match arm) but wasteful — the `ImplResultData` attempt on a 'revise' output will always fail.",
+      "suggestion": "Split the match arm: `\"implement\" => { try ImplResultData }`, `\"revise\" => { try ReviseResultData }` instead of combining them."
+    },
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "control-plane/assets/dashboard.js",
+      "line": 108,
+      "description": "In `fmtTokens`, the function computes `(loop.total_tokens||{}).input + (loop.total_tokens||{}).output`. If `total_tokens` is null/undefined, both `.input` and `.output` are undefined, and `undefined + undefined` is `NaN`. `fmtTokens(NaN)` passes through to `String(NaN)` which displays 'NaN' on the card.",
+      "suggestion": "Guard against null total_tokens: `const t = loop.total_tokens || {}; fmtTokens((t.input || 0) + (t.output || 0))`"
+    },
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/handlers.rs",
+      "line": 63,
+      "description": "In `login_submit`, when `NAUTILOOP_BIND_ADDR` is empty (not set), `is_localhost` is true and the Secure flag is omitted. The spec says 'Production deployments (non-localhost bind) MUST always set Secure.' But many deployments may not set `NAUTILOOP_BIND_ADDR` at all while binding to a non-localhost address (e.g., 0.0.0.0). The default should be secure (Secure flag ON), with explicit localhost detection as the exception.",
+      "suggestion": "Remove `|| bind_addr.is_empty()` from the localhost check. When NAUTILOOP_BIND_ADDR is unset, default to secure (include the Secure flag). Only omit Secure when the bind address is explicitly 127.0.0.1, [::1], or localhost."
+    },
+    {
+      "severity": "low",
+      "category": "correctness",
+      "file": "control-plane/assets/dashboard.js",
+      "line": 86,
+      "description": "The `engineer_color` hash function in JS uses `charCodeAt` (UTF-16 code units) while the Rust equivalent in `templates.rs` uses `name.bytes()` (UTF-8 bytes). For non-ASCII engineer names (e.g., names with accented characters), the server-rendered engineer badge color will differ from the client-rendered color after a JS poll update, causing a visual flicker.",
+      "suggestion": "Use the same hashing basis in both implementations. Either convert to bytes in JS or use char codes in Rust."
+    },
+    {
+      "severity": "low",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/handlers.rs",
+      "line": 305,
+      "description": "The `constant_time_eq` function is duplicated in both `auth.rs` and `handlers.rs`. This is a maintenance risk — a bug fix in one copy might not propagate to the other.",
+      "suggestion": "Extract `constant_time_eq` into a shared utility module (e.g., `crate::util`) and reference it from both `auth.rs` and `handlers.rs`."
+    },
+    {
+      "severity": "low",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/templates.rs",
+      "line": 424,
+      "description": "Feed page filter chips are server-rendered with 'All events' always having the `active` class, regardless of the current `?filter=` query parameter. The active chip doesn't reflect the actual filter state on page load.",
+      "suggestion": "Pass the current filter value to `render_feed` and conditionally apply the `active` class to the matching chip."
+    }
+  ]
+}

--- a/.agent/review-feedback-round-6.json
+++ b/.agent/review-feedback-round-6.json
@@ -1,0 +1,85 @@
+{
+  "round": 6,
+  "source": "review",
+  "issues": [
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/aggregate.rs",
+      "line": 662,
+      "description": "Feed cursor pagination causes boundary-item duplication. The cursor is the `updated_at` of the last item on the current page. The filter uses `l.updated_at > c` to exclude items, so items with `updated_at == cursor` are included. After sorting DESC and slicing, the last item from the previous page reappears as the first item on the next page. The comment acknowledges this ('potential minor duplication') but the spec describes clean pagination with no duplicates.",
+      "suggestion": "Use a compound cursor (updated_at + loop ID) for deterministic pagination, or document the duplication as intentional and let the client deduplicate by ID."
+    },
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/templates.rs",
+      "line": 380,
+      "description": "Rounds table is missing 'issues count' and 'confidence score' columns that FR-4a specifies. The spec says columns should be: round number, stage, verdict, issues count, confidence score, tokens, cost, duration. The implementation only has: #, Stage, Verdict, Tokens, Cost, Duration — omitting issues count and confidence score.",
+      "suggestion": "Add 'Issues' and 'Confidence' columns to the rounds table header and render them from the review/audit verdict data (issues array length and confidence field). For non-review stages, display '—'."
+    },
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/templates.rs",
+      "line": 648,
+      "description": "Feed page is missing per-engineer filter chips. FR-12b specifies filters: 'All events / Converged only / Failed only / per-engineer'. The implementation only renders 'All events', 'Converged', and 'Failed' chips — no per-engineer chips. Engineers cannot filter the feed by specific team member.",
+      "suggestion": "Add per-engineer chips to the feed page filter bar, similar to the card grid's engineer row. This requires passing the list of engineers (from the feed data or a separate query) to the feed template."
+    },
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/templates.rs",
+      "line": 214,
+      "description": "Fleet summary (FR-9c) does not provide field-specific anchor links. The spec says 'Tapping any field of the summary navigates to /dashboard/stats with that field pre-focused' with anchor fragments. The implementation wraps the entire summary in a single link to '/dashboard/stats' — all fields link to the same URL without distinguishing anchors (#total-loops, #converge-rate, etc.).",
+      "suggestion": "Break the fleet summary into individual clickable spans/links, each pointing to '/dashboard/stats#total-loops', '/dashboard/stats#total-cost', '/dashboard/stats#converge-rate', '/dashboard/stats#avg-rounds' respectively."
+    },
+    {
+      "severity": "medium",
+      "category": "performance",
+      "file": "control-plane/src/api/dashboard/aggregate.rs",
+      "line": 449,
+      "description": "N+1 query pattern: `build_dashboard_state` calls `store.get_rounds(record.id)` for every loop in the filtered set. With 50 active loops polled every 5 seconds, this is 50 DB queries per poll cycle. The fleet_summary additionally queries rounds for ALL loops in the 7-day window on every cache miss (potentially hundreds of round queries).",
+      "suggestion": "Add a batch `get_rounds_for_loops(ids: &[Uuid])` method to StateStore that returns all rounds in a single query, or pre-compute token aggregates as materialized columns on the loops table."
+    },
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/mod.rs",
+      "line": 36,
+      "description": "Router state type annotation `Router<AppState>` for the authed routes is incorrect. The handlers extract `State<DashboardState>`, so the router is `Router<DashboardState>`. After `.with_state(dash_state)` it becomes `Router<()>`, not `Router<AppState>`. This either fails to compile (in which case the code is broken) or the annotation is misleading and works through type inference ignoring the explicit annotation (which Rust does not do).",
+      "suggestion": "Change the type annotation to `let authed: Router<()> = Router::new()...` since `.with_state(dash_state)` converts the router from `Router<DashboardState>` to `Router<()>`. Similarly, public routes that don't extract state should have their annotation adjusted, or remove explicit annotations and let the compiler infer."
+    },
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "control-plane/assets/dashboard.js",
+      "line": 256,
+      "description": "Dashboard stream SSE for active loops streams the complete log from the beginning (via the existing stream_logs function), not just the last 200 lines as FR-1a specifies. The spec says '/dashboard/stream/:id' should return 'the last 200 lines as SSE for active loops'. The server-side handler for active loops delegates to `crate::api::sse::stream_logs` which streams all logs, not just the tail.",
+      "suggestion": "Either modify the dashboard_stream handler to start the SSE stream from a recent offset (e.g., last 200 log entries), or create a dashboard-specific stream function that only emits recent lines plus new lines going forward."
+    },
+    {
+      "severity": "low",
+      "category": "correctness",
+      "file": "control-plane/assets/dashboard.js",
+      "line": 393,
+      "description": "Feed filter chip selection does not persist in localStorage across visits. FR-12b says 'Persists selection in localStorage across visits.' FR-16a classifies this as progressive enhancement. The current implementation uses page navigation (onclick changes URL) but doesn't save/restore the selection from localStorage.",
+      "suggestion": "On page load, check localStorage for a saved feed filter value and apply it. On filter chip click, save the selection to localStorage before navigating."
+    },
+    {
+      "severity": "low",
+      "category": "correctness",
+      "file": "control-plane/assets/dashboard.js",
+      "description": "Web audio bell on convergence is not implemented. FR-7a specifies 'Play a \\a bell equivalent via web audio when a loop converges (opt-in, off by default).' FR-16a classifies this as progressive enhancement. Not blocking but noted.",
+      "suggestion": "Add an opt-in web audio notification triggered when a loop transitions to CONVERGED state during polling. Store the opt-in preference in localStorage."
+    },
+    {
+      "severity": "low",
+      "category": "style",
+      "file": "control-plane/src/api/dashboard/handlers.rs",
+      "line": 81,
+      "description": "The raw API key is interpolated directly into the Set-Cookie header value without URL-encoding. While the validation rejects non-alphanumeric characters for engineer_name, the api_key value itself could theoretically contain characters that are problematic in cookie values (though in practice API keys are typically alphanumeric). RFC 6265 restricts cookie values to a subset of ASCII.",
+      "suggestion": "Consider URL-encoding or base64-encoding the API key value in the cookie, or validate that it only contains cookie-safe characters before setting it."
+    }
+  ]
+}

--- a/.agent/review-feedback-round-7.json
+++ b/.agent/review-feedback-round-7.json
@@ -1,0 +1,77 @@
+{
+  "round": 7,
+  "source": "review",
+  "issues": [
+    {
+      "severity": "high",
+      "category": "correctness",
+      "file": "control-plane/src/state/postgres.rs",
+      "line": 447,
+      "description": "PgStateStore::get_loops_for_engineer has LIMIT 100, but all dashboard aggregation functions (fleet_summary, feed, specs, stats) call this method expecting ALL loops. With >100 loops in a 7-day window, fleet_summary.total_loops, converge_rate, avg_rounds, and top_spender will be computed from a truncated dataset, producing silently incorrect numbers. The MemoryStateStore has no such limit, so all tests pass despite this production bug.",
+      "suggestion": "Either (a) add a separate method like get_all_loops_in_window(cutoff: DateTime) without LIMIT for aggregation use cases, or (b) remove the LIMIT 100 from get_loops_for_engineer and add pagination at the caller level where needed (CLI status), or (c) at minimum raise the limit significantly for the include_terminal=true path used by dashboard aggregations."
+    },
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/handlers.rs",
+      "line": 488,
+      "description": "Multiple async tests modify the NAUTILOOP_API_KEY env var via unsafe { std::env::set_var() }. Since cargo test runs tests in parallel within the same process, concurrent tests can race on this shared mutable state. One test setting the key while another test's auth middleware reads it can cause intermittent 401 failures.",
+      "suggestion": "Either (a) use #[serial_test::serial] to run these tests sequentially, (b) use a mutex around env var access, or (c) refactor auth to accept the expected key as a parameter/config rather than reading from env."
+    },
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/aggregate.rs",
+      "line": 656,
+      "description": "Feed cursor pagination applies the state/engineer filter AFTER collecting engineers into engineers_set but BEFORE the cursor exclusion. This means: on page 2 with filter=converged, loops that are Failed (filtered out) still contribute to engineers_set. This is actually correct behavior (show all available engineers regardless of filter). However, the cursor exclusion also runs before the filter, meaning cursor-excluded items that match the filter are permanently skipped even though they should have been on page 1. If page 1's last item shares a timestamp with a filtered-out item, the cursor skips both.",
+      "suggestion": "Reorder: apply cursor exclusion before engineers collection so that cursor-excluded loops don't pollute the engineers list unnecessarily. The filter should be applied independently."
+    },
+    {
+      "severity": "medium",
+      "category": "performance",
+      "file": "control-plane/src/api/dashboard/aggregate.rs",
+      "line": 535,
+      "description": "build_fleet_summary calls get_loops_for_engineer(None, true, true) which loads ALL loops, then partitions into current and previous 7-day windows. Each window then calls get_rounds_batch for ALL loop IDs in that window. On a cache miss (every 60s), this fetches potentially hundreds of loops and thousands of rounds from the database. Meanwhile, /dashboard/state is polled every 5s and also calls get_loops_for_engineer, meaning loops are re-fetched on every poll even though only the fleet_summary is cached.",
+      "suggestion": "Cache the loops query result for the fleet_summary computation, or compute fleet_summary in a background task on a 60s interval rather than on-demand during the poll handler."
+    },
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/templates.rs",
+      "line": 919,
+      "description": "Time series bar widths use integer division: day.converged * 100 / max_val. When max_val is large and day.converged is 1, this evaluates to 0 (since 1*100/8 = 12, but 1*100/101 = 0 for edge cases). More critically, when day.started == 0 (which shouldn't happen since loops must be started to exist), max_val would be max(0, 1) = 1, but if somehow started is 0, there's no division by zero since max_val = day.started.max(1). The real issue is that the 'other' bar computation day.started.saturating_sub(day.converged + day.failed) could underflow if converged + failed > started (possible if a loop converged in a different time window than it was started).",
+      "suggestion": "Guard the 'other' calculation and handle the case where converged + failed > started by clamping to 0 (saturating_sub already does this). Also consider using float division for bar widths to avoid zero-width bars for small counts."
+    },
+    {
+      "severity": "low",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/aggregate.rs",
+      "line": 247,
+      "description": "StatsCache::get uses serde_json::to_value/from_value to clone the cached StatsResponse, which is O(n) in the size of the response and allocates intermediate JSON values. This is called on every /dashboard/stats request within the 60s cache window.",
+      "suggestion": "Derive Clone on StatsResponse (and its component types) to avoid the serialization round-trip. All field types (String, u64, f64, Option<f64>, Vec) already implement Clone."
+    },
+    {
+      "severity": "low",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/templates.rs",
+      "line": 17,
+      "description": "The html_escape function does not escape single quotes (') to &#39;. While currently safe because all HTML attributes in the layout function use double quotes, this is fragile — any future use of single-quoted attributes with user-controlled values would be an XSS vector.",
+      "suggestion": "Add .replace('\\'', '&#39;') to html_escape for defense in depth."
+    },
+    {
+      "severity": "low",
+      "category": "correctness",
+      "file": "control-plane/assets/dashboard.js",
+      "line": 427,
+      "description": "Feed page localStorage filter restore (restoreFeedFilter) triggers a full page navigation via location.href redirect on load. If the user has a stale filter saved (e.g., an engineer who no longer exists), they'll always see an empty feed page with no way to clear the filter without manually editing localStorage.",
+      "suggestion": "Add a 'clear filter' affordance on the feed page, or reset the localStorage value when the feed returns empty results with a saved filter."
+    },
+    {
+      "severity": "low",
+      "category": "style",
+      "file": "control-plane/src/api/dashboard/auth.rs",
+      "description": "Cookie parsing functions (extract_cookie_value, extract_bearer) are duplicated between dashboard/auth.rs and api/auth.rs. Both modules implement identical cookie and bearer extraction logic.",
+      "suggestion": "The api/auth.rs already imports from crate::util. Move the cookie/bearer extraction helpers to crate::util as well and reference from both modules."
+    }
+  ]
+}

--- a/.agent/review-feedback-round-8.json
+++ b/.agent/review-feedback-round-8.json
@@ -1,0 +1,69 @@
+{
+  "round": 8,
+  "source": "review",
+  "issues": [
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/templates.rs",
+      "line": 734,
+      "description": "Feed 'Load more' button is missing a `data-filter` attribute. The JS `bindFeedLoadMore` function reads `btn.dataset.filter` to preserve the current filter when paginating, but the server-rendered button only sets `data-cursor`. When a user is viewing 'Converged only' and clicks Load More, the next page fetches ALL terminal events (unfiltered), breaking FR-12b's filter + pagination interaction.",
+      "suggestion": "Add `data-filter=(current_filter.unwrap_or(\"\"))` to the load-more button element in `render_feed`. The `current_filter` parameter is already available in scope."
+    },
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/aggregate.rs",
+      "line": 678,
+      "description": "Feed filter uses magic string matching that conflates state filters ('converged', 'failed') with engineer name filters in a single `filter` query parameter. If an engineer is named 'converged' or 'failed', their name filter will be interpreted as a state filter. The match arms `Some(\"converged\")` and `Some(\"failed\")` shadow any engineer with those names.",
+      "suggestion": "Use separate query parameters (e.g., `state_filter` and `engineer_filter`) or prefix engineer names (e.g., `engineer:alice`). Alternatively, since engineer names are validated to be alphanumeric with hyphens/underscores/dots, add a note that 'converged' and 'failed' are reserved filter values and cannot be used as engineer names."
+    },
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/aggregate.rs",
+      "line": 926,
+      "description": "Stats time series buckets converged/failed counts by `created_at` date, not `updated_at`. A loop created Monday that converges Wednesday shows as a Monday convergence. The 'Daily Activity' chart becomes misleading for long-running loops — the convergence count on a given day doesn't reflect what actually completed that day.",
+      "suggestion": "Bucket the `started` counter by `created_at` and the `converged`/`failed` counters by `updated_at`. This way 'started' reflects when work began and 'converged'/'failed' reflects when outcomes were reached, which is the natural reading of the time series."
+    },
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/handlers.rs",
+      "description": "No test coverage for the `/dashboard/stream/:id` SSE endpoint. This endpoint has complex logic (last-200-line initial batch, SSE tailing, dedup, terminal detection) that is entirely untested. A regression here would break the live log pane (FR-4a) which is a core dashboard feature.",
+      "suggestion": "Add at least one test for active-loop SSE streaming (verify initial lines are sent) and one test for terminal-loop JSON response (verify it returns a JSON array of the last 200 lines)."
+    },
+    {
+      "severity": "medium",
+      "category": "performance",
+      "file": "control-plane/src/state/postgres.rs",
+      "line": 462,
+      "description": "`get_all_loops` has no row limit and no pagination. For long-lived deployments with thousands of historical loops, this query loads the entire loops table into memory. `build_fleet_summary` calls this on every 60s cache miss, and `build_feed_response`, `build_specs_response`, and `build_stats_response` each call it on every request. Multiple concurrent dashboard users could trigger parallel full-table scans.",
+      "suggestion": "Add a WHERE clause to limit by `created_at` window for endpoints that don't need the full history (fleet_summary only needs 14 days for current + previous window, feed only needs terminal loops, stats only needs the selected window). Alternatively, add a configurable max row count with a warning log when exceeded."
+    },
+    {
+      "severity": "low",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/aggregate.rs",
+      "line": 980,
+      "description": "Manual `Deserialize` implementation for `StatsResponse` is dead code. `StatsResponse` already derives `Clone`, and the `StatsCache::get` method uses `.clone()` directly. The 100-line hand-written Deserialize impl with inner structs adds unnecessary maintenance burden.",
+      "suggestion": "Either derive `Deserialize` on `StatsResponse` (and its nested types) if deserialization is needed elsewhere, or remove the manual impl entirely since `StatsCache` uses `Clone`."
+    },
+    {
+      "severity": "low",
+      "category": "style",
+      "file": "control-plane/src/state/postgres.rs",
+      "line": 462,
+      "description": "`get_all_loops` uses `format!()` for SQL query construction and `sqlx::query()` (runtime) instead of `sqlx::query!()` (compile-time checked). The project guidelines specify compile-time query checking where possible.",
+      "suggestion": "Use two separate `sqlx::query!()` calls behind a conditional branch instead of string formatting, to preserve compile-time SQL checking."
+    },
+    {
+      "severity": "low",
+      "category": "style",
+      "file": "control-plane/src/api/dashboard/mod.rs",
+      "line": 36,
+      "description": "Type annotation `let authed: Router<AppState>` is misleading. After `.with_state(dash_state)` where `dash_state: DashboardState`, the actual type is closer to `Router<()>` (state consumed). The annotation compiles due to axum's merge coercion but misrepresents the router's actual state requirement.",
+      "suggestion": "Remove the explicit type annotation or change to `let authed = Router::new()...` to let the compiler infer the correct type."
+    }
+  ]
+}

--- a/.agent/review-feedback-round-9.json
+++ b/.agent/review-feedback-round-9.json
@@ -1,0 +1,94 @@
+{
+  "round": 9,
+  "source": "review",
+  "issues": [
+    {
+      "severity": "medium",
+      "category": "performance",
+      "file": "control-plane/src/api/dashboard/aggregate.rs",
+      "line": 654,
+      "description": "build_feed_response calls store.get_all_loops(true, None) which loads the ENTIRE loops table from Postgres with no time bound or row limit. For long-lived deployments with thousands of historical loops, this unbounded query runs on every feed page load and every 'Load more' click. The specs endpoint (line 766) has the same problem — it loads all loops then filters by spec_path in Rust instead of SQL.",
+      "suggestion": "For the feed: add a reasonable time window (e.g., 90 days) or pass a since parameter. For the specs endpoint: add a get_loops_by_spec_path(spec_path, limit, offset) method to StateStore that pushes the WHERE clause to SQL instead of loading the full table and filtering in Rust."
+    },
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/templates.rs",
+      "line": 690,
+      "description": "Feed page per-engineer filter chips generate URLs using the legacy ?filter= parameter (e.g., /dashboard/feed?filter=alice). The resolve_feed_filters function maps 'converged' and 'failed' to state filters before checking engineer names. If an engineer is literally named 'converged' or 'failed', their filter chip becomes a state filter instead — showing all converged/failed loops rather than that engineer's loops. The new state_filter/engineer_filter params exist to fix this, but the HTML template still generates legacy filter= URLs.",
+      "suggestion": "Change the engineer chip onclick URLs to use the explicit engineer_filter param: /dashboard/feed?engineer_filter=<name>. Similarly, change state chips to use ?state_filter=converged. This avoids the ambiguity entirely while the legacy fallback continues to work for old bookmarks."
+    },
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/mod.rs",
+      "line": 36,
+      "description": "The authed Router<DashboardState> is converted to Router<()> via .with_state(dash_state), then merged into public Router<AppState>. In axum, merging Router<()> into Router<S> works, but the parent build_router() later calls .with_state(state) on the entire merged router. Public route handlers (login_page, login_submit, etc.) that don't extract State work fine, but the type progression is fragile — any future handler added to the 'public' router that needs AppState will silently fail to compile, with a confusing error about AppState vs ().",
+      "suggestion": "Add a comment documenting the type conversion chain, or restructure so public routes that might need AppState in the future use .with_state(app_state.clone()) explicitly."
+    },
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "control-plane/assets/dashboard.js",
+      "line": 424,
+      "description": "restoreFeedFilter checks feedList.children.length === 0 to detect empty results and clear the stale filter. But feed-list contains both .feed-item elements and potentially the .empty-state div (which IS a child). When the feed has no results but the server renders the empty-state div, children.length is 1 (not 0), so the stale-filter-clearing logic never triggers. User gets stuck seeing 'No events match this filter' with no way to clear it except manually editing localStorage.",
+      "suggestion": "Check for the presence of .feed-item children specifically: feedList.querySelectorAll('.feed-item').length === 0. Or check for the .empty-state element as the indicator."
+    },
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/handlers.rs",
+      "line": 256,
+      "description": "The dashboard_stream SSE handler for active loops calls store.get_logs(id, None, None) to get all logs, then skips to the last 200. For loops with thousands of log lines, this loads the entire log history into memory just to take the tail. This happens on every detail page load for active loops.",
+      "suggestion": "Add a get_recent_logs(loop_id, limit) method to StateStore that uses ORDER BY timestamp DESC LIMIT 200 in SQL, then reverse the results in Rust. This avoids loading the full log history."
+    },
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/handlers.rs",
+      "line": 200,
+      "description": "The loop detail page handler also calls store.get_logs(id, None, None) to load ALL logs for the log pane's initial render. For a loop with 50K log lines, this loads all 50K into memory just to show the last 200. Combined with the SSE handler doing the same thing, a detail page load for an active loop executes two full-log-history queries.",
+      "suggestion": "Same fix: use a LIMIT query for the initial log pane render. The SSE handler's initial batch should also use the limited query."
+    },
+    {
+      "severity": "medium",
+      "category": "correctness",
+      "file": "control-plane/src/state/postgres.rs",
+      "line": 481,
+      "description": "get_all_loops(true, None) executes 'SELECT * FROM loops ORDER BY created_at DESC' with no LIMIT. Combined with the fact that build_feed_response and build_specs_response both call this with None, long-lived deployments accumulate unbounded data. The project guidelines say 'Postgres not SQLite: Multi-pod future, concurrent access' — multiple dashboard users hitting feed/specs simultaneously would each trigger a full table scan.",
+      "suggestion": "Add a safety LIMIT (e.g., 10000) to the (true, None) branch with a tracing::warn when the limit is hit. Or require callers to always provide a since parameter by removing the None option."
+    },
+    {
+      "severity": "low",
+      "category": "correctness",
+      "file": "control-plane/assets/dashboard.js",
+      "line": 163,
+      "description": "The kill switch button is visible when engineerFilter !== 'mine' (including individual engineer views), but FR-10d says it should only be visible 'when viewing team mode, NOT in Mine'. Showing it for individual engineer views (e.g., viewing just alice's loops) is a spec deviation — the kill switch would cancel ALL active loops, not just the displayed engineer's loops, which is confusing UX.",
+      "suggestion": "Change the condition to: killBtn.style.display = engineerFilter === 'team' ? '' : 'none'. This restricts the kill switch to team mode only, matching the spec."
+    },
+    {
+      "severity": "low",
+      "category": "style",
+      "file": "control-plane/src/state/postgres.rs",
+      "line": 467,
+      "description": "get_all_loops uses runtime sqlx::query() instead of compile-time sqlx::query!() for all three query branches. The project guidelines specify 'Compile-time query checking where possible.'",
+      "suggestion": "Use sqlx::query!() with separate static queries for each branch to get compile-time SQL checking."
+    },
+    {
+      "severity": "low",
+      "category": "correctness",
+      "file": "control-plane/src/api/dashboard/templates.rs",
+      "line": 690,
+      "description": "Feed filter chip onclick handlers use inline onclick attributes which won't fire if Content-Security-Policy restricts inline event handlers. While no CSP is currently set, this is fragile for future security hardening.",
+      "suggestion": "Use data attributes and addEventListener in dashboard.js instead of inline onclick handlers, consistent with how other interactive elements are wired."
+    },
+    {
+      "severity": "low",
+      "category": "style",
+      "file": "control-plane/src/api/dashboard/aggregate.rs",
+      "line": 980,
+      "description": "The manual Deserialize implementation for StatsResponse (referenced in round 8 review) appears to have been removed in favor of Clone derive. However, StatsResponse still doesn't derive Deserialize, which means it can't be deserialized from external sources if needed in the future.",
+      "suggestion": "Consider deriving Deserialize on StatsResponse for completeness, though it's not strictly needed if only Clone is used for caching."
+    }
+  ]
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2259,6 +2259,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "maud"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8156733e27020ea5c684db5beac5d1d611e1272ab17901a49466294b84fc217e"
+dependencies = [
+ "axum-core",
+ "http",
+ "itoa",
+ "maud_macros",
+]
+
+[[package]]
+name = "maud_macros"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7261b00f3952f617899bc012e3dbd56e4f0110a038175929fa5d18e5a19913ca"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2337,6 +2361,7 @@ dependencies = [
  "http",
  "k8s-openapi",
  "kube",
+ "maud",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -2933,6 +2958,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
 ]
 
 [[package]]

--- a/control-plane/Cargo.toml
+++ b/control-plane/Cargo.toml
@@ -36,6 +36,7 @@ futures.workspace = true
 toml.workspace = true
 async-trait.workspace = true
 async-stream.workspace = true
+maud = { version = "0.27", features = ["axum"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/control-plane/assets/dashboard.css
+++ b/control-plane/assets/dashboard.css
@@ -1,0 +1,546 @@
+/* nautiloop dashboard — mobile-first CSS (FR-6) */
+/* Dark palette from helm TUI; light palette inverts luminance */
+
+:root {
+  --bg: #f8f8f7;
+  --surface: #ffffff;
+  --surface-hover: #f0efee;
+  --text: #1a1918;
+  --text-muted: #6b6966;
+  --border: #e0dfde;
+  --teal: #1b6b5a;
+  --amber: #b8841c;
+  --green: #2d7a4f;
+  --red: #c4392d;
+  --blue: #3b7bc0;
+  --gray: #8a8785;
+  --badge-green-bg: #d4edda;
+  --badge-green-fg: #155724;
+  --badge-red-bg: #f8d7da;
+  --badge-red-fg: #721c24;
+  --badge-amber-bg: #fff3cd;
+  --badge-amber-fg: #856404;
+  --badge-blue-bg: #cce5ff;
+  --badge-blue-fg: #004085;
+  --badge-gray-bg: #e2e3e5;
+  --badge-gray-fg: #383d41;
+  --input-bg: #ffffff;
+  --input-border: #cccccc;
+  --toast-bg: #333333;
+  --toast-fg: #ffffff;
+  --modal-overlay: rgba(0,0,0,0.4);
+  --pulse-color: #2d7a4f;
+  --chip-bg: #e8e7e6;
+  --chip-active-bg: #1b6b5a;
+  --chip-active-fg: #ffffff;
+  --bar-bg: #e0dfde;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0f0f0e;
+    --surface: #1a1918;
+    --surface-hover: #252423;
+    --text: #e8e7e6;
+    --text-muted: #8a8785;
+    --border: #2e2d2c;
+    --badge-green-bg: #1a3d2a;
+    --badge-green-fg: #6fcf97;
+    --badge-red-bg: #3d1a1a;
+    --badge-red-fg: #f07070;
+    --badge-amber-bg: #3d3018;
+    --badge-amber-fg: #e8a838;
+    --badge-blue-bg: #1a2d40;
+    --badge-blue-fg: #7cb3e0;
+    --badge-gray-bg: #2e2d2c;
+    --badge-gray-fg: #a0a0a0;
+    --input-bg: #252423;
+    --input-border: #444;
+    --toast-bg: #333;
+    --toast-fg: #eee;
+    --modal-overlay: rgba(0,0,0,0.6);
+    --chip-bg: #2e2d2c;
+    --chip-active-bg: #1b6b5a;
+    --chip-active-fg: #e8e7e6;
+    --bar-bg: #2e2d2c;
+  }
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.5;
+  -webkit-text-size-adjust: 100%;
+  padding: 0;
+  margin: 0;
+}
+
+a { color: var(--blue); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+/* Header */
+.dash-header {
+  position: sticky; top: 0; z-index: 100;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  padding: 0.5rem 1rem;
+  display: flex; align-items: center; justify-content: space-between;
+}
+.dash-header h1 { font-size: 1.1rem; font-weight: 600; }
+.dash-header nav { display: flex; gap: 1rem; font-size: 0.85rem; }
+.dash-header nav a { color: var(--text-muted); }
+.dash-header nav a.active { color: var(--text); font-weight: 600; }
+.header-menu { position: relative; }
+.header-menu-btn {
+  background: none; border: none; color: var(--text-muted);
+  font-size: 1.3rem; cursor: pointer; padding: 0.25rem 0.5rem;
+}
+.header-menu-dropdown {
+  display: none; position: absolute; right: 0; top: 100%;
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 6px; padding: 0.25rem 0; min-width: 200px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15); z-index: 200;
+}
+.header-menu-dropdown.open { display: block; }
+.header-menu-dropdown button {
+  width: 100%; text-align: left; padding: 0.5rem 1rem;
+  background: none; border: none; color: var(--red);
+  cursor: pointer; font-size: 0.85rem;
+}
+.header-menu-dropdown button:hover { background: var(--surface-hover); }
+
+/* Fleet summary (FR-9) */
+.fleet-summary {
+  padding: 0.5rem 1rem;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+  white-space: nowrap;
+  overflow-x: auto;
+}
+.fleet-summary span { margin-right: 0.3rem; }
+.fleet-summary a { color: var(--text-muted); }
+.fleet-summary a:hover { color: var(--text); }
+.trend-up { color: var(--green); }
+.trend-down { color: var(--red); }
+
+/* Filter chips (FR-3e) */
+.filter-bar {
+  padding: 0.5rem 1rem;
+  display: flex; flex-wrap: wrap; gap: 0.4rem;
+  border-bottom: 1px solid var(--border);
+}
+.chip {
+  display: inline-flex; align-items: center;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  background: var(--chip-bg);
+  color: var(--text);
+  cursor: pointer; border: none;
+  transition: background 0.2s, color 0.2s;
+  white-space: nowrap;
+}
+.chip.active {
+  background: var(--chip-active-bg);
+  color: var(--chip-active-fg);
+}
+.chip:hover { opacity: 0.85; }
+
+/* Card grid (FR-3a) */
+.card-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+}
+@media (min-width: 640px) {
+  .card-grid { grid-template-columns: repeat(2, 1fr); }
+}
+@media (min-width: 1024px) {
+  .card-grid { grid-template-columns: repeat(3, 1fr); }
+}
+@media (min-width: 1400px) {
+  .card-grid { grid-template-columns: repeat(4, 1fr); }
+}
+
+/* Card (FR-3b) */
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.75rem;
+  cursor: pointer;
+  transition: border-color 0.2s;
+  position: relative;
+  text-decoration: none;
+  color: inherit;
+  display: block;
+}
+.card:hover { border-color: var(--teal); text-decoration: none; }
+.card-header { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.35rem; }
+.card-title { font-weight: 600; font-size: 0.9rem; word-break: break-all; }
+.card-subtitle { font-size: 0.75rem; color: var(--text-muted); margin-bottom: 0.25rem; word-break: break-all; }
+.card-progress { font-size: 0.75rem; color: var(--text-muted); margin-bottom: 0.25rem; }
+.card-metrics { display: flex; gap: 0.75rem; font-size: 0.75rem; color: var(--text-muted); flex-wrap: wrap; }
+.card-engineer {
+  position: absolute; top: 0.4rem; right: 0.5rem;
+  font-size: 0.65rem; font-weight: 600;
+  padding: 0.1rem 0.35rem; border-radius: 4px;
+  color: #fff;
+}
+
+/* Badges */
+.badge {
+  display: inline-block;
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  white-space: nowrap;
+  transition: background 1s, color 1s;
+}
+.badge-green { background: var(--badge-green-bg); color: var(--badge-green-fg); }
+.badge-red { background: var(--badge-red-bg); color: var(--badge-red-fg); }
+.badge-amber { background: var(--badge-amber-bg); color: var(--badge-amber-fg); }
+.badge-blue { background: var(--badge-blue-bg); color: var(--badge-blue-fg); }
+.badge-gray { background: var(--badge-gray-bg); color: var(--badge-gray-fg); }
+
+/* Pulse indicator (FR-3b) */
+.pulse {
+  display: inline-block; width: 8px; height: 8px;
+  border-radius: 50%; flex-shrink: 0;
+}
+.pulse-running {
+  background: var(--pulse-color);
+  animation: pulse-anim 1.2s infinite;
+}
+.pulse-dispatched {
+  border: 2px solid var(--pulse-color);
+  background: transparent;
+  animation: pulse-anim 2.4s infinite;
+}
+.pulse-completed { background: var(--gray); }
+@keyframes pulse-anim {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+/* Detail page (FR-4) */
+.detail-hero {
+  padding: 1rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+}
+.detail-hero h2 { font-size: 1.1rem; margin-bottom: 0.25rem; }
+.detail-hero .meta { font-size: 0.8rem; color: var(--text-muted); display: flex; flex-wrap: wrap; gap: 0.5rem; }
+
+.detail-actions {
+  padding: 0.5rem 1rem;
+  display: flex; gap: 0.5rem;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--border);
+}
+.btn {
+  padding: 0.4rem 0.8rem;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s;
+}
+.btn:hover { background: var(--surface-hover); }
+.btn-primary { background: var(--teal); color: #fff; border-color: var(--teal); }
+.btn-primary:hover { opacity: 0.9; }
+.btn-danger { color: var(--red); border-color: var(--red); }
+.btn-danger:hover { background: var(--badge-red-bg); }
+
+/* Rounds table (FR-4a) */
+.rounds-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8rem;
+}
+.rounds-table th {
+  text-align: left;
+  padding: 0.4rem 0.5rem;
+  border-bottom: 2px solid var(--border);
+  font-weight: 600;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  white-space: nowrap;
+}
+.rounds-table td {
+  padding: 0.4rem 0.5rem;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+.rounds-table tr:hover { background: var(--surface-hover); }
+.rounds-table .expandable { cursor: pointer; }
+.round-detail {
+  display: none;
+  padding: 0.5rem;
+  background: var(--bg);
+  font-size: 0.75rem;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+.round-detail.open { display: table-row; }
+
+/* Log pane (FR-4a) */
+.log-pane {
+  background: #0d0d0c;
+  color: #c8c8c6;
+  font-family: "SF Mono", "Fira Code", "Cascadia Code", monospace;
+  font-size: 0.72rem;
+  padding: 0.5rem;
+  overflow-y: auto;
+  max-height: 400px;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+.log-pane .log-line { display: block; }
+
+/* Detail layout */
+.detail-content { padding: 0.75rem 1rem; }
+@media (min-width: 1024px) {
+  .detail-split {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+  }
+}
+
+/* Pod introspect (FR-5) */
+.pod-introspect summary {
+  cursor: pointer;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  padding: 0.5rem 0;
+}
+.pod-introspect-data {
+  font-size: 0.75rem;
+  padding: 0.5rem;
+  background: var(--bg);
+  border-radius: 6px;
+}
+
+/* Token breakdown */
+.token-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.75rem;
+  margin-top: 0.5rem;
+}
+.token-table th, .token-table td {
+  padding: 0.3rem 0.5rem;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+}
+.bar-cell { width: 40%; }
+.bar {
+  height: 14px;
+  background: var(--teal);
+  border-radius: 3px;
+  transition: width 0.3s;
+}
+
+/* Login page */
+.login-container {
+  max-width: 360px;
+  margin: 4rem auto;
+  padding: 2rem;
+  background: var(--surface);
+  border-radius: 10px;
+  border: 1px solid var(--border);
+}
+.login-container h1 { font-size: 1.3rem; margin-bottom: 1rem; text-align: center; }
+.login-container label {
+  display: block; font-size: 0.85rem;
+  margin-bottom: 0.25rem; color: var(--text-muted);
+}
+.login-container input {
+  width: 100%; padding: 0.5rem;
+  border: 1px solid var(--input-border);
+  border-radius: 6px;
+  background: var(--input-bg);
+  color: var(--text);
+  font-size: 0.9rem;
+  margin-bottom: 0.75rem;
+}
+.login-container .btn { width: 100%; margin-top: 0.5rem; }
+.login-error {
+  background: var(--badge-red-bg);
+  color: var(--badge-red-fg);
+  padding: 0.5rem;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  margin-bottom: 0.75rem;
+}
+
+/* Feed page (FR-12) */
+.feed-list { padding: 0.75rem 1rem; }
+.feed-item {
+  display: flex; align-items: center; gap: 0.5rem;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.8rem;
+  flex-wrap: wrap;
+  cursor: pointer;
+  color: inherit;
+  text-decoration: none;
+}
+.feed-item:hover { background: var(--surface-hover); }
+.feed-time { color: var(--text-muted); white-space: nowrap; min-width: 3.5rem; }
+.feed-spec { font-weight: 500; word-break: break-all; }
+.feed-detail { color: var(--text-muted); }
+
+/* Stats page (FR-14) */
+.stats-cards {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+}
+@media (min-width: 640px) {
+  .stats-cards { grid-template-columns: repeat(4, 1fr); }
+}
+.stat-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.75rem;
+  scroll-margin-top: 80px;
+}
+.stat-card .label { font-size: 0.7rem; color: var(--text-muted); text-transform: uppercase; }
+.stat-card .value { font-size: 1.3rem; font-weight: 700; }
+
+.stats-section {
+  padding: 0.75rem 1rem;
+}
+.stats-section h3 {
+  font-size: 0.85rem;
+  margin-bottom: 0.5rem;
+  color: var(--text-muted);
+  scroll-margin-top: 80px;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8rem;
+}
+.data-table th {
+  text-align: left;
+  padding: 0.35rem 0.5rem;
+  border-bottom: 2px solid var(--border);
+  font-weight: 600;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+}
+.data-table td {
+  padding: 0.35rem 0.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+/* Time series bars */
+.ts-row { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.25rem; font-size: 0.75rem; }
+.ts-label { min-width: 5rem; color: var(--text-muted); }
+.ts-bars { flex: 1; display: flex; gap: 2px; height: 16px; }
+.ts-bar { border-radius: 2px; height: 100%; }
+.ts-bar-converged { background: var(--green); }
+.ts-bar-failed { background: var(--red); }
+.ts-bar-started { background: var(--bar-bg); }
+.ts-count { min-width: 2rem; text-align: right; color: var(--text-muted); }
+
+/* Modal */
+.modal-overlay {
+  display: none; position: fixed; inset: 0;
+  background: var(--modal-overlay); z-index: 1000;
+  align-items: center; justify-content: center;
+}
+.modal-overlay.open { display: flex; }
+.modal {
+  background: var(--surface);
+  border-radius: 10px;
+  padding: 1.5rem;
+  max-width: 360px;
+  width: 90%;
+  border: 1px solid var(--border);
+}
+.modal h3 { font-size: 1rem; margin-bottom: 0.75rem; }
+.modal-actions { display: flex; gap: 0.5rem; margin-top: 1rem; justify-content: flex-end; }
+
+/* Toast */
+.toast-container {
+  position: fixed; top: 1rem; right: 1rem; z-index: 1100;
+  display: flex; flex-direction: column; gap: 0.5rem;
+}
+.toast {
+  background: var(--toast-bg); color: var(--toast-fg);
+  padding: 0.6rem 1rem; border-radius: 6px;
+  font-size: 0.8rem; max-width: 340px;
+  animation: toast-in 0.3s;
+}
+@keyframes toast-in { from { opacity: 0; transform: translateY(-10px); } }
+
+/* Spec history (FR-13) */
+.spec-header { padding: 1rem; border-bottom: 1px solid var(--border); background: var(--surface); }
+.spec-header h2 { font-size: 1rem; word-break: break-all; }
+.spec-aggregates { display: flex; gap: 1rem; font-size: 0.8rem; color: var(--text-muted); margin-top: 0.3rem; flex-wrap: wrap; }
+
+/* Empty state */
+.empty-state {
+  text-align: center;
+  padding: 3rem 1rem;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+/* Load more */
+.load-more {
+  text-align: center; padding: 1rem;
+}
+.load-more .btn { min-width: 150px; }
+
+/* Highlight animation (FR-9c) */
+.highlight-pulse {
+  animation: highlight-ring 2s ease-out;
+}
+@keyframes highlight-ring {
+  0% { outline: 3px solid var(--teal); outline-offset: 2px; }
+  100% { outline: 3px solid transparent; outline-offset: 2px; }
+}
+
+/* Responsive table scroll */
+.table-wrap { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+
+/* Judge icon (FR-11) */
+.judge-icon {
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+.judge-drawer {
+  display: none;
+  padding: 0.5rem;
+  background: var(--bg);
+  font-size: 0.75rem;
+  border-radius: 6px;
+  margin-top: 0.25rem;
+}
+.judge-drawer.open { display: block; }
+
+/* Section padding helper */
+.section { padding: 0.75rem 1rem; }
+
+/* Scrollable container */
+.scroll-y { overflow-y: auto; -webkit-overflow-scrolling: touch; }

--- a/control-plane/assets/dashboard.js
+++ b/control-plane/assets/dashboard.js
@@ -85,11 +85,12 @@
     return !isTerminal(state);
   }
 
-  // Stable per-engineer color from name hash
+  // Stable per-engineer color from name hash (uses UTF-8 bytes to match Rust)
   function engineerColor(name) {
     let h = 0;
-    for (let i = 0; i < name.length; i++) {
-      h = ((h << 5) - h + name.charCodeAt(i)) | 0;
+    const bytes = new TextEncoder().encode(name);
+    for (let i = 0; i < bytes.length; i++) {
+      h = ((h << 5) - h + bytes[i]) | 0;
     }
     const hue = ((h % 360) + 360) % 360;
     return "hsl(" + hue + ",55%,45%)";
@@ -123,7 +124,7 @@
       + '<div class="card-subtitle">' + esc(loop.branch) + '</div>'
       + '<div class="card-progress">' + progress + '</div>'
       + '<div class="card-metrics">'
-      + '<span>' + fmtTokens((loop.total_tokens||{}).input + (loop.total_tokens||{}).output) + ' tok</span>'
+      + '<span>' + fmtTokens(((loop.total_tokens||{}).input || 0) + ((loop.total_tokens||{}).output || 0)) + ' tok</span>'
       + '<span>' + fmtCost(loop.total_cost) + '</span>'
       + '<span>' + esc(verdict) + '</span>'
       + '</div>'
@@ -352,25 +353,37 @@
           .then(() => { showToast("Extended +10 rounds"); location.reload(); })
           .catch(err => showToast("Error: " + err.message));
       } else if (action === "cancel-all") {
-        const activeLoops = btn.dataset.activeIds ? btn.dataset.activeIds.split(",") : [];
-        showConfirmModal(
-          "Cancel " + activeLoops.length + " active loops?",
-          "This cannot be undone.",
-          function() {
-            let ok = 0, fail = 0;
-            const promises = activeLoops.map(id =>
-              actionFetch("/cancel/" + id, "DELETE")
-                .then(() => ok++)
-                .catch(() => fail++)
+        // Fetch current active loop IDs from /dashboard/state before cancelling
+        fetch("/dashboard/state?team=true", { credentials: "same-origin" })
+          .then(r => r.ok ? r.json() : Promise.reject(r.status))
+          .then(data => {
+            const activeLoops = (data.loops || [])
+              .filter(l => isActive(l.state))
+              .map(l => l.id);
+            if (activeLoops.length === 0) {
+              showToast("No active loops to cancel.");
+              return;
+            }
+            showConfirmModal(
+              "Cancel " + activeLoops.length + " active loops?",
+              "This cannot be undone.",
+              function() {
+                let ok = 0, fail = 0;
+                const promises = activeLoops.map(id =>
+                  actionFetch("/cancel/" + id, "DELETE")
+                    .then(() => ok++)
+                    .catch(() => fail++)
+                );
+                Promise.all(promises).then(() => {
+                  let msg = "Cancelled " + ok + "/" + activeLoops.length + " loops";
+                  if (fail > 0) msg += " (" + fail + " failed)";
+                  showToast(msg);
+                  poll();
+                });
+              }
             );
-            Promise.all(promises).then(() => {
-              let msg = "Cancelled " + ok + "/" + activeLoops.length + " loops";
-              if (fail > 0) msg += " (" + fail + " failed)";
-              showToast(msg);
-              poll();
-            });
-          }
-        );
+          })
+          .catch(e => showToast("Error fetching active loops: " + e));
       }
     });
   }

--- a/control-plane/assets/dashboard.js
+++ b/control-plane/assets/dashboard.js
@@ -152,6 +152,7 @@
       for (const loop of data.loops) {
         if (prevStates[loop.id] && !isTerminal(prevStates[loop.id]) && loop.state === "CONVERGED") {
           convergedSinceLastFocus++;
+          playBell();
         }
         prevStates[loop.id] = loop.state;
       }
@@ -227,8 +228,8 @@
     const f = data.fleet_summary;
     let parts = [];
     parts.push("This week");
-    parts.push("\u00b7 " + f.total_loops + " loops");
-    if (f.total_cost != null) parts.push("\u00b7 " + fmtCost(f.total_cost));
+    parts.push('\u00b7 <a href="/dashboard/stats#total-loops" class="fleet-link">' + f.total_loops + " loops</a>");
+    if (f.total_cost != null) parts.push('\u00b7 <a href="/dashboard/stats#total-cost" class="fleet-link">' + fmtCost(f.total_cost) + "</a>");
     const cr = f.converge_rate != null ? Math.round(f.converge_rate * 100) : null;
     if (cr != null) {
       let trend = "";
@@ -237,7 +238,7 @@
         if (d > 0) trend = ' <span class="trend-up">\u2191' + d + '%</span>';
         else if (d < 0) trend = ' <span class="trend-down">\u2193' + Math.abs(d) + '%</span>';
       }
-      parts.push("\u00b7 " + cr + "%" + trend + " converged");
+      parts.push('\u00b7 <a href="/dashboard/stats#converge-rate" class="fleet-link">' + cr + "%" + trend + " converged</a>");
     }
     if (f.avg_rounds != null) {
       let trend = "";
@@ -246,10 +247,10 @@
         if (d > 0.05) trend = ' <span class="trend-down">\u2191' + d.toFixed(1) + '</span>';
         else if (d < -0.05) trend = ' <span class="trend-up">\u2193' + Math.abs(d).toFixed(1) + '</span>';
       }
-      parts.push("\u00b7 avg " + f.avg_rounds.toFixed(1) + trend + " rounds");
+      parts.push('\u00b7 <a href="/dashboard/stats#avg-rounds" class="fleet-link">avg ' + f.avg_rounds.toFixed(1) + trend + " rounds</a>");
     }
     if (f.top_spender && f.top_spender.cost != null) {
-      parts.push("\u00b7 top: " + esc(f.top_spender.engineer) + " (" + fmtCost(f.top_spender.cost) + ")");
+      parts.push('\u00b7 <a href="/dashboard/stats#per-engineer" class="fleet-link">top: ' + esc(f.top_spender.engineer) + " (" + fmtCost(f.top_spender.cost) + ")</a>");
     }
     el.innerHTML = parts.join(" ");
   }
@@ -472,6 +473,20 @@
     });
   }
 
+  // --- Bell Toggle ---
+  function bindBellToggle() {
+    const btn = document.getElementById("bell-toggle");
+    if (!btn) return;
+    // Initialize label from current state
+    btn.textContent = bellEnabled ? "Bell: on" : "Bell: off";
+    btn.addEventListener("click", function(e) {
+      e.stopPropagation();
+      bellEnabled = !bellEnabled;
+      btn.textContent = bellEnabled ? "Bell: on" : "Bell: off";
+      try { localStorage.setItem("nautiloop_bell", bellEnabled ? "on" : "off"); } catch(e) {}
+    });
+  }
+
   // --- Round Row Expand ---
   function bindRoundExpand() {
     document.querySelectorAll(".round-row").forEach(function(row) {
@@ -485,6 +500,41 @@
   }
 
   // --- Feed Page ---
+  // Persist feed filter selection in localStorage (FR-12b, progressive enhancement).
+  function bindFeedFilters() {
+    const feedList = document.getElementById("feed-list");
+    if (!feedList) return;
+    // Intercept filter chip clicks within the feed page filter bar to persist in localStorage.
+    document.querySelectorAll(".filter-bar .chip[onclick]").forEach(function(chip) {
+      const originalOnclick = chip.getAttribute("onclick");
+      chip.removeAttribute("onclick");
+      chip.addEventListener("click", function() {
+        // Extract filter value from the onclick URL
+        const match = originalOnclick.match(/filter=([^'"]*)/);
+        const filter = match ? match[1] : "";
+        try { localStorage.setItem("nautiloop_feed_filter", filter); } catch(e) {}
+        // Execute original navigation
+        (new Function(originalOnclick))();
+      });
+    });
+  }
+
+  // On feed page load, apply saved filter if no explicit filter is in the URL.
+  function restoreFeedFilter() {
+    const feedList = document.getElementById("feed-list");
+    if (!feedList) return;
+    const params = new URLSearchParams(location.search);
+    // Only restore if user navigated to /dashboard/feed without a filter param.
+    if (!params.has("filter") && !params.has("cursor")) {
+      try {
+        const saved = localStorage.getItem("nautiloop_feed_filter");
+        if (saved) {
+          location.href = "/dashboard/feed?filter=" + encodeURIComponent(saved);
+        }
+      } catch(e) {}
+    }
+  }
+
   function bindFeedLoadMore() {
     const btn = document.getElementById("feed-load-more");
     if (!btn) return;
@@ -503,7 +553,8 @@
             list.insertAdjacentHTML("beforeend", renderFeedItem(ev));
           }
           if (data.has_more && data.events.length > 0) {
-            btn.dataset.cursor = data.events[data.events.length - 1].updated_at;
+            const last = data.events[data.events.length - 1];
+            btn.dataset.cursor = last.updated_at + "|" + last.id;
           } else {
             btn.style.display = "none";
           }
@@ -535,6 +586,28 @@
         window.location.href = "/dashboard/stats?window=" + w;
       });
     });
+  }
+
+  // --- Web Audio Bell (Progressive Enhancement, FR-7a) ---
+  // Opt-in notification bell when a loop converges. Preference stored in localStorage.
+  let bellEnabled = false;
+  try { bellEnabled = localStorage.getItem("nautiloop_bell") === "on"; } catch(e) {}
+
+  function playBell() {
+    if (!bellEnabled) return;
+    try {
+      const ctx = new (window.AudioContext || window.webkitAudioContext)();
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      osc.type = "sine";
+      osc.frequency.value = 880;
+      gain.gain.setValueAtTime(0.3, ctx.currentTime);
+      gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.3);
+      osc.start(ctx.currentTime);
+      osc.stop(ctx.currentTime + 0.3);
+    } catch(e) {}
   }
 
   // --- Focus Tracking (Progressive Enhancement) ---
@@ -584,7 +657,10 @@
 
     bindActions();
     bindHeaderMenu();
+    bindBellToggle();
     bindRoundExpand();
+    restoreFeedFilter();
+    bindFeedFilters();
     bindFeedLoadMore();
     bindStatsWindow();
     highlightHash();

--- a/control-plane/assets/dashboard.js
+++ b/control-plane/assets/dashboard.js
@@ -520,10 +520,19 @@
   }
 
   // On feed page load, apply saved filter if no explicit filter is in the URL.
+  // If the restored filter yields an empty feed, clear the localStorage value
+  // and redirect to the unfiltered view so the user is not stuck.
   function restoreFeedFilter() {
     const feedList = document.getElementById("feed-list");
     if (!feedList) return;
     const params = new URLSearchParams(location.search);
+    // If we navigated with a saved filter and the feed is empty, clear it.
+    if (params.has("filter") && feedList.children.length === 0) {
+      try { localStorage.removeItem("nautiloop_feed_filter"); } catch(e) {}
+      // Redirect to unfiltered feed so user sees content
+      location.href = "/dashboard/feed";
+      return;
+    }
     // Only restore if user navigated to /dashboard/feed without a filter param.
     if (!params.has("filter") && !params.has("cursor")) {
       try {

--- a/control-plane/assets/dashboard.js
+++ b/control-plane/assets/dashboard.js
@@ -180,7 +180,7 @@
     // Show/hide kill switch (FR-10d)
     const killBtn = document.getElementById("kill-switch-btn");
     if (killBtn) {
-      killBtn.style.display = engineerFilter === "team" || engineerFilter !== "mine" ? "" : "none";
+      killBtn.style.display = engineerFilter === "team" ? "" : "none";
     }
   }
 
@@ -504,17 +504,22 @@
   function bindFeedFilters() {
     const feedList = document.getElementById("feed-list");
     if (!feedList) return;
-    // Intercept filter chip clicks within the feed page filter bar to persist in localStorage.
-    document.querySelectorAll(".filter-bar .chip[onclick]").forEach(function(chip) {
-      const originalOnclick = chip.getAttribute("onclick");
-      chip.removeAttribute("onclick");
+    // Wire feed filter chips via data attributes (no inline onclick).
+    document.querySelectorAll(".filter-bar [data-feed-filter-type]").forEach(function(chip) {
       chip.addEventListener("click", function() {
-        // Extract filter value from the onclick URL
-        const match = originalOnclick.match(/filter=([^'"]*)/);
-        const filter = match ? match[1] : "";
-        try { localStorage.setItem("nautiloop_feed_filter", filter); } catch(e) {}
-        // Execute original navigation
-        (new Function(originalOnclick))();
+        var filterType = chip.getAttribute("data-feed-filter-type");
+        var filterVal = chip.getAttribute("data-feed-filter");
+        var url = "/dashboard/feed";
+        if (filterType === "state" && filterVal) {
+          url += "?state_filter=" + encodeURIComponent(filterVal);
+        } else if (filterType === "engineer" && filterVal) {
+          url += "?engineer_filter=" + encodeURIComponent(filterVal);
+        }
+        // Persist for restore on next visit
+        try {
+          localStorage.setItem("nautiloop_feed_filter", filterType + ":" + (filterVal || ""));
+        } catch(e) {}
+        location.href = url;
       });
     });
   }
@@ -523,22 +528,29 @@
   // If the restored filter yields an empty feed, clear the localStorage value
   // and redirect to the unfiltered view so the user is not stuck.
   function restoreFeedFilter() {
-    const feedList = document.getElementById("feed-list");
+    var feedList = document.getElementById("feed-list");
     if (!feedList) return;
-    const params = new URLSearchParams(location.search);
-    // If we navigated with a saved filter and the feed is empty, clear it.
-    if (params.has("filter") && feedList.children.length === 0) {
+    var params = new URLSearchParams(location.search);
+    var hasFilter = params.has("state_filter") || params.has("engineer_filter") || params.has("filter");
+    // If we navigated with a filter and the feed has no items, clear the stale filter.
+    if (hasFilter && feedList.querySelectorAll(".feed-item").length === 0) {
       try { localStorage.removeItem("nautiloop_feed_filter"); } catch(e) {}
-      // Redirect to unfiltered feed so user sees content
       location.href = "/dashboard/feed";
       return;
     }
-    // Only restore if user navigated to /dashboard/feed without a filter param.
-    if (!params.has("filter") && !params.has("cursor")) {
+    // Only restore if user navigated to /dashboard/feed without any filter param.
+    if (!hasFilter && !params.has("cursor")) {
       try {
-        const saved = localStorage.getItem("nautiloop_feed_filter");
+        var saved = localStorage.getItem("nautiloop_feed_filter");
         if (saved) {
-          location.href = "/dashboard/feed?filter=" + encodeURIComponent(saved);
+          var parts = saved.split(":");
+          var type = parts[0];
+          var val = parts.slice(1).join(":");
+          if (type === "state" && val) {
+            location.href = "/dashboard/feed?state_filter=" + encodeURIComponent(val);
+          } else if (type === "engineer" && val) {
+            location.href = "/dashboard/feed?engineer_filter=" + encodeURIComponent(val);
+          }
         }
       } catch(e) {}
     }
@@ -549,10 +561,12 @@
     if (!btn) return;
     btn.addEventListener("click", function() {
       const cursor = btn.dataset.cursor;
-      const filter = btn.dataset.filter || "";
+      const stateFilter = btn.dataset.stateFilter || "";
+      const engineerFilter = btn.dataset.engineerFilter || "";
       let url = "/dashboard/feed?limit=50";
       if (cursor) url += "&cursor=" + encodeURIComponent(cursor);
-      if (filter) url += "&filter=" + encodeURIComponent(filter);
+      if (stateFilter) url += "&state_filter=" + encodeURIComponent(stateFilter);
+      if (engineerFilter) url += "&engineer_filter=" + encodeURIComponent(engineerFilter);
       fetch(url, { credentials: "same-origin" })
         .then(r => r.json())
         .then(data => {

--- a/control-plane/assets/dashboard.js
+++ b/control-plane/assets/dashboard.js
@@ -350,9 +350,11 @@
           .then(() => { showToast("Resumed"); location.reload(); })
           .catch(err => showToast("Error: " + err.message));
       } else if (action === "extend") {
-        actionFetch("/extend/" + loopId, "POST", { add_rounds: 10 })
-          .then(() => { showToast("Extended +10 rounds"); location.reload(); })
-          .catch(err => showToast("Error: " + err.message));
+        showConfirmModal("Extend +10 rounds?", "This will add 10 rounds and resume the loop.", function() {
+          actionFetch("/extend/" + loopId, "POST", { add_rounds: 10 })
+            .then(() => { showToast("Extended +10 rounds"); location.reload(); })
+            .catch(err => showToast("Error: " + err.message));
+        });
       } else if (action === "cancel-all") {
         // Fetch current active loop IDs from /dashboard/state before cancelling
         fetch("/dashboard/state?team=true", { credentials: "same-origin" })
@@ -616,10 +618,16 @@
   let bellEnabled = false;
   try { bellEnabled = localStorage.getItem("nautiloop_bell") === "on"; } catch(e) {}
 
+  // Reuse a single AudioContext to avoid hitting browser instance limits (typically 6-8).
+  let bellAudioCtx = null;
   function playBell() {
     if (!bellEnabled) return;
     try {
-      const ctx = new (window.AudioContext || window.webkitAudioContext)();
+      if (!bellAudioCtx) {
+        bellAudioCtx = new (window.AudioContext || window.webkitAudioContext)();
+      }
+      const ctx = bellAudioCtx;
+      if (ctx.state === "suspended") { ctx.resume(); }
       const osc = ctx.createOscillator();
       const gain = ctx.createGain();
       osc.connect(gain);

--- a/control-plane/assets/dashboard.js
+++ b/control-plane/assets/dashboard.js
@@ -1,0 +1,580 @@
+// nautiloop dashboard — vanilla ES2022 (FR-7)
+// Mandatory: polling, action buttons, SSE log stream, filter chips, confirm modals
+// Progressive: tab title badge, web audio bell, color fade animation, localStorage filters
+
+(function() {
+  "use strict";
+
+  const POLL_INTERVAL = 5000;
+  const INTROSPECT_INTERVAL = 5000;
+  const LOG_LINE_CAP = 200;
+
+  // --- State ---
+  let pollTimer = null;
+  let introspectTimer = null;
+  let eventSource = null;
+  let activeFilter = "active";
+  let engineerFilter = "mine";
+  let convergedSinceLastFocus = 0;
+  let prevStates = {};
+  let viewer = document.body.dataset.viewer || "";
+
+  // --- Helpers ---
+  function esc(s) {
+    if (!s) return "";
+    const d = document.createElement("div");
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  function fmtTokens(n) {
+    if (n == null) return "\u2014";
+    if (n >= 1000000) return (n / 1000000).toFixed(1) + "M";
+    if (n >= 1000) return (n / 1000).toFixed(0) + "K";
+    return String(n);
+  }
+
+  function fmtCost(c) {
+    if (c == null) return "\u2014";
+    return "$" + c.toFixed(2);
+  }
+
+  function fmtElapsed(created) {
+    const ms = Date.now() - new Date(created).getTime();
+    const s = Math.floor(ms / 1000);
+    if (s < 60) return s + "s";
+    const m = Math.floor(s / 60);
+    if (m < 60) return m + "m " + (s % 60) + "s";
+    const h = Math.floor(m / 60);
+    return h + "h " + (m % 60) + "m";
+  }
+
+  function specFilename(path) {
+    if (!path) return "\u2014";
+    const parts = path.split("/");
+    return parts[parts.length - 1];
+  }
+
+  function shortId(id) {
+    return id ? id.substring(0, 8) : "\u2014";
+  }
+
+  function badgeClass(state) {
+    const green = ["CONVERGED", "HARDENED", "SHIPPED"];
+    const red = ["FAILED", "CANCELLED"];
+    const amber = ["AWAITING_APPROVAL", "PAUSED", "AWAITING_REAUTH"];
+    const blue = ["IMPLEMENTING", "TESTING", "REVIEWING", "HARDENING"];
+    if (green.includes(state)) return "badge-green";
+    if (red.includes(state)) return "badge-red";
+    if (amber.includes(state)) return "badge-amber";
+    if (blue.includes(state)) return "badge-blue";
+    return "badge-gray";
+  }
+
+  function pulseClass(subState) {
+    if (subState === "RUNNING") return "pulse-running";
+    if (subState === "DISPATCHED") return "pulse-dispatched";
+    return "pulse-completed";
+  }
+
+  function isTerminal(state) {
+    return ["CONVERGED", "FAILED", "CANCELLED", "HARDENED", "SHIPPED"].includes(state);
+  }
+
+  function isActive(state) {
+    return !isTerminal(state);
+  }
+
+  // Stable per-engineer color from name hash
+  function engineerColor(name) {
+    let h = 0;
+    for (let i = 0; i < name.length; i++) {
+      h = ((h << 5) - h + name.charCodeAt(i)) | 0;
+    }
+    const hue = ((h % 360) + 360) % 360;
+    return "hsl(" + hue + ",55%,45%)";
+  }
+
+  function engineerInitials(name) {
+    if (!name) return "?";
+    return name.substring(0, 2).toUpperCase();
+  }
+
+  // --- Card Grid ---
+  function renderCard(loop) {
+    const showEngineer = engineerFilter !== "mine" || loop.engineer !== viewer;
+    const engBadge = showEngineer
+      ? '<span class="card-engineer" style="background:' + engineerColor(loop.engineer) + '">' + esc(engineerInitials(loop.engineer)) + '</span>'
+      : '';
+    const verdict = loop.last_verdict || "\u2014";
+    const progress = isTerminal(loop.state)
+      ? "round " + loop.round
+      : "round " + loop.round + "/" + loop.max_rounds + " \u00b7 stage: " + esc(loop.current_stage || "\u2014");
+
+    return '<a class="card" href="/dashboard/loops/' + esc(loop.id) + '" data-id="' + esc(loop.id) + '">'
+      + engBadge
+      + '<div class="card-header">'
+      + '<span class="pulse ' + pulseClass(loop.sub_state) + '"></span>'
+      + '<span class="badge ' + badgeClass(loop.state) + '">' + esc(loop.state) + '</span>'
+      + '<span style="font-size:0.75rem;color:var(--text-muted)">' + esc(shortId(loop.id)) + '</span>'
+      + '<span style="margin-left:auto;font-size:0.75rem;color:var(--text-muted)">' + fmtElapsed(loop.created_at) + '</span>'
+      + '</div>'
+      + '<div class="card-title">' + esc(specFilename(loop.spec_path)) + '</div>'
+      + '<div class="card-subtitle">' + esc(loop.branch) + '</div>'
+      + '<div class="card-progress">' + progress + '</div>'
+      + '<div class="card-metrics">'
+      + '<span>' + fmtTokens((loop.total_tokens||{}).input + (loop.total_tokens||{}).output) + ' tok</span>'
+      + '<span>' + fmtCost(loop.total_cost) + '</span>'
+      + '<span>' + esc(verdict) + '</span>'
+      + '</div>'
+      + '</a>';
+  }
+
+  function matchesFilter(loop) {
+    // State filter
+    if (activeFilter === "active" && isTerminal(loop.state)) return false;
+    if (activeFilter === "converged" && loop.state !== "CONVERGED" && loop.state !== "HARDENED" && loop.state !== "SHIPPED") return false;
+    if (activeFilter === "failed" && loop.state !== "FAILED" && loop.state !== "CANCELLED") return false;
+    // Engineer filter — "mine" filters handled server-side via ?team param,
+    // but also filter client-side for immediate chip changes before next poll
+    if (engineerFilter === "mine" && loop.engineer !== viewer) return false;
+    if (engineerFilter !== "mine" && engineerFilter !== "team" && loop.engineer !== engineerFilter) return false;
+    return true;
+  }
+
+  function updateGrid(data) {
+    const grid = document.getElementById("card-grid");
+    if (!grid) return;
+
+    // Track state changes for tab title
+    if (data.loops) {
+      for (const loop of data.loops) {
+        if (prevStates[loop.id] && !isTerminal(prevStates[loop.id]) && loop.state === "CONVERGED") {
+          convergedSinceLastFocus++;
+        }
+        prevStates[loop.id] = loop.state;
+      }
+    }
+
+    const filtered = (data.loops || []).filter(matchesFilter);
+    if (filtered.length === 0) {
+      grid.innerHTML = '<div class="empty-state">No loops match the current filters.</div>';
+    } else {
+      grid.innerHTML = filtered.map(renderCard).join("");
+    }
+
+    // Update chips counts
+    updateChipCounts(data);
+
+    // Update fleet summary
+    updateFleetSummary(data);
+
+    // Update viewer from response
+    if (data.viewer) viewer = data.viewer;
+
+    // Update tab title (progressive enhancement)
+    updateTabTitle();
+
+    // Show/hide kill switch (FR-10d)
+    const killBtn = document.getElementById("kill-switch-btn");
+    if (killBtn) {
+      killBtn.style.display = engineerFilter === "team" || engineerFilter !== "mine" ? "" : "none";
+    }
+  }
+
+  function updateChipCounts(data) {
+    const counts = data.aggregates ? data.aggregates.counts_by_state : {};
+    let activeCount = 0, convergedCount = 0, failedCount = 0, totalCount = data.aggregates ? data.aggregates.total_loops : 0;
+    for (const [st, n] of Object.entries(counts)) {
+      if (isTerminal(st)) {
+        if (st === "CONVERGED" || st === "HARDENED" || st === "SHIPPED") convergedCount += n;
+        else failedCount += n;
+      } else {
+        activeCount += n;
+      }
+    }
+    setText("chip-active-count", activeCount);
+    setText("chip-converged-count", convergedCount);
+    setText("chip-failed-count", failedCount);
+    setText("chip-all-count", totalCount);
+
+    // Engineer chips
+    const engBar = document.getElementById("engineer-chips");
+    if (engBar && data.engineers) {
+      // Keep Mine and Team, replace individual engineer chips
+      const existing = engBar.querySelectorAll("[data-eng-individual]");
+      existing.forEach(e => e.remove());
+      for (const eng of data.engineers) {
+        const chip = document.createElement("button");
+        chip.className = "chip" + (engineerFilter === eng ? " active" : "");
+        chip.dataset.engIndividual = eng;
+        chip.textContent = eng;
+        chip.onclick = () => { setEngineerFilter(eng); };
+        engBar.appendChild(chip);
+      }
+    }
+  }
+
+  function setText(id, val) {
+    const el = document.getElementById(id);
+    if (el) el.textContent = val;
+  }
+
+  function updateFleetSummary(data) {
+    const el = document.getElementById("fleet-summary-content");
+    if (!el || !data.fleet_summary) return;
+    const f = data.fleet_summary;
+    let parts = [];
+    parts.push("This week");
+    parts.push("\u00b7 " + f.total_loops + " loops");
+    if (f.total_cost != null) parts.push("\u00b7 " + fmtCost(f.total_cost));
+    const cr = f.converge_rate != null ? Math.round(f.converge_rate * 100) : null;
+    if (cr != null) {
+      let trend = "";
+      if (f.trends && f.trends.converge_rate_delta != null) {
+        const d = Math.round(f.trends.converge_rate_delta * 100);
+        if (d > 0) trend = ' <span class="trend-up">\u2191' + d + '%</span>';
+        else if (d < 0) trend = ' <span class="trend-down">\u2193' + Math.abs(d) + '%</span>';
+      }
+      parts.push("\u00b7 " + cr + "%" + trend + " converged");
+    }
+    if (f.avg_rounds != null) {
+      let trend = "";
+      if (f.trends && f.trends.avg_rounds_delta != null) {
+        const d = f.trends.avg_rounds_delta;
+        if (d > 0.05) trend = ' <span class="trend-down">\u2191' + d.toFixed(1) + '</span>';
+        else if (d < -0.05) trend = ' <span class="trend-up">\u2193' + Math.abs(d).toFixed(1) + '</span>';
+      }
+      parts.push("\u00b7 avg " + f.avg_rounds.toFixed(1) + trend + " rounds");
+    }
+    if (f.top_spender && f.top_spender.cost != null) {
+      parts.push("\u00b7 top: " + esc(f.top_spender.engineer) + " (" + fmtCost(f.top_spender.cost) + ")");
+    }
+    el.innerHTML = parts.join(" ");
+  }
+
+  function updateTabTitle() {
+    if (document.hasFocus()) {
+      convergedSinceLastFocus = 0;
+      document.title = "nautiloop";
+    } else if (convergedSinceLastFocus > 0) {
+      document.title = "(" + convergedSinceLastFocus + ") nautiloop";
+    }
+  }
+
+  // --- Polling ---
+  function startPolling() {
+    if (pollTimer) return;
+    poll();
+    pollTimer = setInterval(poll, POLL_INTERVAL);
+  }
+
+  function stopPolling() {
+    if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+  }
+
+  function poll() {
+    const team = engineerFilter !== "mine";
+    const url = "/dashboard/state?team=" + team + "&include_terminal=all";
+    fetch(url, { credentials: "same-origin" })
+      .then(r => { if (!r.ok) throw new Error(r.status); return r.json(); })
+      .then(updateGrid)
+      .catch(e => console.warn("poll failed:", e));
+  }
+
+  // --- Filter Chips ---
+  function setStateFilter(filter) {
+    activeFilter = filter;
+    document.querySelectorAll("[data-state-filter]").forEach(el => {
+      el.classList.toggle("active", el.dataset.stateFilter === filter);
+    });
+    poll();
+  }
+
+  function setEngineerFilter(filter) {
+    engineerFilter = filter;
+    document.querySelectorAll("[data-eng-filter]").forEach(el => {
+      el.classList.toggle("active", el.dataset.engFilter === filter);
+    });
+    document.querySelectorAll("[data-eng-individual]").forEach(el => {
+      el.classList.toggle("active", el.dataset.engIndividual === filter);
+    });
+    poll();
+  }
+
+  // --- Action Buttons ---
+  function actionFetch(url, method, body) {
+    const opts = { method: method, credentials: "same-origin", headers: {} };
+    if (body) {
+      opts.headers["Content-Type"] = "application/json";
+      opts.body = JSON.stringify(body);
+    }
+    return fetch(url, opts).then(r => {
+      if (!r.ok) return r.json().then(d => { throw new Error(d.error || r.status); });
+      return r.json();
+    });
+  }
+
+  function showToast(msg, duration) {
+    const container = document.getElementById("toast-container");
+    if (!container) return;
+    const toast = document.createElement("div");
+    toast.className = "toast";
+    toast.textContent = msg;
+    container.appendChild(toast);
+    setTimeout(() => toast.remove(), duration || 10000);
+  }
+
+  function bindActions() {
+    document.addEventListener("click", function(e) {
+      const btn = e.target.closest("[data-action]");
+      if (!btn) return;
+      e.preventDefault();
+      const action = btn.dataset.action;
+      const loopId = btn.dataset.loopId;
+
+      if (action === "approve") {
+        actionFetch("/approve/" + loopId, "POST")
+          .then(() => { showToast("Approved"); location.reload(); })
+          .catch(err => showToast("Error: " + err.message));
+      } else if (action === "cancel") {
+        showConfirmModal("Cancel this loop?", "This cannot be undone.", function() {
+          actionFetch("/cancel/" + loopId, "DELETE")
+            .then(() => { showToast("Cancelled"); location.reload(); })
+            .catch(err => showToast("Error: " + err.message));
+        });
+      } else if (action === "resume") {
+        actionFetch("/resume/" + loopId, "POST")
+          .then(() => { showToast("Resumed"); location.reload(); })
+          .catch(err => showToast("Error: " + err.message));
+      } else if (action === "extend") {
+        actionFetch("/extend/" + loopId, "POST", { add_rounds: 10 })
+          .then(() => { showToast("Extended +10 rounds"); location.reload(); })
+          .catch(err => showToast("Error: " + err.message));
+      } else if (action === "cancel-all") {
+        const activeLoops = btn.dataset.activeIds ? btn.dataset.activeIds.split(",") : [];
+        showConfirmModal(
+          "Cancel " + activeLoops.length + " active loops?",
+          "This cannot be undone.",
+          function() {
+            let ok = 0, fail = 0;
+            const promises = activeLoops.map(id =>
+              actionFetch("/cancel/" + id, "DELETE")
+                .then(() => ok++)
+                .catch(() => fail++)
+            );
+            Promise.all(promises).then(() => {
+              let msg = "Cancelled " + ok + "/" + activeLoops.length + " loops";
+              if (fail > 0) msg += " (" + fail + " failed)";
+              showToast(msg);
+              poll();
+            });
+          }
+        );
+      }
+    });
+  }
+
+  // --- Confirm Modal ---
+  function showConfirmModal(title, body, onConfirm) {
+    const overlay = document.getElementById("confirm-modal");
+    if (!overlay) return;
+    document.getElementById("modal-title").textContent = title;
+    document.getElementById("modal-body").textContent = body;
+    overlay.classList.add("open");
+
+    const confirmBtn = document.getElementById("modal-confirm");
+    const cancelBtn = document.getElementById("modal-cancel");
+    const handler = () => {
+      overlay.classList.remove("open");
+      confirmBtn.removeEventListener("click", handler);
+      onConfirm();
+    };
+    const cancelHandler = () => {
+      overlay.classList.remove("open");
+      cancelBtn.removeEventListener("click", cancelHandler);
+    };
+    confirmBtn.addEventListener("click", handler);
+    cancelBtn.addEventListener("click", cancelHandler);
+  }
+
+  // --- SSE Log Stream ---
+  function startLogStream(loopId, pane) {
+    if (eventSource) eventSource.close();
+    eventSource = new EventSource("/dashboard/stream/" + loopId);
+    eventSource.onmessage = function(e) {
+      const line = document.createElement("span");
+      line.className = "log-line";
+      line.textContent = e.data;
+      pane.appendChild(line);
+      // Cap lines
+      while (pane.children.length > LOG_LINE_CAP) {
+        pane.removeChild(pane.firstChild);
+      }
+      pane.scrollTop = pane.scrollHeight;
+    };
+    eventSource.onerror = function() {
+      eventSource.close();
+      eventSource = null;
+    };
+  }
+
+  // --- Pod Introspect Polling (FR-5) ---
+  function startIntrospectPolling(loopId) {
+    const details = document.getElementById("pod-introspect");
+    if (!details) return;
+    details.addEventListener("toggle", function() {
+      if (details.open) {
+        fetchIntrospect(loopId);
+        introspectTimer = setInterval(() => fetchIntrospect(loopId), INTROSPECT_INTERVAL);
+      } else {
+        if (introspectTimer) { clearInterval(introspectTimer); introspectTimer = null; }
+      }
+    });
+  }
+
+  function fetchIntrospect(loopId) {
+    const el = document.getElementById("introspect-data");
+    if (!el) return;
+    fetch("/pod-introspect/" + loopId, { credentials: "same-origin" })
+      .then(r => r.ok ? r.json() : Promise.reject(r.status))
+      .then(data => {
+        let html = "<pre>" + esc(JSON.stringify(data, null, 2)) + "</pre>";
+        el.innerHTML = html;
+      })
+      .catch(() => { el.textContent = "Unavailable"; });
+  }
+
+  // --- Header Menu ---
+  function bindHeaderMenu() {
+    const btn = document.getElementById("header-menu-toggle");
+    const dropdown = document.getElementById("header-menu-dropdown");
+    if (!btn || !dropdown) return;
+    btn.addEventListener("click", function(e) {
+      e.stopPropagation();
+      dropdown.classList.toggle("open");
+    });
+    document.addEventListener("click", function() {
+      dropdown.classList.remove("open");
+    });
+  }
+
+  // --- Round Row Expand ---
+  function bindRoundExpand() {
+    document.querySelectorAll(".round-row").forEach(function(row) {
+      row.addEventListener("click", function() {
+        const detail = row.nextElementSibling;
+        if (detail && detail.classList.contains("round-detail")) {
+          detail.classList.toggle("open");
+        }
+      });
+    });
+  }
+
+  // --- Feed Page ---
+  function bindFeedLoadMore() {
+    const btn = document.getElementById("feed-load-more");
+    if (!btn) return;
+    btn.addEventListener("click", function() {
+      const cursor = btn.dataset.cursor;
+      const filter = btn.dataset.filter || "";
+      let url = "/dashboard/feed?limit=50";
+      if (cursor) url += "&cursor=" + encodeURIComponent(cursor);
+      if (filter) url += "&filter=" + encodeURIComponent(filter);
+      fetch(url, { credentials: "same-origin" })
+        .then(r => r.json())
+        .then(data => {
+          const list = document.getElementById("feed-list");
+          if (!list) return;
+          for (const ev of data.events) {
+            list.insertAdjacentHTML("beforeend", renderFeedItem(ev));
+          }
+          if (data.has_more && data.events.length > 0) {
+            btn.dataset.cursor = data.events[data.events.length - 1].updated_at;
+          } else {
+            btn.style.display = "none";
+          }
+        })
+        .catch(e => console.warn("feed load failed:", e));
+    });
+  }
+
+  function renderFeedItem(ev) {
+    const time = new Date(ev.updated_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+    const ext = ev.extensions > 0 ? " [extended \u00d7" + ev.extensions + "]" : "";
+    return '<a class="feed-item" href="/dashboard/loops/' + esc(ev.id) + '">'
+      + '<span class="feed-time">' + esc(time) + '</span>'
+      + '<span>' + esc(ev.engineer) + '</span>'
+      + '<span class="feed-spec">' + esc(specFilename(ev.spec_path)) + '</span>'
+      + '<span class="badge ' + badgeClass(ev.state) + '">' + esc(ev.state) + '</span>'
+      + (ev.spec_pr_url ? '<span class="feed-detail">PR</span>' : '')
+      + '<span class="feed-detail">' + ev.rounds + ' rounds</span>'
+      + '<span class="feed-detail">' + fmtCost(ev.total_cost) + '</span>'
+      + '<span class="feed-detail">' + ext + '</span>'
+      + '</a>';
+  }
+
+  // --- Stats Page ---
+  function bindStatsWindow() {
+    document.querySelectorAll("[data-window]").forEach(function(btn) {
+      btn.addEventListener("click", function() {
+        const w = btn.dataset.window;
+        window.location.href = "/dashboard/stats?window=" + w;
+      });
+    });
+  }
+
+  // --- Focus Tracking (Progressive Enhancement) ---
+  window.addEventListener("focus", function() {
+    convergedSinceLastFocus = 0;
+    updateTabTitle();
+  });
+
+  // --- Highlight on hash (FR-9c) ---
+  function highlightHash() {
+    if (!location.hash) return;
+    const el = document.getElementById(location.hash.slice(1));
+    if (el) {
+      el.scrollIntoView({ behavior: "smooth", block: "center" });
+      el.classList.add("highlight-pulse");
+      setTimeout(() => el.classList.remove("highlight-pulse"), 2000);
+    }
+  }
+
+  // --- Init ---
+  document.addEventListener("DOMContentLoaded", function() {
+    // Card grid page
+    if (document.getElementById("card-grid")) {
+      // Bind filter chips
+      document.querySelectorAll("[data-state-filter]").forEach(function(el) {
+        el.addEventListener("click", function() { setStateFilter(el.dataset.stateFilter); });
+      });
+      document.querySelectorAll("[data-eng-filter]").forEach(function(el) {
+        el.addEventListener("click", function() { setEngineerFilter(el.dataset.engFilter); });
+      });
+      startPolling();
+    }
+
+    // Detail page
+    const logPane = document.getElementById("log-pane");
+    const loopId = document.body.dataset.loopId;
+    if (logPane && loopId) {
+      const isLive = document.body.dataset.loopTerminal !== "true";
+      if (isLive) {
+        startLogStream(loopId, logPane);
+      }
+      logPane.scrollTop = logPane.scrollHeight;
+    }
+    if (loopId) {
+      startIntrospectPolling(loopId);
+    }
+
+    bindActions();
+    bindHeaderMenu();
+    bindRoundExpand();
+    bindFeedLoadMore();
+    bindStatsWindow();
+    highlightHash();
+  });
+
+})();

--- a/control-plane/src/api/auth.rs
+++ b/control-plane/src/api/auth.rs
@@ -3,49 +3,71 @@ use axum::http::StatusCode;
 use axum::middleware::Next;
 use axum::response::Response;
 
-/// Auth middleware: validates API key from `Authorization: Bearer <key>` header.
+use crate::util::constant_time_eq;
+
+/// Auth middleware: validates API key from `Authorization: Bearer <key>` header
+/// OR from the `nautiloop_api_key` cookie (FR-4b).
 ///
 /// Validates against `NAUTILOOP_API_KEY` env var. If unset, rejects all requests.
-/// In V1, all authenticated users have full access (FR-14).
-/// mTLS is handled at the ingress/load-balancer level, not in application code.
+/// Cookie is checked first, then Bearer header — matching the dashboard auth logic.
+/// This allows dashboard action buttons (Approve, Cancel, Resume, Extend) to call
+/// existing API endpoints via same-origin fetch() with the HttpOnly cookie.
 pub async fn auth_middleware(request: Request, next: Next) -> Result<Response, StatusCode> {
     let expected_key = std::env::var("NAUTILOOP_API_KEY").map_err(|_| {
         tracing::error!("NAUTILOOP_API_KEY not set - all requests will be rejected");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
-    let auth_header = request
-        .headers()
-        .get("authorization")
-        .and_then(|v| v.to_str().ok());
+    // Try cookie first (dashboard JS sends HttpOnly cookie via same-origin fetch)
+    let api_key = extract_cookie_value(request.headers(), "nautiloop_api_key")
+        .or_else(|| extract_bearer(request.headers()));
 
-    match auth_header {
-        Some(header) if header.len() > 7 && header[..7].eq_ignore_ascii_case("bearer ") => {
-            let api_key = &header[7..];
-            if api_key.is_empty() {
-                return Err(StatusCode::UNAUTHORIZED);
-            }
-            // Constant-time comparison to prevent timing attacks
-            if constant_time_eq(api_key.as_bytes(), expected_key.as_bytes()) {
-                Ok(next.run(request).await)
-            } else {
-                Err(StatusCode::UNAUTHORIZED)
-            }
+    match api_key {
+        Some(key) if constant_time_eq(key.as_bytes(), expected_key.as_bytes()) => {
+            Ok(next.run(request).await)
         }
         _ => Err(StatusCode::UNAUTHORIZED),
     }
 }
 
-/// Constant-time byte comparison to prevent timing side-channel attacks.
-fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    let mut diff = 0u8;
-    for (x, y) in a.iter().zip(b.iter()) {
-        diff |= x ^ y;
-    }
-    diff == 0
+/// Extract a cookie value by name from the Cookie header.
+fn extract_cookie_value(
+    headers: &axum::http::HeaderMap,
+    name: &str,
+) -> Option<String> {
+    headers
+        .get("cookie")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|cookies| {
+            cookies.split(';').find_map(|pair| {
+                let pair = pair.trim();
+                let (k, v) = pair.split_once('=')?;
+                if k.trim() == name {
+                    Some(v.trim().to_string())
+                } else {
+                    None
+                }
+            })
+        })
+}
+
+/// Extract API key from Authorization: Bearer <key> header.
+fn extract_bearer(headers: &axum::http::HeaderMap) -> Option<String> {
+    headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|header| {
+            if header.len() > 7 && header[..7].eq_ignore_ascii_case("bearer ") {
+                let key = &header[7..];
+                if key.is_empty() {
+                    None
+                } else {
+                    Some(key.to_string())
+                }
+            } else {
+                None
+            }
+        })
 }
 
 #[cfg(test)]
@@ -53,11 +75,29 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_constant_time_eq() {
-        assert!(constant_time_eq(b"abc", b"abc"));
-        assert!(!constant_time_eq(b"abc", b"abd"));
-        assert!(!constant_time_eq(b"abc", b"ab"));
-        assert!(!constant_time_eq(b"", b"a"));
-        assert!(constant_time_eq(b"", b""));
+    fn test_extract_cookie_value() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(
+            "cookie",
+            "nautiloop_api_key=secret123; nautiloop_engineer=alice"
+                .parse()
+                .unwrap(),
+        );
+        assert_eq!(
+            extract_cookie_value(&headers, "nautiloop_api_key"),
+            Some("secret123".to_string())
+        );
+        assert_eq!(extract_cookie_value(&headers, "missing"), None);
+    }
+
+    #[test]
+    fn test_extract_bearer() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert("authorization", "Bearer mykey".parse().unwrap());
+        assert_eq!(extract_bearer(&headers), Some("mykey".to_string()));
+
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert("authorization", "Bearer ".parse().unwrap());
+        assert_eq!(extract_bearer(&headers), None);
     }
 }

--- a/control-plane/src/api/auth.rs
+++ b/control-plane/src/api/auth.rs
@@ -3,7 +3,7 @@ use axum::http::StatusCode;
 use axum::middleware::Next;
 use axum::response::Response;
 
-use crate::util::constant_time_eq;
+use crate::util::{constant_time_eq, extract_bearer, extract_cookie_value};
 
 /// Auth middleware: validates API key from `Authorization: Bearer <key>` header
 /// OR from the `nautiloop_api_key` cookie (FR-4b).
@@ -30,49 +30,9 @@ pub async fn auth_middleware(request: Request, next: Next) -> Result<Response, S
     }
 }
 
-/// Extract a cookie value by name from the Cookie header.
-fn extract_cookie_value(
-    headers: &axum::http::HeaderMap,
-    name: &str,
-) -> Option<String> {
-    headers
-        .get("cookie")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|cookies| {
-            cookies.split(';').find_map(|pair| {
-                let pair = pair.trim();
-                let (k, v) = pair.split_once('=')?;
-                if k.trim() == name {
-                    Some(v.trim().to_string())
-                } else {
-                    None
-                }
-            })
-        })
-}
-
-/// Extract API key from Authorization: Bearer <key> header.
-fn extract_bearer(headers: &axum::http::HeaderMap) -> Option<String> {
-    headers
-        .get("authorization")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|header| {
-            if header.len() > 7 && header[..7].eq_ignore_ascii_case("bearer ") {
-                let key = &header[7..];
-                if key.is_empty() {
-                    None
-                } else {
-                    Some(key.to_string())
-                }
-            } else {
-                None
-            }
-        })
-}
-
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::util::{extract_bearer, extract_cookie_value};
 
     #[test]
     fn test_extract_cookie_value() {

--- a/control-plane/src/api/dashboard/aggregate.rs
+++ b/control-plane/src/api/dashboard/aggregate.rs
@@ -1,0 +1,1087 @@
+use std::collections::HashMap;
+use std::time::Instant;
+
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+
+use crate::config::{ModelPricing, NautiloopConfig, PricingConfig};
+use crate::state::StateStore;
+use crate::types::verdict::{
+    ImplResultData, ReviewResultData, ReviseResultData, TestResultData, TokenUsage,
+};
+use crate::types::{LoopRecord, LoopState, RoundRecord};
+
+// ── Response types ──
+
+#[derive(Debug, Serialize)]
+pub struct DashboardStateResponse {
+    pub loops: Vec<DashboardLoop>,
+    pub aggregates: Aggregates,
+    pub fleet_summary: Option<FleetSummary>,
+    pub engineers: Vec<String>,
+    pub viewer: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DashboardLoop {
+    pub id: String,
+    pub spec_path: String,
+    pub branch: String,
+    pub engineer: String,
+    pub state: String,
+    pub sub_state: Option<String>,
+    pub round: i32,
+    pub max_rounds: i32,
+    pub current_stage: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub spec_pr_url: Option<String>,
+    pub failed_from_state: Option<String>,
+    pub last_verdict: Option<String>,
+    pub total_tokens: TokenSummary,
+    pub total_cost: Option<f64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TokenSummary {
+    pub input: u64,
+    pub output: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Aggregates {
+    pub counts_by_state: HashMap<String, u64>,
+    pub total_tokens: TokenSummary,
+    pub total_cost: Option<f64>,
+    pub total_loops: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FleetSummary {
+    pub window_days: u32,
+    pub total_loops: u64,
+    pub total_cost: Option<f64>,
+    pub converge_rate: Option<f64>,
+    pub avg_rounds: Option<f64>,
+    pub top_spender: Option<TopSpender>,
+    pub trends: Option<Trends>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TopSpender {
+    pub engineer: String,
+    pub cost: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Trends {
+    pub converge_rate_delta: Option<f64>,
+    pub avg_rounds_delta: Option<f64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct FeedResponse {
+    pub events: Vec<FeedEvent>,
+    pub has_more: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct FeedEvent {
+    pub id: String,
+    pub spec_path: String,
+    pub engineer: String,
+    pub state: String,
+    pub rounds: i32,
+    pub total_tokens: TokenSummary,
+    pub total_cost: Option<f64>,
+    pub spec_pr_url: Option<String>,
+    pub updated_at: DateTime<Utc>,
+    pub extensions: i32,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SpecsResponse {
+    pub spec_path: String,
+    pub runs: Vec<SpecRun>,
+    pub aggregates: SpecAggregates,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SpecRun {
+    pub id: String,
+    pub engineer: String,
+    pub state: String,
+    pub rounds: i32,
+    pub total_cost: Option<f64>,
+    pub branch: String,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SpecAggregates {
+    pub total_runs: u64,
+    pub converge_rate: Option<f64>,
+    pub avg_rounds: Option<f64>,
+    pub total_cost: Option<f64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct StatsResponse {
+    pub window: String,
+    pub headline: StatsHeadline,
+    pub per_engineer: Vec<EngineerStats>,
+    pub per_spec: Vec<SpecStats>,
+    pub time_series: Vec<DayStats>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct StatsHeadline {
+    pub total_loops: u64,
+    pub total_cost: Option<f64>,
+    pub converge_rate: Option<f64>,
+    pub avg_rounds: Option<f64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct EngineerStats {
+    pub engineer: String,
+    pub loops: u64,
+    pub cost: Option<f64>,
+    pub converge_rate: Option<f64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SpecStats {
+    pub spec_path: String,
+    pub runs: u64,
+    pub cost: Option<f64>,
+    pub converge_rate: Option<f64>,
+    pub avg_rounds: Option<f64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DayStats {
+    pub date: String,
+    pub started: u64,
+    pub converged: u64,
+    pub failed: u64,
+}
+
+// ── Fleet Summary Cache ──
+
+pub struct FleetSummaryCache {
+    inner: RwLock<Option<(FleetSummary, Instant)>>,
+}
+
+impl Default for FleetSummaryCache {
+    fn default() -> Self {
+        Self {
+            inner: RwLock::new(None),
+        }
+    }
+}
+
+impl FleetSummaryCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn get(&self) -> Option<FleetSummary> {
+        let guard = self.inner.read().await;
+        guard.as_ref().and_then(|(summary, ts)| {
+            if ts.elapsed().as_secs() < 60 {
+                Some(summary.clone())
+            } else {
+                None
+            }
+        })
+    }
+
+    pub async fn set(&self, summary: FleetSummary) {
+        let mut guard = self.inner.write().await;
+        *guard = Some((summary, Instant::now()));
+    }
+}
+
+// ── Stats Cache ──
+
+pub struct StatsCache {
+    inner: RwLock<HashMap<String, (StatsResponse, Instant)>>,
+}
+
+impl Default for StatsCache {
+    fn default() -> Self {
+        Self {
+            inner: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+impl StatsCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn get(&self, window: &str) -> Option<StatsResponse> {
+        let guard = self.inner.read().await;
+        guard.get(window).and_then(|(resp, ts)| {
+            if ts.elapsed().as_secs() < 60 {
+                // StatsResponse doesn't implement Clone, so we serialize/deserialize
+                serde_json::to_value(resp)
+                    .ok()
+                    .and_then(|v| serde_json::from_value(v).ok())
+            } else {
+                None
+            }
+        })
+    }
+
+    pub async fn set(&self, window: String, resp: &StatsResponse) {
+        if let Ok(cloned) = serde_json::to_value(resp)
+            .and_then(serde_json::from_value::<StatsResponse>)
+        {
+            let mut guard = self.inner.write().await;
+            guard.insert(window, (cloned, Instant::now()));
+        }
+    }
+}
+
+// ── Pricing ──
+
+/// Compute cost in USD for a token usage given model name and pricing config (FR-15b).
+pub fn compute_cost(
+    token_usage: &TokenUsage,
+    model: &str,
+    pricing: &PricingConfig,
+) -> Option<f64> {
+    let model_pricing = pricing.models.get(model)?;
+    Some(compute_cost_with_pricing(token_usage, model_pricing))
+}
+
+fn compute_cost_with_pricing(token_usage: &TokenUsage, pricing: &ModelPricing) -> f64 {
+    let input_cost = (token_usage.input as f64 / 1_000_000.0) * pricing.input_per_million;
+    let output_cost = (token_usage.output as f64 / 1_000_000.0) * pricing.output_per_million;
+    input_cost + output_cost
+}
+
+/// Resolve the model for a given stage using the loop's model fields (FR-15b).
+fn resolve_model_for_stage(
+    stage: &str,
+    loop_record: &LoopRecord,
+    config: &NautiloopConfig,
+) -> Option<String> {
+    let model = match stage {
+        "implement" | "revise" | "test" => loop_record
+            .model_implementor
+            .clone()
+            .unwrap_or_else(|| config.models.implementor.clone()),
+        "review" | "audit" => loop_record
+            .model_reviewer
+            .clone()
+            .unwrap_or_else(|| config.models.reviewer.clone()),
+        _ => return None,
+    };
+    Some(model)
+}
+
+/// Extract token usage from a round's output JSON.
+fn extract_token_usage(round: &RoundRecord) -> Option<TokenUsage> {
+    let output = round.output.as_ref()?;
+    // Try each stage-specific type
+    match round.stage.as_str() {
+        "implement" => serde_json::from_value::<ImplResultData>(output.clone())
+            .ok()
+            .map(|d| d.token_usage),
+        "test" => serde_json::from_value::<TestResultData>(output.clone())
+            .ok()
+            .map(|d| d.token_usage),
+        "review" | "audit" => serde_json::from_value::<ReviewResultData>(output.clone())
+            .ok()
+            .map(|d| d.token_usage),
+        "revise" => serde_json::from_value::<ReviseResultData>(output.clone())
+            .ok()
+            .map(|d| d.token_usage),
+        _ => None,
+    }
+}
+
+/// Extract the last review/audit verdict from rounds.
+fn extract_last_verdict(rounds: &[RoundRecord]) -> Option<String> {
+    rounds
+        .iter()
+        .rev()
+        .find(|r| r.stage == "review" || r.stage == "audit")
+        .and_then(|r| r.output.as_ref())
+        .and_then(|output| {
+            serde_json::from_value::<ReviewResultData>(output.clone())
+                .ok()
+                .and_then(|rd| {
+                    rd.verdict.get("clean").and_then(|v| v.as_bool()).map(|clean| {
+                        if clean {
+                            "clean".to_string()
+                        } else {
+                            "not clean".to_string()
+                        }
+                    })
+                })
+        })
+}
+
+/// Compute total tokens and cost for a loop given its rounds.
+fn compute_loop_totals(
+    rounds: &[RoundRecord],
+    loop_record: &LoopRecord,
+    config: &NautiloopConfig,
+) -> (TokenSummary, Option<f64>) {
+    let mut total_input = 0u64;
+    let mut total_output = 0u64;
+    let mut total_cost = 0.0f64;
+    let mut has_pricing = false;
+
+    let pricing = config.pricing.as_ref();
+
+    for round in rounds {
+        if let Some(tu) = extract_token_usage(round) {
+            total_input += tu.input;
+            total_output += tu.output;
+            if let Some(pc) = pricing
+                && let Some(model) = resolve_model_for_stage(&round.stage, loop_record, config)
+                    && let Some(cost) = compute_cost(&tu, &model, pc) {
+                        total_cost += cost;
+                        has_pricing = true;
+                    }
+        }
+    }
+
+    let cost = if has_pricing || pricing.is_some() {
+        if has_pricing {
+            Some(total_cost)
+        } else {
+            Some(0.0)
+        }
+    } else {
+        None
+    };
+
+    (
+        TokenSummary {
+            input: total_input,
+            output: total_output,
+        },
+        cost,
+    )
+}
+
+// ── Current Stage Resolution (mirrors handlers.rs logic) ──
+
+fn current_stage_for_record(record: &LoopRecord, rounds: &[RoundRecord]) -> Option<String> {
+    let source_state = if record.state.is_active_stage() {
+        Some(record.state)
+    } else {
+        match record.state {
+            LoopState::Paused => record.paused_from_state,
+            LoopState::AwaitingReauth => record.reauth_from_state,
+            LoopState::Failed => record.failed_from_state,
+            _ => None,
+        }
+    };
+
+    let source_state = source_state?;
+
+    match source_state {
+        LoopState::Implementing => Some("implement".to_string()),
+        LoopState::Testing => Some("test".to_string()),
+        LoopState::Reviewing => Some("review".to_string()),
+        LoopState::Hardening => {
+            let stage = rounds
+                .iter()
+                .rev()
+                .find(|r| r.round == record.round)
+                .map(|r| r.stage.clone())
+                .unwrap_or_else(|| "audit".to_string());
+            Some(stage)
+        }
+        _ => None,
+    }
+}
+
+// ── Build dashboard state response ──
+
+pub async fn build_dashboard_state(
+    store: &dyn StateStore,
+    config: &NautiloopConfig,
+    team: bool,
+    include_all_terminal: bool,
+    viewer_engineer: &str,
+    fleet_cache: &FleetSummaryCache,
+) -> crate::error::Result<DashboardStateResponse> {
+    let engineer_filter = if team {
+        None
+    } else {
+        Some(viewer_engineer)
+    };
+
+    // Get all loops (active + terminal for card grid)
+    let loops = store
+        .get_loops_for_engineer(engineer_filter, team, true)
+        .await?;
+
+    let now = Utc::now();
+    let cutoff = now - Duration::hours(24);
+
+    // Filter: active + recently-terminal (or all terminal if requested)
+    let filtered: Vec<&LoopRecord> = loops
+        .iter()
+        .filter(|l| {
+            !l.state.is_terminal() || include_all_terminal || l.updated_at > cutoff
+        })
+        .collect();
+
+    let mut dashboard_loops = Vec::with_capacity(filtered.len());
+    let mut counts_by_state: HashMap<String, u64> = HashMap::new();
+    let mut agg_input = 0u64;
+    let mut agg_output = 0u64;
+    let mut agg_cost = 0.0f64;
+    let mut has_cost = false;
+    let mut engineers_set: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    for record in &filtered {
+        let rounds = store.get_rounds(record.id).await?;
+        let current_stage = current_stage_for_record(record, &rounds);
+        let last_verdict = extract_last_verdict(&rounds);
+        let (tokens, cost) = compute_loop_totals(&rounds, record, config);
+
+        *counts_by_state
+            .entry(record.state.to_string())
+            .or_insert(0) += 1;
+        agg_input += tokens.input;
+        agg_output += tokens.output;
+        if let Some(c) = cost {
+            agg_cost += c;
+            has_cost = true;
+        }
+        engineers_set.insert(record.engineer.clone());
+
+        dashboard_loops.push(DashboardLoop {
+            id: record.id.to_string(),
+            spec_path: record.spec_path.clone(),
+            branch: record.branch.clone(),
+            engineer: record.engineer.clone(),
+            state: record.state.to_string(),
+            sub_state: record.sub_state.map(|s| s.to_string()),
+            round: record.round,
+            max_rounds: record.max_rounds,
+            current_stage,
+            created_at: record.created_at,
+            updated_at: record.updated_at,
+            spec_pr_url: record.spec_pr_url.clone(),
+            failed_from_state: record.failed_from_state.map(|s| s.to_string()),
+            last_verdict,
+            total_tokens: tokens,
+            total_cost: cost,
+        });
+    }
+
+    let mut engineers: Vec<String> = engineers_set.into_iter().collect();
+    engineers.sort();
+
+    // Fleet summary (cached 60s)
+    let fleet_summary = if let Some(cached) = fleet_cache.get().await {
+        Some(cached)
+    } else {
+        let summary =
+            build_fleet_summary(store, config, now).await.ok();
+        if let Some(ref s) = summary {
+            fleet_cache.set(s.clone()).await;
+        }
+        summary
+    };
+
+    Ok(DashboardStateResponse {
+        loops: dashboard_loops,
+        aggregates: Aggregates {
+            counts_by_state,
+            total_tokens: TokenSummary {
+                input: agg_input,
+                output: agg_output,
+            },
+            total_cost: if has_cost { Some(agg_cost) } else { None },
+            total_loops: filtered.len() as u64,
+        },
+        fleet_summary,
+        engineers,
+        viewer: viewer_engineer.to_string(),
+    })
+}
+
+/// Build the fleet summary for the last 7 days (FR-9).
+async fn build_fleet_summary(
+    store: &dyn StateStore,
+    config: &NautiloopConfig,
+    now: DateTime<Utc>,
+) -> crate::error::Result<FleetSummary> {
+    let window = Duration::days(7);
+    let cutoff = now - window;
+    let prev_cutoff = cutoff - window;
+
+    // Get all loops (including terminal) for the window
+    let all_loops = store
+        .get_loops_for_engineer(None, true, true)
+        .await?;
+
+    let current_window: Vec<&LoopRecord> = all_loops
+        .iter()
+        .filter(|l| l.created_at > cutoff)
+        .collect();
+    let prev_window: Vec<&LoopRecord> = all_loops
+        .iter()
+        .filter(|l| l.created_at > prev_cutoff && l.created_at <= cutoff)
+        .collect();
+
+    let (summary, _cost) =
+        compute_window_summary(&current_window, store, config).await?;
+    let (prev_summary, _) =
+        compute_window_summary(&prev_window, store, config).await?;
+
+    let trends = if !prev_window.is_empty() {
+        Some(Trends {
+            converge_rate_delta: match (summary.converge_rate, prev_summary.converge_rate) {
+                (Some(a), Some(b)) => Some(a - b),
+                _ => None,
+            },
+            avg_rounds_delta: match (summary.avg_rounds, prev_summary.avg_rounds) {
+                (Some(a), Some(b)) => Some(a - b),
+                _ => None,
+            },
+        })
+    } else {
+        None
+    };
+
+    Ok(FleetSummary {
+        window_days: 7,
+        total_loops: summary.total_loops,
+        total_cost: summary.total_cost,
+        converge_rate: summary.converge_rate,
+        avg_rounds: summary.avg_rounds,
+        top_spender: summary.top_spender,
+        trends,
+    })
+}
+
+struct WindowSummary {
+    total_loops: u64,
+    total_cost: Option<f64>,
+    converge_rate: Option<f64>,
+    avg_rounds: Option<f64>,
+    top_spender: Option<TopSpender>,
+}
+
+async fn compute_window_summary(
+    loops: &[&LoopRecord],
+    store: &dyn StateStore,
+    config: &NautiloopConfig,
+) -> crate::error::Result<(WindowSummary, f64)> {
+    let total_loops = loops.len() as u64;
+    let mut total_cost = 0.0f64;
+    let mut has_cost = false;
+    let mut terminal_count = 0u64;
+    let mut converged_count = 0u64;
+    let mut rounds_sum = 0i64;
+    let mut cost_by_engineer: HashMap<String, f64> = HashMap::new();
+
+    for record in loops {
+        let rounds = store.get_rounds(record.id).await?;
+        let (_, cost) = compute_loop_totals(&rounds, record, config);
+        if let Some(c) = cost {
+            total_cost += c;
+            has_cost = true;
+            *cost_by_engineer.entry(record.engineer.clone()).or_insert(0.0) += c;
+        }
+        if record.state.is_terminal() {
+            terminal_count += 1;
+            rounds_sum += record.round as i64;
+            if matches!(
+                record.state,
+                LoopState::Converged | LoopState::Hardened | LoopState::Shipped
+            ) {
+                converged_count += 1;
+            }
+        }
+    }
+
+    let converge_rate = if terminal_count > 0 {
+        Some(converged_count as f64 / terminal_count as f64)
+    } else {
+        None
+    };
+    let avg_rounds = if terminal_count > 0 {
+        Some(rounds_sum as f64 / terminal_count as f64)
+    } else {
+        None
+    };
+    let top_spender = cost_by_engineer
+        .into_iter()
+        .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+        .map(|(engineer, cost)| TopSpender { engineer, cost });
+
+    Ok((
+        WindowSummary {
+            total_loops,
+            total_cost: if has_cost { Some(total_cost) } else { None },
+            converge_rate,
+            avg_rounds,
+            top_spender,
+        },
+        total_cost,
+    ))
+}
+
+// ── Build feed response (FR-12) ──
+
+pub async fn build_feed_response(
+    store: &dyn StateStore,
+    config: &NautiloopConfig,
+    cursor: Option<DateTime<Utc>>,
+    limit: usize,
+    filter: Option<&str>,
+) -> crate::error::Result<FeedResponse> {
+    let all_loops = store
+        .get_loops_for_engineer(None, true, true)
+        .await?;
+
+    let mut terminal: Vec<&LoopRecord> = all_loops
+        .iter()
+        .filter(|l| {
+            if !l.state.is_terminal() {
+                return false;
+            }
+            if let Some(c) = cursor
+                && l.updated_at >= c {
+                    return false;
+                }
+            match filter {
+                Some("converged") => matches!(
+                    l.state,
+                    LoopState::Converged | LoopState::Hardened | LoopState::Shipped
+                ),
+                Some("failed") => matches!(l.state, LoopState::Failed | LoopState::Cancelled),
+                Some(eng) => l.engineer == eng,
+                None => true,
+            }
+        })
+        .collect();
+
+    terminal.sort_by_key(|r| std::cmp::Reverse(r.updated_at));
+    let has_more = terminal.len() > limit;
+    let events_slice = &terminal[..terminal.len().min(limit)];
+
+    let mut events = Vec::with_capacity(events_slice.len());
+    for record in events_slice {
+        let rounds = store.get_rounds(record.id).await?;
+        let (tokens, cost) = compute_loop_totals(&rounds, record, config);
+        // Count extensions: max_rounds above the configured default
+        let default_max = if record.kind == crate::types::LoopKind::Harden {
+            config.limits.max_rounds_harden as i32
+        } else {
+            config.limits.max_rounds_implement as i32
+        };
+        let extensions = ((record.max_rounds - default_max) / 10).max(0);
+
+        events.push(FeedEvent {
+            id: record.id.to_string(),
+            spec_path: record.spec_path.clone(),
+            engineer: record.engineer.clone(),
+            state: record.state.to_string(),
+            rounds: record.round,
+            total_tokens: tokens,
+            total_cost: cost,
+            spec_pr_url: record.spec_pr_url.clone(),
+            updated_at: record.updated_at,
+            extensions,
+        });
+    }
+
+    Ok(FeedResponse { events, has_more })
+}
+
+// ── Build specs response (FR-13) ──
+
+pub async fn build_specs_response(
+    store: &dyn StateStore,
+    config: &NautiloopConfig,
+    spec_path: &str,
+    limit: usize,
+) -> crate::error::Result<SpecsResponse> {
+    let all_loops = store
+        .get_loops_for_engineer(None, true, true)
+        .await?;
+
+    let mut matching: Vec<&LoopRecord> = all_loops
+        .iter()
+        .filter(|l| l.spec_path == spec_path)
+        .collect();
+    matching.sort_by_key(|r| std::cmp::Reverse(r.created_at));
+
+    let total_runs = matching.len() as u64;
+    let mut converged = 0u64;
+    let mut terminal = 0u64;
+    let mut rounds_sum = 0i64;
+    let mut total_cost_sum = 0.0f64;
+    let mut has_cost = false;
+
+    let mut runs = Vec::with_capacity(matching.len().min(limit));
+    for record in &matching[..matching.len().min(limit)] {
+        let rounds = store.get_rounds(record.id).await?;
+        let (_, cost) = compute_loop_totals(&rounds, record, config);
+        runs.push(SpecRun {
+            id: record.id.to_string(),
+            engineer: record.engineer.clone(),
+            state: record.state.to_string(),
+            rounds: record.round,
+            total_cost: cost,
+            branch: record.branch.clone(),
+            created_at: record.created_at,
+        });
+    }
+
+    for record in &matching {
+        if record.state.is_terminal() {
+            terminal += 1;
+            rounds_sum += record.round as i64;
+            if matches!(
+                record.state,
+                LoopState::Converged | LoopState::Hardened | LoopState::Shipped
+            ) {
+                converged += 1;
+            }
+        }
+        let rounds = store.get_rounds(record.id).await?;
+        let (_, cost) = compute_loop_totals(&rounds, record, config);
+        if let Some(c) = cost {
+            total_cost_sum += c;
+            has_cost = true;
+        }
+    }
+
+    Ok(SpecsResponse {
+        spec_path: spec_path.to_string(),
+        runs,
+        aggregates: SpecAggregates {
+            total_runs,
+            converge_rate: if terminal > 0 {
+                Some(converged as f64 / terminal as f64)
+            } else {
+                None
+            },
+            avg_rounds: if terminal > 0 {
+                Some(rounds_sum as f64 / terminal as f64)
+            } else {
+                None
+            },
+            total_cost: if has_cost {
+                Some(total_cost_sum)
+            } else {
+                None
+            },
+        },
+    })
+}
+
+// ── Build stats response (FR-14) ──
+
+pub async fn build_stats_response(
+    store: &dyn StateStore,
+    config: &NautiloopConfig,
+    window_str: &str,
+) -> crate::error::Result<StatsResponse> {
+    let now = Utc::now();
+    let window_days: i64 = match window_str {
+        "24h" => 1,
+        "30d" => 30,
+        _ => 7, // default 7d
+    };
+    let cutoff = now - Duration::days(window_days);
+
+    let all_loops = store
+        .get_loops_for_engineer(None, true, true)
+        .await?;
+
+    let window_loops: Vec<&LoopRecord> = all_loops
+        .iter()
+        .filter(|l| l.created_at > cutoff)
+        .collect();
+
+    // Headline
+    let mut total_cost = 0.0f64;
+    let mut has_cost = false;
+    let mut terminal_count = 0u64;
+    let mut converged_count = 0u64;
+    let mut rounds_sum = 0i64;
+
+    // Per-engineer
+    let mut eng_map: HashMap<String, (u64, f64, u64, u64)> = HashMap::new(); // (loops, cost, converged, terminal)
+    // Per-spec
+    let mut spec_map: HashMap<String, (u64, f64, u64, u64, i64)> = HashMap::new(); // (runs, cost, converged, terminal, rounds_sum)
+    // Time series
+    let mut day_map: HashMap<String, (u64, u64, u64)> = HashMap::new(); // (started, converged, failed)
+
+    for record in &window_loops {
+        let rounds = store.get_rounds(record.id).await?;
+        let (_, cost) = compute_loop_totals(&rounds, record, config);
+        let cost_val = cost.unwrap_or(0.0);
+        if cost.is_some() {
+            has_cost = true;
+        }
+        total_cost += cost_val;
+
+        if record.state.is_terminal() {
+            terminal_count += 1;
+            rounds_sum += record.round as i64;
+            if matches!(
+                record.state,
+                LoopState::Converged | LoopState::Hardened | LoopState::Shipped
+            ) {
+                converged_count += 1;
+            }
+        }
+
+        // Per-engineer
+        let eng = eng_map.entry(record.engineer.clone()).or_default();
+        eng.0 += 1;
+        eng.1 += cost_val;
+        if matches!(
+            record.state,
+            LoopState::Converged | LoopState::Hardened | LoopState::Shipped
+        ) {
+            eng.2 += 1;
+        }
+        if record.state.is_terminal() {
+            eng.3 += 1;
+        }
+
+        // Per-spec
+        let spec = spec_map.entry(record.spec_path.clone()).or_default();
+        spec.0 += 1;
+        spec.1 += cost_val;
+        if matches!(
+            record.state,
+            LoopState::Converged | LoopState::Hardened | LoopState::Shipped
+        ) {
+            spec.2 += 1;
+        }
+        if record.state.is_terminal() {
+            spec.3 += 1;
+            spec.4 += record.round as i64;
+        }
+
+        // Time series
+        let day = record.created_at.format("%Y-%m-%d").to_string();
+        let ds = day_map.entry(day).or_default();
+        ds.0 += 1;
+        if matches!(
+            record.state,
+            LoopState::Converged | LoopState::Hardened | LoopState::Shipped
+        ) {
+            ds.1 += 1;
+        }
+        if matches!(record.state, LoopState::Failed | LoopState::Cancelled) {
+            ds.2 += 1;
+        }
+    }
+
+    let mut per_engineer: Vec<EngineerStats> = eng_map
+        .into_iter()
+        .map(|(engineer, (loops, cost, converged, terminal))| EngineerStats {
+            engineer,
+            loops,
+            cost: if has_cost { Some(cost) } else { None },
+            converge_rate: if terminal > 0 {
+                Some(converged as f64 / terminal as f64)
+            } else {
+                None
+            },
+        })
+        .collect();
+    per_engineer.sort_by_key(|e| std::cmp::Reverse(e.loops));
+
+    let mut per_spec: Vec<SpecStats> = spec_map
+        .into_iter()
+        .map(
+            |(spec_path, (runs, cost, converged, terminal, rsum))| SpecStats {
+                spec_path,
+                runs,
+                cost: if has_cost { Some(cost) } else { None },
+                converge_rate: if terminal > 0 {
+                    Some(converged as f64 / terminal as f64)
+                } else {
+                    None
+                },
+                avg_rounds: if terminal > 0 {
+                    Some(rsum as f64 / terminal as f64)
+                } else {
+                    None
+                },
+            },
+        )
+        .collect();
+    per_spec.sort_by_key(|s| std::cmp::Reverse(s.runs));
+    per_spec.truncate(10);
+
+    let mut time_series: Vec<DayStats> = day_map
+        .into_iter()
+        .map(|(date, (started, converged, failed))| DayStats {
+            date,
+            started,
+            converged,
+            failed,
+        })
+        .collect();
+    time_series.sort_by(|a, b| a.date.cmp(&b.date));
+
+    Ok(StatsResponse {
+        window: window_str.to_string(),
+        headline: StatsHeadline {
+            total_loops: window_loops.len() as u64,
+            total_cost: if has_cost { Some(total_cost) } else { None },
+            converge_rate: if terminal_count > 0 {
+                Some(converged_count as f64 / terminal_count as f64)
+            } else {
+                None
+            },
+            avg_rounds: if terminal_count > 0 {
+                Some(rounds_sum as f64 / terminal_count as f64)
+            } else {
+                None
+            },
+        },
+        per_engineer,
+        per_spec,
+        time_series,
+    })
+}
+
+// Need Deserialize for cache clone via serde
+impl<'de> Deserialize<'de> for StatsResponse {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Inner {
+            window: String,
+            headline: InnerHeadline,
+            per_engineer: Vec<InnerEngineerStats>,
+            per_spec: Vec<InnerSpecStats>,
+            time_series: Vec<InnerDayStats>,
+        }
+        #[derive(Deserialize)]
+        struct InnerHeadline {
+            total_loops: u64,
+            total_cost: Option<f64>,
+            converge_rate: Option<f64>,
+            avg_rounds: Option<f64>,
+        }
+        #[derive(Deserialize)]
+        struct InnerEngineerStats {
+            engineer: String,
+            loops: u64,
+            cost: Option<f64>,
+            converge_rate: Option<f64>,
+        }
+        #[derive(Deserialize)]
+        struct InnerSpecStats {
+            spec_path: String,
+            runs: u64,
+            cost: Option<f64>,
+            converge_rate: Option<f64>,
+            avg_rounds: Option<f64>,
+        }
+        #[derive(Deserialize)]
+        struct InnerDayStats {
+            date: String,
+            started: u64,
+            converged: u64,
+            failed: u64,
+        }
+
+        let inner = Inner::deserialize(deserializer)?;
+        Ok(StatsResponse {
+            window: inner.window,
+            headline: StatsHeadline {
+                total_loops: inner.headline.total_loops,
+                total_cost: inner.headline.total_cost,
+                converge_rate: inner.headline.converge_rate,
+                avg_rounds: inner.headline.avg_rounds,
+            },
+            per_engineer: inner
+                .per_engineer
+                .into_iter()
+                .map(|e| EngineerStats {
+                    engineer: e.engineer,
+                    loops: e.loops,
+                    cost: e.cost,
+                    converge_rate: e.converge_rate,
+                })
+                .collect(),
+            per_spec: inner
+                .per_spec
+                .into_iter()
+                .map(|s| SpecStats {
+                    spec_path: s.spec_path,
+                    runs: s.runs,
+                    cost: s.cost,
+                    converge_rate: s.converge_rate,
+                    avg_rounds: s.avg_rounds,
+                })
+                .collect(),
+            time_series: inner
+                .time_series
+                .into_iter()
+                .map(|d| DayStats {
+                    date: d.date,
+                    started: d.started,
+                    converged: d.converged,
+                    failed: d.failed,
+                })
+                .collect(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compute_cost() {
+        let tu = TokenUsage {
+            input: 1_000_000,
+            output: 500_000,
+        };
+        let pricing = PricingConfig {
+            models: HashMap::from([(
+                "claude-sonnet-4-20250514".to_string(),
+                ModelPricing {
+                    input_per_million: 3.0,
+                    output_per_million: 15.0,
+                },
+            )]),
+        };
+        let cost = compute_cost(&tu, "claude-sonnet-4-20250514", &pricing).unwrap();
+        assert!((cost - 10.5).abs() < 0.001); // 3.0 + 7.5
+    }
+
+    #[test]
+    fn test_compute_cost_unknown_model() {
+        let tu = TokenUsage {
+            input: 1000,
+            output: 500,
+        };
+        let pricing = PricingConfig {
+            models: HashMap::new(),
+        };
+        assert!(compute_cost(&tu, "unknown-model", &pricing).is_none());
+    }
+}

--- a/control-plane/src/api/dashboard/aggregate.rs
+++ b/control-plane/src/api/dashboard/aggregate.rs
@@ -4,6 +4,7 @@ use std::time::Instant;
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
+use uuid::Uuid;
 
 use crate::config::{ModelPricing, NautiloopConfig, PricingConfig};
 use crate::state::StateStore;
@@ -84,6 +85,7 @@ pub struct Trends {
 pub struct FeedResponse {
     pub events: Vec<FeedEvent>,
     pub has_more: bool,
+    pub engineers: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -445,11 +447,15 @@ pub async fn build_dashboard_state(
     let mut has_cost = false;
     let mut engineers_set: std::collections::HashSet<String> = std::collections::HashSet::new();
 
+    // Batch-fetch all rounds in a single query to avoid N+1 (review feedback #5).
+    let loop_ids: Vec<Uuid> = filtered.iter().map(|r| r.id).collect();
+    let all_rounds = store.get_rounds_batch(&loop_ids).await?;
+
     for record in &filtered {
-        let rounds = store.get_rounds(record.id).await?;
-        let current_stage = current_stage_for_record(record, &rounds);
-        let last_verdict = extract_last_verdict(&rounds);
-        let (tokens, cost) = compute_loop_totals(&rounds, record, config);
+        let rounds = all_rounds.get(&record.id).map(|v| v.as_slice()).unwrap_or(&[]);
+        let current_stage = current_stage_for_record(record, rounds);
+        let last_verdict = extract_last_verdict(rounds);
+        let (tokens, cost) = compute_loop_totals(rounds, record, config);
 
         *counts_by_state
             .entry(record.state.to_string())
@@ -590,9 +596,12 @@ async fn compute_window_summary(
     let mut rounds_sum = 0i64;
     let mut cost_by_engineer: HashMap<String, f64> = HashMap::new();
 
+    let loop_ids: Vec<Uuid> = loops.iter().map(|r| r.id).collect();
+    let all_rounds = store.get_rounds_batch(&loop_ids).await?;
+
     for record in loops {
-        let rounds = store.get_rounds(record.id).await?;
-        let (_, cost) = compute_loop_totals(&rounds, record, config);
+        let rounds = all_rounds.get(&record.id).map(|v| v.as_slice()).unwrap_or(&[]);
+        let (_, cost) = compute_loop_totals(rounds, record, config);
         if let Some(c) = cost {
             total_cost += c;
             has_cost = true;
@@ -642,7 +651,7 @@ async fn compute_window_summary(
 pub async fn build_feed_response(
     store: &dyn StateStore,
     config: &NautiloopConfig,
-    cursor: Option<DateTime<Utc>>,
+    cursor: Option<(DateTime<Utc>, Uuid)>,
     limit: usize,
     filter: Option<&str>,
 ) -> crate::error::Result<FeedResponse> {
@@ -650,19 +659,31 @@ pub async fn build_feed_response(
         .get_loops_for_engineer(None, true, true)
         .await?;
 
+    // Collect distinct engineers from all terminal loops for feed filter chips (FR-12b).
+    let mut engineers_set: std::collections::HashSet<String> = std::collections::HashSet::new();
+
     let mut terminal: Vec<&LoopRecord> = all_loops
         .iter()
         .filter(|l| {
             if !l.state.is_terminal() {
                 return false;
             }
-            // Cursor-based pagination: exclude loops strictly after the cursor.
-            // Use `>` so that items sharing the cursor timestamp are included
-            // (potential minor duplication is preferable to losing events).
-            if let Some(c) = cursor
-                && l.updated_at > c {
+            engineers_set.insert(l.engineer.clone());
+            // Compound cursor pagination: exclude items at or before the cursor
+            // position. Items are sorted by (updated_at DESC, id DESC). An item
+            // is "before" the cursor when its timestamp is strictly later than the
+            // cursor timestamp, OR when timestamps match and its id is >= the
+            // cursor id (the cursor id itself was the last item on the prev page).
+            if let Some((cursor_ts, cursor_id)) = cursor {
+                if l.updated_at > cursor_ts {
+                    // Strictly after cursor in desc order — already shown
                     return false;
                 }
+                if l.updated_at == cursor_ts && l.id >= cursor_id {
+                    // Same timestamp: exclude the cursor item and anything "above" it
+                    return false;
+                }
+            }
             match filter {
                 Some("converged") => matches!(
                     l.state,
@@ -675,14 +696,19 @@ pub async fn build_feed_response(
         })
         .collect();
 
-    terminal.sort_by_key(|r| std::cmp::Reverse(r.updated_at));
+    terminal.sort_by(|a, b| {
+        b.updated_at.cmp(&a.updated_at).then_with(|| b.id.cmp(&a.id))
+    });
     let has_more = terminal.len() > limit;
     let events_slice = &terminal[..terminal.len().min(limit)];
 
+    let feed_ids: Vec<Uuid> = events_slice.iter().map(|r| r.id).collect();
+    let feed_rounds = store.get_rounds_batch(&feed_ids).await?;
+
     let mut events = Vec::with_capacity(events_slice.len());
     for record in events_slice {
-        let rounds = store.get_rounds(record.id).await?;
-        let (tokens, cost) = compute_loop_totals(&rounds, record, config);
+        let rounds = feed_rounds.get(&record.id).map(|v| v.as_slice()).unwrap_or(&[]);
+        let (tokens, cost) = compute_loop_totals(rounds, record, config);
         // Count extensions: max_rounds above the configured default
         let default_max = if record.kind == crate::types::LoopKind::Harden {
             config.limits.max_rounds_harden as i32
@@ -705,7 +731,14 @@ pub async fn build_feed_response(
         });
     }
 
-    Ok(FeedResponse { events, has_more })
+    let mut engineers: Vec<String> = engineers_set.into_iter().collect();
+    engineers.sort();
+
+    Ok(FeedResponse {
+        events,
+        has_more,
+        engineers,
+    })
 }
 
 // ── Build specs response (FR-13) ──
@@ -733,11 +766,14 @@ pub async fn build_specs_response(
     let mut total_cost_sum = 0.0f64;
     let mut has_cost = false;
 
+    let spec_ids: Vec<Uuid> = matching.iter().map(|r| r.id).collect();
+    let spec_rounds = store.get_rounds_batch(&spec_ids).await?;
+
     // Single pass: compute rounds/cost once per loop, build both runs slice and aggregates
     let mut runs = Vec::with_capacity(matching.len().min(limit));
     for (i, record) in matching.iter().enumerate() {
-        let rounds = store.get_rounds(record.id).await?;
-        let (_, cost) = compute_loop_totals(&rounds, record, config);
+        let rounds = spec_rounds.get(&record.id).map(|v| v.as_slice()).unwrap_or(&[]);
+        let (_, cost) = compute_loop_totals(rounds, record, config);
 
         // Build the runs response slice for the first `limit` items
         if i < limit {
@@ -831,9 +867,12 @@ pub async fn build_stats_response(
     // Time series
     let mut day_map: HashMap<String, (u64, u64, u64)> = HashMap::new(); // (started, converged, failed)
 
+    let stats_ids: Vec<Uuid> = window_loops.iter().map(|r| r.id).collect();
+    let stats_rounds = store.get_rounds_batch(&stats_ids).await?;
+
     for record in &window_loops {
-        let rounds = store.get_rounds(record.id).await?;
-        let (_, cost) = compute_loop_totals(&rounds, record, config);
+        let rounds = stats_rounds.get(&record.id).map(|v| v.as_slice()).unwrap_or(&[]);
+        let (_, cost) = compute_loop_totals(rounds, record, config);
         let cost_val = cost.unwrap_or(0.0);
         if cost.is_some() {
             has_cost = true;

--- a/control-plane/src/api/dashboard/aggregate.rs
+++ b/control-plane/src/api/dashboard/aggregate.rs
@@ -128,7 +128,7 @@ pub struct SpecAggregates {
     pub total_cost: Option<f64>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct StatsResponse {
     pub window: String,
     pub headline: StatsHeadline,
@@ -137,7 +137,7 @@ pub struct StatsResponse {
     pub time_series: Vec<DayStats>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct StatsHeadline {
     pub total_loops: u64,
     pub total_cost: Option<f64>,
@@ -145,7 +145,7 @@ pub struct StatsHeadline {
     pub avg_rounds: Option<f64>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct EngineerStats {
     pub engineer: String,
     pub loops: u64,
@@ -153,7 +153,7 @@ pub struct EngineerStats {
     pub converge_rate: Option<f64>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct SpecStats {
     pub spec_path: String,
     pub runs: u64,
@@ -162,7 +162,7 @@ pub struct SpecStats {
     pub avg_rounds: Option<f64>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct DayStats {
     pub date: String,
     pub started: u64,
@@ -229,10 +229,7 @@ impl StatsCache {
         let guard = self.inner.read().await;
         guard.get(window).and_then(|(resp, ts)| {
             if ts.elapsed().as_secs() < 60 {
-                // StatsResponse doesn't implement Clone, so we serialize/deserialize
-                serde_json::to_value(resp)
-                    .ok()
-                    .and_then(|v| serde_json::from_value(v).ok())
+                Some(resp.clone())
             } else {
                 None
             }
@@ -240,12 +237,8 @@ impl StatsCache {
     }
 
     pub async fn set(&self, window: String, resp: &StatsResponse) {
-        if let Ok(cloned) = serde_json::to_value(resp)
-            .and_then(serde_json::from_value::<StatsResponse>)
-        {
-            let mut guard = self.inner.write().await;
-            guard.insert(window, (cloned, Instant::now()));
-        }
+        let mut guard = self.inner.write().await;
+        guard.insert(window, (resp.clone(), Instant::now()));
     }
 }
 
@@ -532,7 +525,7 @@ async fn build_fleet_summary(
 
     // Get all loops (including terminal) for the window
     let all_loops = store
-        .get_loops_for_engineer(None, true, true)
+        .get_all_loops(true)
         .await?;
 
     let current_window: Vec<&LoopRecord> = all_loops
@@ -656,35 +649,33 @@ pub async fn build_feed_response(
     filter: Option<&str>,
 ) -> crate::error::Result<FeedResponse> {
     let all_loops = store
-        .get_loops_for_engineer(None, true, true)
+        .get_all_loops(true)
         .await?;
 
     // Collect distinct engineers from all terminal loops for feed filter chips (FR-12b).
+    // Engineers are collected independently of cursor/filter so chips always show
+    // all available engineers regardless of the current page or filter selection.
     let mut engineers_set: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for l in &all_loops {
+        if l.state.is_terminal() {
+            engineers_set.insert(l.engineer.clone());
+        }
+    }
 
+    // Step 1: filter to terminal loops only
+    // Step 2: apply content filter (state/engineer)
+    // Step 3: apply cursor exclusion (pagination)
+    // This ordering ensures that cursor-excluded items that match the filter
+    // are only those already shown on previous pages, not items filtered out
+    // by a different criterion.
     let mut terminal: Vec<&LoopRecord> = all_loops
         .iter()
         .filter(|l| {
             if !l.state.is_terminal() {
                 return false;
             }
-            engineers_set.insert(l.engineer.clone());
-            // Compound cursor pagination: exclude items at or before the cursor
-            // position. Items are sorted by (updated_at DESC, id DESC). An item
-            // is "before" the cursor when its timestamp is strictly later than the
-            // cursor timestamp, OR when timestamps match and its id is >= the
-            // cursor id (the cursor id itself was the last item on the prev page).
-            if let Some((cursor_ts, cursor_id)) = cursor {
-                if l.updated_at > cursor_ts {
-                    // Strictly after cursor in desc order — already shown
-                    return false;
-                }
-                if l.updated_at == cursor_ts && l.id >= cursor_id {
-                    // Same timestamp: exclude the cursor item and anything "above" it
-                    return false;
-                }
-            }
-            match filter {
+            // Apply content filter
+            let passes_filter = match filter {
                 Some("converged") => matches!(
                     l.state,
                     LoopState::Converged | LoopState::Hardened | LoopState::Shipped
@@ -692,7 +683,20 @@ pub async fn build_feed_response(
                 Some("failed") => matches!(l.state, LoopState::Failed | LoopState::Cancelled),
                 Some(eng) => l.engineer == eng,
                 None => true,
+            };
+            if !passes_filter {
+                return false;
             }
+            // Apply cursor exclusion after filter
+            if let Some((cursor_ts, cursor_id)) = cursor {
+                if l.updated_at > cursor_ts {
+                    return false;
+                }
+                if l.updated_at == cursor_ts && l.id >= cursor_id {
+                    return false;
+                }
+            }
+            true
         })
         .collect();
 
@@ -750,7 +754,7 @@ pub async fn build_specs_response(
     limit: usize,
 ) -> crate::error::Result<SpecsResponse> {
     let all_loops = store
-        .get_loops_for_engineer(None, true, true)
+        .get_all_loops(true)
         .await?;
 
     let mut matching: Vec<&LoopRecord> = all_loops
@@ -845,7 +849,7 @@ pub async fn build_stats_response(
     let cutoff = now - Duration::days(window_days);
 
     let all_loops = store
-        .get_loops_for_engineer(None, true, true)
+        .get_all_loops(true)
         .await?;
 
     let window_loops: Vec<&LoopRecord> = all_loops

--- a/control-plane/src/api/dashboard/aggregate.rs
+++ b/control-plane/src/api/dashboard/aggregate.rs
@@ -650,67 +650,14 @@ pub async fn build_feed_response(
     state_filter: Option<&str>,
     engineer_filter: Option<&str>,
 ) -> crate::error::Result<FeedResponse> {
-    // Feed shows terminal events. No time window: pagination handles bounding.
-    let all_loops = store
-        .get_all_loops(true, None)
+    // Fetch distinct engineers for filter chips (independent of current page/filter).
+    let engineers_list = store.get_terminal_engineers().await?;
+
+    // Fetch limit+1 terminal loops with filters pushed to SQL (avoids loading entire table).
+    let terminal = store
+        .get_terminal_loops(None, state_filter, engineer_filter, limit + 1, cursor)
         .await?;
 
-    // Collect distinct engineers from all terminal loops for feed filter chips (FR-12b).
-    // Engineers are collected independently of cursor/filter so chips always show
-    // all available engineers regardless of the current page or filter selection.
-    let mut engineers_set: std::collections::HashSet<String> = std::collections::HashSet::new();
-    for l in &all_loops {
-        if l.state.is_terminal() {
-            engineers_set.insert(l.engineer.clone());
-        }
-    }
-
-    // Step 1: filter to terminal loops only
-    // Step 2: apply content filter (state/engineer)
-    // Step 3: apply cursor exclusion (pagination)
-    // This ordering ensures that cursor-excluded items that match the filter
-    // are only those already shown on previous pages, not items filtered out
-    // by a different criterion.
-    let mut terminal: Vec<&LoopRecord> = all_loops
-        .iter()
-        .filter(|l| {
-            if !l.state.is_terminal() {
-                return false;
-            }
-            // Apply state filter and engineer filter independently.
-            // Both must pass (AND semantics) when both are specified.
-            let passes_state = match state_filter {
-                Some("converged") => matches!(
-                    l.state,
-                    LoopState::Converged | LoopState::Hardened | LoopState::Shipped
-                ),
-                Some("failed") => matches!(l.state, LoopState::Failed | LoopState::Cancelled),
-                _ => true,
-            };
-            let passes_engineer = match engineer_filter {
-                Some(eng) => l.engineer == eng,
-                None => true,
-            };
-            let passes_filter = passes_state && passes_engineer;
-            if !passes_filter {
-                return false;
-            }
-            // Apply cursor exclusion after filter
-            if let Some((cursor_ts, cursor_id)) = cursor {
-                if l.updated_at > cursor_ts {
-                    return false;
-                }
-                if l.updated_at == cursor_ts && l.id >= cursor_id {
-                    return false;
-                }
-            }
-            true
-        })
-        .collect();
-
-    terminal.sort_by(|a, b| {
-        b.updated_at.cmp(&a.updated_at).then_with(|| b.id.cmp(&a.id))
-    });
     let has_more = terminal.len() > limit;
     let events_slice = &terminal[..terminal.len().min(limit)];
 
@@ -743,13 +690,10 @@ pub async fn build_feed_response(
         });
     }
 
-    let mut engineers: Vec<String> = engineers_set.into_iter().collect();
-    engineers.sort();
-
     Ok(FeedResponse {
         events,
         has_more,
-        engineers,
+        engineers: engineers_list,
     })
 }
 
@@ -761,16 +705,11 @@ pub async fn build_specs_response(
     spec_path: &str,
     limit: usize,
 ) -> crate::error::Result<SpecsResponse> {
-    // Specs page shows all runs of a specific spec — no time window.
-    let all_loops = store
-        .get_all_loops(true, None)
+    // Push WHERE spec_path = $1 to SQL instead of loading all loops and filtering in Rust.
+    // Use a generous limit for aggregate computation; the response is truncated to `limit`.
+    let matching = store
+        .get_loops_by_spec_path(spec_path, 10000)
         .await?;
-
-    let mut matching: Vec<&LoopRecord> = all_loops
-        .iter()
-        .filter(|l| l.spec_path == spec_path)
-        .collect();
-    matching.sort_by_key(|r| std::cmp::Reverse(r.created_at));
 
     let total_runs = matching.len() as u64;
     let mut converged = 0u64;

--- a/control-plane/src/api/dashboard/aggregate.rs
+++ b/control-plane/src/api/dashboard/aggregate.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::time::Instant;
 
 use chrono::{DateTime, Duration, Utc};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 use uuid::Uuid;
 
@@ -128,7 +128,7 @@ pub struct SpecAggregates {
     pub total_cost: Option<f64>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StatsResponse {
     pub window: String,
     pub headline: StatsHeadline,
@@ -137,7 +137,7 @@ pub struct StatsResponse {
     pub time_series: Vec<DayStats>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StatsHeadline {
     pub total_loops: u64,
     pub total_cost: Option<f64>,
@@ -145,7 +145,7 @@ pub struct StatsHeadline {
     pub avg_rounds: Option<f64>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EngineerStats {
     pub engineer: String,
     pub loops: u64,
@@ -153,7 +153,7 @@ pub struct EngineerStats {
     pub converge_rate: Option<f64>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SpecStats {
     pub spec_path: String,
     pub runs: u64,
@@ -162,7 +162,7 @@ pub struct SpecStats {
     pub avg_rounds: Option<f64>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DayStats {
     pub date: String,
     pub started: u64,

--- a/control-plane/src/api/dashboard/aggregate.rs
+++ b/control-plane/src/api/dashboard/aggregate.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::time::Instant;
 
 use chrono::{DateTime, Duration, Utc};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use tokio::sync::RwLock;
 use uuid::Uuid;
 
@@ -523,9 +523,10 @@ async fn build_fleet_summary(
     let cutoff = now - window;
     let prev_cutoff = cutoff - window;
 
-    // Get all loops (including terminal) for the window
+    // Get loops since the previous window cutoff (14 days back) to compute
+    // both current and prior-period summaries without loading the full table.
     let all_loops = store
-        .get_all_loops(true)
+        .get_all_loops(true, Some(prev_cutoff))
         .await?;
 
     let current_window: Vec<&LoopRecord> = all_loops
@@ -646,10 +647,12 @@ pub async fn build_feed_response(
     config: &NautiloopConfig,
     cursor: Option<(DateTime<Utc>, Uuid)>,
     limit: usize,
-    filter: Option<&str>,
+    state_filter: Option<&str>,
+    engineer_filter: Option<&str>,
 ) -> crate::error::Result<FeedResponse> {
+    // Feed shows terminal events. No time window: pagination handles bounding.
     let all_loops = store
-        .get_all_loops(true)
+        .get_all_loops(true, None)
         .await?;
 
     // Collect distinct engineers from all terminal loops for feed filter chips (FR-12b).
@@ -674,16 +677,21 @@ pub async fn build_feed_response(
             if !l.state.is_terminal() {
                 return false;
             }
-            // Apply content filter
-            let passes_filter = match filter {
+            // Apply state filter and engineer filter independently.
+            // Both must pass (AND semantics) when both are specified.
+            let passes_state = match state_filter {
                 Some("converged") => matches!(
                     l.state,
                     LoopState::Converged | LoopState::Hardened | LoopState::Shipped
                 ),
                 Some("failed") => matches!(l.state, LoopState::Failed | LoopState::Cancelled),
+                _ => true,
+            };
+            let passes_engineer = match engineer_filter {
                 Some(eng) => l.engineer == eng,
                 None => true,
             };
+            let passes_filter = passes_state && passes_engineer;
             if !passes_filter {
                 return false;
             }
@@ -753,8 +761,9 @@ pub async fn build_specs_response(
     spec_path: &str,
     limit: usize,
 ) -> crate::error::Result<SpecsResponse> {
+    // Specs page shows all runs of a specific spec — no time window.
     let all_loops = store
-        .get_all_loops(true)
+        .get_all_loops(true, None)
         .await?;
 
     let mut matching: Vec<&LoopRecord> = all_loops
@@ -848,8 +857,9 @@ pub async fn build_stats_response(
     };
     let cutoff = now - Duration::days(window_days);
 
+    // Pass the window cutoff to SQL so we don't load the entire loops table.
     let all_loops = store
-        .get_all_loops(true)
+        .get_all_loops(true, Some(cutoff))
         .await?;
 
     let window_loops: Vec<&LoopRecord> = all_loops
@@ -923,18 +933,22 @@ pub async fn build_stats_response(
             spec.4 += record.round as i64;
         }
 
-        // Time series
-        let day = record.created_at.format("%Y-%m-%d").to_string();
-        let ds = day_map.entry(day).or_default();
-        ds.0 += 1;
+        // Time series: bucket "started" by created_at, outcomes by updated_at.
+        // This way the "started" count reflects when work began, and
+        // "converged"/"failed" reflect when outcomes were reached.
+        let start_day = record.created_at.format("%Y-%m-%d").to_string();
+        day_map.entry(start_day).or_default().0 += 1;
+
         if matches!(
             record.state,
             LoopState::Converged | LoopState::Hardened | LoopState::Shipped
         ) {
-            ds.1 += 1;
+            let outcome_day = record.updated_at.format("%Y-%m-%d").to_string();
+            day_map.entry(outcome_day).or_default().1 += 1;
         }
         if matches!(record.state, LoopState::Failed | LoopState::Cancelled) {
-            ds.2 += 1;
+            let outcome_day = record.updated_at.format("%Y-%m-%d").to_string();
+            day_map.entry(outcome_day).or_default().2 += 1;
         }
     }
 
@@ -1009,93 +1023,6 @@ pub async fn build_stats_response(
     })
 }
 
-// Need Deserialize for cache clone via serde
-impl<'de> Deserialize<'de> for StatsResponse {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        struct Inner {
-            window: String,
-            headline: InnerHeadline,
-            per_engineer: Vec<InnerEngineerStats>,
-            per_spec: Vec<InnerSpecStats>,
-            time_series: Vec<InnerDayStats>,
-        }
-        #[derive(Deserialize)]
-        struct InnerHeadline {
-            total_loops: u64,
-            total_cost: Option<f64>,
-            converge_rate: Option<f64>,
-            avg_rounds: Option<f64>,
-        }
-        #[derive(Deserialize)]
-        struct InnerEngineerStats {
-            engineer: String,
-            loops: u64,
-            cost: Option<f64>,
-            converge_rate: Option<f64>,
-        }
-        #[derive(Deserialize)]
-        struct InnerSpecStats {
-            spec_path: String,
-            runs: u64,
-            cost: Option<f64>,
-            converge_rate: Option<f64>,
-            avg_rounds: Option<f64>,
-        }
-        #[derive(Deserialize)]
-        struct InnerDayStats {
-            date: String,
-            started: u64,
-            converged: u64,
-            failed: u64,
-        }
-
-        let inner = Inner::deserialize(deserializer)?;
-        Ok(StatsResponse {
-            window: inner.window,
-            headline: StatsHeadline {
-                total_loops: inner.headline.total_loops,
-                total_cost: inner.headline.total_cost,
-                converge_rate: inner.headline.converge_rate,
-                avg_rounds: inner.headline.avg_rounds,
-            },
-            per_engineer: inner
-                .per_engineer
-                .into_iter()
-                .map(|e| EngineerStats {
-                    engineer: e.engineer,
-                    loops: e.loops,
-                    cost: e.cost,
-                    converge_rate: e.converge_rate,
-                })
-                .collect(),
-            per_spec: inner
-                .per_spec
-                .into_iter()
-                .map(|s| SpecStats {
-                    spec_path: s.spec_path,
-                    runs: s.runs,
-                    cost: s.cost,
-                    converge_rate: s.converge_rate,
-                    avg_rounds: s.avg_rounds,
-                })
-                .collect(),
-            time_series: inner
-                .time_series
-                .into_iter()
-                .map(|d| DayStats {
-                    date: d.date,
-                    started: d.started,
-                    converged: d.converged,
-                    failed: d.failed,
-                })
-                .collect(),
-        })
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/control-plane/src/api/dashboard/aggregate.rs
+++ b/control-plane/src/api/dashboard/aggregate.rs
@@ -410,25 +410,25 @@ pub async fn build_dashboard_state(
     viewer_engineer: &str,
     fleet_cache: &FleetSummaryCache,
 ) -> crate::error::Result<DashboardStateResponse> {
-    let engineer_filter = if team {
-        None
-    } else {
-        Some(viewer_engineer)
-    };
-
-    // Get all loops (active + terminal for card grid)
-    let loops = store
-        .get_loops_for_engineer(engineer_filter, team, true)
-        .await?;
-
     let now = Utc::now();
     let cutoff = now - Duration::hours(24);
 
-    // Filter: active + recently-terminal (or all terminal if requested)
-    let filtered: Vec<&LoopRecord> = loops
+    // Use get_all_loops for aggregation instead of get_loops_for_engineer which
+    // has a LIMIT 100 in the Postgres implementation. The trait comment explicitly
+    // reserves get_loops_for_engineer for CLI/UI display. We filter by engineer
+    // in Rust after fetching.
+    let all_loops = store.get_all_loops(true, Some(cutoff)).await?;
+
+    // Apply engineer filter in Rust (matches get_loops_for_engineer semantics)
+    let filtered: Vec<&LoopRecord> = all_loops
         .iter()
         .filter(|l| {
-            !l.state.is_terminal() || include_all_terminal || l.updated_at > cutoff
+            // Engineer scoping
+            let eng_match = team || l.engineer == viewer_engineer;
+            // Time scoping: active + recently-terminal (or all terminal if requested)
+            let time_match =
+                !l.state.is_terminal() || include_all_terminal || l.updated_at > cutoff;
+            eng_match && time_match
         })
         .collect();
 
@@ -653,9 +653,20 @@ pub async fn build_feed_response(
     // Fetch distinct engineers for filter chips (independent of current page/filter).
     let engineers_list = store.get_terminal_engineers().await?;
 
+    // Default to 90-day time bound to prevent full-table scans on long-lived deployments.
+    // The feed shows recent terminal events; historical loops older than 90 days are
+    // unlikely to be relevant.
+    let default_since = Utc::now() - Duration::days(90);
+
     // Fetch limit+1 terminal loops with filters pushed to SQL (avoids loading entire table).
     let terminal = store
-        .get_terminal_loops(None, state_filter, engineer_filter, limit + 1, cursor)
+        .get_terminal_loops(
+            Some(default_since),
+            state_filter,
+            engineer_filter,
+            limit + 1,
+            cursor,
+        )
         .await?;
 
     let has_more = terminal.len() > limit;

--- a/control-plane/src/api/dashboard/aggregate.rs
+++ b/control-plane/src/api/dashboard/aggregate.rs
@@ -354,12 +354,11 @@ fn compute_loop_totals(
         }
     }
 
-    let cost = if has_pricing || pricing.is_some() {
-        if has_pricing {
-            Some(total_cost)
-        } else {
-            Some(0.0)
-        }
+    // Only return Some(cost) when at least one round had computable cost.
+    // When pricing is configured but no rounds have token data yet, return None
+    // so the UI shows "—" instead of "$0.00".
+    let cost = if has_pricing {
+        Some(total_cost)
     } else {
         None
     };
@@ -657,8 +656,11 @@ pub async fn build_feed_response(
             if !l.state.is_terminal() {
                 return false;
             }
+            // Cursor-based pagination: exclude loops strictly after the cursor.
+            // Use `>` so that items sharing the cursor timestamp are included
+            // (potential minor duplication is preferable to losing events).
             if let Some(c) = cursor
-                && l.updated_at >= c {
+                && l.updated_at > c {
                     return false;
                 }
             match filter {
@@ -731,22 +733,26 @@ pub async fn build_specs_response(
     let mut total_cost_sum = 0.0f64;
     let mut has_cost = false;
 
+    // Single pass: compute rounds/cost once per loop, build both runs slice and aggregates
     let mut runs = Vec::with_capacity(matching.len().min(limit));
-    for record in &matching[..matching.len().min(limit)] {
+    for (i, record) in matching.iter().enumerate() {
         let rounds = store.get_rounds(record.id).await?;
         let (_, cost) = compute_loop_totals(&rounds, record, config);
-        runs.push(SpecRun {
-            id: record.id.to_string(),
-            engineer: record.engineer.clone(),
-            state: record.state.to_string(),
-            rounds: record.round,
-            total_cost: cost,
-            branch: record.branch.clone(),
-            created_at: record.created_at,
-        });
-    }
 
-    for record in &matching {
+        // Build the runs response slice for the first `limit` items
+        if i < limit {
+            runs.push(SpecRun {
+                id: record.id.to_string(),
+                engineer: record.engineer.clone(),
+                state: record.state.to_string(),
+                rounds: record.round,
+                total_cost: cost,
+                branch: record.branch.clone(),
+                created_at: record.created_at,
+            });
+        }
+
+        // Aggregate across all matching loops
         if record.state.is_terminal() {
             terminal += 1;
             rounds_sum += record.round as i64;
@@ -757,8 +763,6 @@ pub async fn build_specs_response(
                 converged += 1;
             }
         }
-        let rounds = store.get_rounds(record.id).await?;
-        let (_, cost) = compute_loop_totals(&rounds, record, config);
         if let Some(c) = cost {
             total_cost_sum += c;
             has_cost = true;

--- a/control-plane/src/api/dashboard/auth.rs
+++ b/control-plane/src/api/dashboard/auth.rs
@@ -3,7 +3,7 @@ use axum::http::StatusCode;
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Redirect, Response};
 
-use crate::util::constant_time_eq;
+use crate::util::{constant_time_eq, extract_bearer, extract_cookie_value};
 
 /// Dashboard auth middleware: accepts cookie OR Bearer header.
 /// On failure, redirects to `/dashboard/login` for browser requests,
@@ -42,48 +42,9 @@ pub async fn dashboard_auth_middleware(
     }
 }
 
-/// Extract a cookie value by name from the Cookie header.
-pub fn extract_cookie_value(
-    headers: &axum::http::HeaderMap,
-    name: &str,
-) -> Option<String> {
-    headers
-        .get("cookie")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|cookies| {
-            cookies.split(';').find_map(|pair| {
-                let pair = pair.trim();
-                let (k, v) = pair.split_once('=')?;
-                if k.trim() == name {
-                    Some(v.trim().to_string())
-                } else {
-                    None
-                }
-            })
-        })
-}
-
-fn extract_bearer(headers: &axum::http::HeaderMap) -> Option<String> {
-    headers
-        .get("authorization")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|header| {
-            if header.len() > 7 && header[..7].eq_ignore_ascii_case("bearer ") {
-                let key = &header[7..];
-                if key.is_empty() {
-                    None
-                } else {
-                    Some(key.to_string())
-                }
-            } else {
-                None
-            }
-        })
-}
-
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::util::{extract_bearer, extract_cookie_value};
     use axum::http::HeaderMap;
 
     #[test]

--- a/control-plane/src/api/dashboard/auth.rs
+++ b/control-plane/src/api/dashboard/auth.rs
@@ -3,6 +3,8 @@ use axum::http::StatusCode;
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Redirect, Response};
 
+use crate::util::constant_time_eq;
+
 /// Dashboard auth middleware: accepts cookie OR Bearer header.
 /// On failure, redirects to `/dashboard/login` for browser requests,
 /// returns 401 for API requests (Accept: application/json).
@@ -79,17 +81,6 @@ fn extract_bearer(headers: &axum::http::HeaderMap) -> Option<String> {
         })
 }
 
-fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    let mut diff = 0u8;
-    for (x, y) in a.iter().zip(b.iter()) {
-        diff |= x ^ y;
-    }
-    diff == 0
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -137,12 +128,5 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("authorization", "Bearer ".parse().unwrap());
         assert_eq!(extract_bearer(&headers), None);
-    }
-
-    #[test]
-    fn test_constant_time_eq() {
-        assert!(constant_time_eq(b"abc", b"abc"));
-        assert!(!constant_time_eq(b"abc", b"abd"));
-        assert!(!constant_time_eq(b"abc", b"ab"));
     }
 }

--- a/control-plane/src/api/dashboard/auth.rs
+++ b/control-plane/src/api/dashboard/auth.rs
@@ -1,0 +1,148 @@
+use axum::extract::Request;
+use axum::http::StatusCode;
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Redirect, Response};
+
+/// Dashboard auth middleware: accepts cookie OR Bearer header.
+/// On failure, redirects to `/dashboard/login` for browser requests,
+/// returns 401 for API requests (Accept: application/json).
+pub async fn dashboard_auth_middleware(
+    request: Request,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    let expected_key = std::env::var("NAUTILOOP_API_KEY").map_err(|_| {
+        tracing::error!("NAUTILOOP_API_KEY not set");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    // Extract API key from cookie first, then Bearer header
+    let api_key = extract_cookie_value(request.headers(), "nautiloop_api_key")
+        .or_else(|| extract_bearer(request.headers()));
+
+    match api_key {
+        Some(key) if constant_time_eq(key.as_bytes(), expected_key.as_bytes()) => {
+            Ok(next.run(request).await)
+        }
+        _ => {
+            // Check if this is a JSON API request
+            let accepts_json = request
+                .headers()
+                .get("accept")
+                .and_then(|v| v.to_str().ok())
+                .is_some_and(|v| v.contains("application/json"));
+
+            if accepts_json {
+                Err(StatusCode::UNAUTHORIZED)
+            } else {
+                Ok(Redirect::to("/dashboard/login").into_response())
+            }
+        }
+    }
+}
+
+/// Extract a cookie value by name from the Cookie header.
+pub fn extract_cookie_value(
+    headers: &axum::http::HeaderMap,
+    name: &str,
+) -> Option<String> {
+    headers
+        .get("cookie")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|cookies| {
+            cookies.split(';').find_map(|pair| {
+                let pair = pair.trim();
+                let (k, v) = pair.split_once('=')?;
+                if k.trim() == name {
+                    Some(v.trim().to_string())
+                } else {
+                    None
+                }
+            })
+        })
+}
+
+fn extract_bearer(headers: &axum::http::HeaderMap) -> Option<String> {
+    headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|header| {
+            if header.len() > 7 && header[..7].eq_ignore_ascii_case("bearer ") {
+                let key = &header[7..];
+                if key.is_empty() {
+                    None
+                } else {
+                    Some(key.to_string())
+                }
+            } else {
+                None
+            }
+        })
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderMap;
+
+    #[test]
+    fn test_extract_cookie_value() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "cookie",
+            "nautiloop_api_key=secret123; nautiloop_engineer=alice"
+                .parse()
+                .unwrap(),
+        );
+        assert_eq!(
+            extract_cookie_value(&headers, "nautiloop_api_key"),
+            Some("secret123".to_string())
+        );
+        assert_eq!(
+            extract_cookie_value(&headers, "nautiloop_engineer"),
+            Some("alice".to_string())
+        );
+        assert_eq!(extract_cookie_value(&headers, "missing"), None);
+    }
+
+    #[test]
+    fn test_extract_cookie_single() {
+        let mut headers = HeaderMap::new();
+        headers.insert("cookie", "nautiloop_api_key=abc".parse().unwrap());
+        assert_eq!(
+            extract_cookie_value(&headers, "nautiloop_api_key"),
+            Some("abc".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_bearer() {
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", "Bearer mykey".parse().unwrap());
+        assert_eq!(extract_bearer(&headers), Some("mykey".to_string()));
+    }
+
+    #[test]
+    fn test_extract_bearer_empty() {
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", "Bearer ".parse().unwrap());
+        assert_eq!(extract_bearer(&headers), None);
+    }
+
+    #[test]
+    fn test_constant_time_eq() {
+        assert!(constant_time_eq(b"abc", b"abc"));
+        assert!(!constant_time_eq(b"abc", b"abd"));
+        assert!(!constant_time_eq(b"abc", b"ab"));
+    }
+}

--- a/control-plane/src/api/dashboard/handlers.rs
+++ b/control-plane/src/api/dashboard/handlers.rs
@@ -204,15 +204,9 @@ pub async fn loop_detail_page(
 
     let rounds = state.app.store.get_rounds(id).await?;
 
-    // Get last 200 log lines for the log pane
-    let logs = state.app.store.get_logs(id, None, None).await?;
-    let log_lines: Vec<String> = logs
-        .iter()
-        .rev()
-        .take(200)
-        .rev()
-        .map(|l| l.line.clone())
-        .collect();
+    // Get last 200 log lines for the log pane (uses LIMIT query, not full load)
+    let recent_logs = state.app.store.get_recent_logs(id, 200).await?;
+    let log_lines: Vec<String> = recent_logs.iter().map(|l| l.line.clone()).collect();
 
     Ok(Html(templates::render_loop_detail(
         &record,
@@ -237,24 +231,14 @@ pub async fn dashboard_stream(
         .ok_or(NautiloopError::LoopNotFound { id })?;
 
     if record.state.is_terminal() {
-        // Return last 200 lines as JSON
-        let logs = state.app.store.get_logs(id, None, None).await?;
-        let lines: Vec<String> = logs
-            .iter()
-            .rev()
-            .take(200)
-            .rev()
-            .map(|l| l.line.clone())
-            .collect();
+        // Return last 200 lines as JSON (uses LIMIT query, not full load)
+        let recent = state.app.store.get_recent_logs(id, 200).await?;
+        let lines: Vec<String> = recent.iter().map(|l| l.line.clone()).collect();
         Ok(Json(lines).into_response())
     } else {
         // SSE stream for active loops: send last 200 lines first, then tail new lines.
-        // Get recent logs to determine the SSE start offset.
-        let logs = state.app.store.get_logs(id, None, None).await?;
-        let skip = logs.len().saturating_sub(200);
-        // Clone into owned data that the stream can capture with 'static lifetime.
-        let recent_logs: Vec<crate::types::LogEvent> =
-            logs.into_iter().skip(skip).collect();
+        // Get recent logs to determine the SSE start offset (uses LIMIT query, not full load).
+        let recent_logs = state.app.store.get_recent_logs(id, 200).await?;
 
         // Determine the cursor timestamp: start SSE from the last recent log's
         // timestamp so we only get new lines going forward (no re-sending).
@@ -407,15 +391,17 @@ pub async fn feed_page(
     )
     .await?;
 
-    // Build a canonical filter string for template rendering (active chip highlighting).
-    let canonical_filter = canonical_feed_filter(state_filter.as_deref(), engineer_filter.as_deref());
-
     if accepts_json {
         Ok(Json(data).into_response())
     } else {
         let viewer = extract_cookie_value(&headers, "nautiloop_engineer")
             .unwrap_or_else(|| "unknown".to_string());
-        Ok(Html(templates::render_feed(&data, &viewer, canonical_filter.as_deref())).into_response())
+        Ok(Html(templates::render_feed(
+            &data,
+            &viewer,
+            state_filter.as_deref(),
+            engineer_filter.as_deref(),
+        )).into_response())
     }
 }
 
@@ -437,15 +423,6 @@ fn resolve_feed_filters(
         Some("converged") | Some("failed") => (legacy_filter.map(|s| s.to_string()), None),
         Some(eng) if !eng.is_empty() => (None, Some(eng.to_string())),
         _ => (None, None),
-    }
-}
-
-/// Build a canonical filter string for template rendering (chip highlighting + load-more data attr).
-fn canonical_feed_filter(state_filter: Option<&str>, engineer_filter: Option<&str>) -> Option<String> {
-    if let Some(sf) = state_filter {
-        Some(sf.to_string())
-    } else {
-        engineer_filter.map(|ef| ef.to_string())
     }
 }
 

--- a/control-plane/src/api/dashboard/handlers.rs
+++ b/control-plane/src/api/dashboard/handlers.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 use uuid::Uuid;
 
 use super::aggregate::{self, FleetSummaryCache, StatsCache};
-use super::auth::extract_cookie_value;
+use crate::util::extract_cookie_value;
 use super::templates;
 use crate::api::AppState;
 use crate::error::NautiloopError;
@@ -538,6 +538,18 @@ mod tests {
     use axum::http::Request;
     use tower::ServiceExt;
 
+    /// Mutex to serialize tests that modify the NAUTILOOP_API_KEY env var,
+    /// preventing races when cargo test runs them in parallel.
+    static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Set the API key env var under the mutex lock. Returns the guard
+    /// which must be held for the duration of the test.
+    fn set_test_api_key(key: &str) -> std::sync::MutexGuard<'static, ()> {
+        let guard = ENV_MUTEX.lock().unwrap();
+        unsafe { std::env::set_var("NAUTILOOP_API_KEY", key) };
+        guard
+    }
+
     fn make_test_loop(engineer: &str, state: LoopState) -> LoopRecord {
         LoopRecord {
             id: Uuid::new_v4(),
@@ -641,7 +653,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_login_submit_invalid_key() {
-        unsafe { std::env::set_var("NAUTILOOP_API_KEY", "test-secret-key") };
+        let _guard = set_test_api_key("test-secret-key");
         let (app, _) = build_test_app();
         let response = app
             .oneshot(
@@ -665,7 +677,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_login_submit_valid_key() {
-        unsafe { std::env::set_var("NAUTILOOP_API_KEY", "test-secret-key") };
+        let _guard = set_test_api_key("test-secret-key");
         let (app, _) = build_test_app();
         let response = app
             .oneshot(
@@ -700,7 +712,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_dashboard_redirects_without_auth() {
-        unsafe { std::env::set_var("NAUTILOOP_API_KEY", "test-secret-key") };
+        let _guard = set_test_api_key("test-secret-key");
         let (app, _) = build_test_app();
         let response = app
             .oneshot(
@@ -717,7 +729,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_dashboard_renders_with_cookie() {
-        unsafe { std::env::set_var("NAUTILOOP_API_KEY", "test-secret-key") };
+        let _guard = set_test_api_key("test-secret-key");
         let (app, store) = build_test_app();
 
         // Add a test loop
@@ -745,7 +757,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_dashboard_state_json() {
-        unsafe { std::env::set_var("NAUTILOOP_API_KEY", "test-secret-key") };
+        let _guard = set_test_api_key("test-secret-key");
         let (app, store) = build_test_app();
 
         let loop_record = make_test_loop("alice", LoopState::Implementing);
@@ -779,7 +791,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_loop_detail_page() {
-        unsafe { std::env::set_var("NAUTILOOP_API_KEY", "test-secret-key") };
+        let _guard = set_test_api_key("test-secret-key");
         let (app, store) = build_test_app();
 
         let loop_record = make_test_loop("alice", LoopState::Implementing);
@@ -811,7 +823,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_feed_page() {
-        unsafe { std::env::set_var("NAUTILOOP_API_KEY", "test-secret-key") };
+        let _guard = set_test_api_key("test-secret-key");
         let (app, store) = build_test_app();
 
         let mut loop_record = make_test_loop("alice", LoopState::Converged);
@@ -833,7 +845,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_feed_json() {
-        unsafe { std::env::set_var("NAUTILOOP_API_KEY", "test-secret-key") };
+        let _guard = set_test_api_key("test-secret-key");
         let (app, store) = build_test_app();
 
         let mut loop_record = make_test_loop("alice", LoopState::Converged);
@@ -861,7 +873,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_specs_page_no_path() {
-        unsafe { std::env::set_var("NAUTILOOP_API_KEY", "test-secret-key") };
+        let _guard = set_test_api_key("test-secret-key");
         let (app, _) = build_test_app();
 
         let response = app
@@ -884,7 +896,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_stats_page() {
-        unsafe { std::env::set_var("NAUTILOOP_API_KEY", "test-secret-key") };
+        let _guard = set_test_api_key("test-secret-key");
         let (app, _) = build_test_app();
 
         let response = app
@@ -902,7 +914,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_stats_json() {
-        unsafe { std::env::set_var("NAUTILOOP_API_KEY", "test-secret-key") };
+        let _guard = set_test_api_key("test-secret-key");
         let (app, _) = build_test_app();
 
         let response = app
@@ -994,7 +1006,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_dashboard_state_bearer_auth() {
-        unsafe { std::env::set_var("NAUTILOOP_API_KEY", "test-secret-key") };
+        let _guard = set_test_api_key("test-secret-key");
         let (app, _) = build_test_app();
 
         let response = app

--- a/control-plane/src/api/dashboard/handlers.rs
+++ b/control-plane/src/api/dashboard/handlers.rs
@@ -78,6 +78,24 @@ pub async fn login_submit(
 
     let secure_flag = if is_localhost { "" } else { "; Secure" };
 
+    // Validate the API key contains only cookie-safe characters (RFC 6265 §4.1.1).
+    // Cookie-values must not contain semicolons, commas, spaces, backslash,
+    // double-quotes, or control characters.
+    if !form.api_key.bytes().all(|b| {
+        b > 0x20
+            && b < 0x7F
+            && b != b';'
+            && b != b','
+            && b != b' '
+            && b != b'\\'
+            && b != b'"'
+    }) {
+        return Html(templates::render_login(Some(
+            "API key contains characters not safe for cookies",
+        )))
+        .into_response();
+    }
+
     let key_cookie = format!(
         "nautiloop_api_key={}; HttpOnly; SameSite=Strict; Path=/; Max-Age=604800{}",
         form.api_key, secure_flag
@@ -230,12 +248,106 @@ pub async fn dashboard_stream(
             .collect();
         Ok(Json(lines).into_response())
     } else {
-        // SSE stream for active loops
-        Ok(
-            crate::api::sse::stream_logs(state.app.store.clone(), id, None, None)
-                .await
-                .into_response(),
-        )
+        // SSE stream for active loops: send last 200 lines first, then tail new lines.
+        // Get recent logs to determine the SSE start offset.
+        let logs = state.app.store.get_logs(id, None, None).await?;
+        let skip = logs.len().saturating_sub(200);
+        // Clone into owned data that the stream can capture with 'static lifetime.
+        let recent_logs: Vec<crate::types::LogEvent> =
+            logs.into_iter().skip(skip).collect();
+
+        // Determine the cursor timestamp: start SSE from the last recent log's
+        // timestamp so we only get new lines going forward (no re-sending).
+        let start_ts = recent_logs
+            .last()
+            .map(|l| l.timestamp)
+            .unwrap_or(chrono::DateTime::<chrono::Utc>::UNIX_EPOCH);
+
+        // Collect seen IDs from recent logs for dedup in the tail phase.
+        let initial_seen: std::collections::HashSet<uuid::Uuid> =
+            recent_logs.iter().map(|l| l.id).collect();
+
+        let store = state.app.store.clone();
+        let stream = async_stream::stream! {
+            use axum::response::sse::Event;
+
+            // First, emit the recent log lines as SSE events
+            for log in &recent_logs {
+                let event = crate::types::api::LogEventResponse {
+                    timestamp: log.timestamp,
+                    stage: log.stage.clone(),
+                    round: log.round,
+                    line: log.line.clone(),
+                };
+                if let Ok(json) = serde_json::to_string(&event) {
+                    yield Ok::<_, std::convert::Infallible>(Event::default().data(json));
+                }
+            }
+
+            // Now tail new lines using the same pattern as sse::stream_logs
+            let mut cursor_timestamp = start_ts;
+            let mut seen_ids = initial_seen.clone();
+            let poll_interval = std::time::Duration::from_millis(500);
+
+            loop {
+                let new_logs = match store.get_logs_after(id, cursor_timestamp).await {
+                    Ok(logs) => logs,
+                    Err(e) => {
+                        tracing::error!(error = %e, "Dashboard stream: failed to get logs");
+                        break;
+                    }
+                };
+
+                for log in &new_logs {
+                    if !seen_ids.insert(log.id) {
+                        continue;
+                    }
+                    if log.timestamp > cursor_timestamp {
+                        cursor_timestamp = log.timestamp;
+                        seen_ids.clear();
+                        seen_ids.insert(log.id);
+                    }
+
+                    let event = crate::types::api::LogEventResponse {
+                        timestamp: log.timestamp,
+                        stage: log.stage.clone(),
+                        round: log.round,
+                        line: log.line.clone(),
+                    };
+                    if let Ok(json) = serde_json::to_string(&event) {
+                        yield Ok(Event::default().data(json));
+                    }
+                }
+
+                // Check if loop is terminal
+                match store.get_loop(id).await {
+                    Ok(Some(rec)) if rec.state.is_terminal() => {
+                        yield Ok(Event::default().data(
+                            serde_json::json!({
+                                "type": "end",
+                                "state": rec.state,
+                            }).to_string()
+                        ));
+                        break;
+                    }
+                    Err(e) => {
+                        tracing::error!(error = %e, "Dashboard stream: failed to check loop state");
+                        break;
+                    }
+                    _ => {}
+                }
+
+                tokio::time::sleep(poll_interval).await;
+            }
+        };
+
+        use axum::response::sse::Sse;
+        Ok(Sse::new(stream)
+            .keep_alive(
+                axum::response::sse::KeepAlive::new()
+                    .interval(std::time::Duration::from_secs(15))
+            )
+            .into_response())
     }
 }
 
@@ -254,10 +366,19 @@ pub async fn feed_page(
     Query(query): Query<FeedQuery>,
 ) -> Result<Response, NautiloopError> {
     let accepts_json = wants_json(&headers);
-    let cursor = query
-        .cursor
-        .as_deref()
-        .and_then(|c| c.parse::<DateTime<Utc>>().ok());
+    // Compound cursor: "timestamp|uuid" for deterministic pagination (no boundary duplication).
+    let cursor = query.cursor.as_deref().and_then(|c| {
+        let parts: Vec<&str> = c.splitn(2, '|').collect();
+        if parts.len() == 2 {
+            let ts = parts[0].parse::<DateTime<Utc>>().ok()?;
+            let id = parts[1].parse::<Uuid>().ok()?;
+            Some((ts, id))
+        } else {
+            // Fallback: legacy timestamp-only cursor (backwards compat during rollout)
+            let ts = c.parse::<DateTime<Utc>>().ok()?;
+            Some((ts, Uuid::nil()))
+        }
+    });
     let limit = query.limit.unwrap_or(50).min(100);
 
     let data = aggregate::build_feed_response(

--- a/control-plane/src/api/dashboard/handlers.rs
+++ b/control-plane/src/api/dashboard/handlers.rs
@@ -1,0 +1,902 @@
+use std::sync::Arc;
+
+use axum::extract::{Path, Query, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{Html, IntoResponse, Redirect, Response};
+use axum::Json;
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+use uuid::Uuid;
+
+use super::aggregate::{self, FleetSummaryCache, StatsCache};
+use super::auth::extract_cookie_value;
+use super::templates;
+use crate::api::AppState;
+use crate::error::NautiloopError;
+
+/// Extended app state for dashboard endpoints.
+#[derive(Clone)]
+pub struct DashboardState {
+    pub app: AppState,
+    pub fleet_cache: Arc<FleetSummaryCache>,
+    pub stats_cache: Arc<StatsCache>,
+}
+
+// ── Login ──
+
+pub async fn login_page() -> Html<String> {
+    Html(templates::render_login(None))
+}
+
+#[derive(Deserialize)]
+pub struct LoginForm {
+    pub api_key: String,
+    pub engineer_name: String,
+}
+
+pub async fn login_submit(
+    axum::Form(form): axum::Form<LoginForm>,
+) -> Response {
+    let expected_key = match std::env::var("NAUTILOOP_API_KEY") {
+        Ok(k) => k,
+        Err(_) => {
+            return Html(templates::render_login(Some("Server misconfigured")))
+                .into_response();
+        }
+    };
+
+    if form.api_key.is_empty() || form.engineer_name.is_empty() {
+        return Html(templates::render_login(Some("Both fields are required")))
+            .into_response();
+    }
+
+    if !constant_time_eq(form.api_key.as_bytes(), expected_key.as_bytes()) {
+        return Html(templates::render_login(Some("Invalid API key")))
+            .into_response();
+    }
+
+    // Determine if localhost (omit Secure flag)
+    let bind_addr = std::env::var("NAUTILOOP_BIND_ADDR").unwrap_or_default();
+    let is_localhost = bind_addr == "127.0.0.1"
+        || bind_addr == "[::1]"
+        || bind_addr == "localhost"
+        || bind_addr.is_empty(); // default for dev
+
+    let secure_flag = if is_localhost { "" } else { "; Secure" };
+
+    let key_cookie = format!(
+        "nautiloop_api_key={}; HttpOnly; SameSite=Strict; Path=/; Max-Age=604800{}",
+        form.api_key, secure_flag
+    );
+    let engineer_cookie = format!(
+        "nautiloop_engineer={}; HttpOnly; SameSite=Strict; Path=/; Max-Age=604800{}",
+        form.engineer_name, secure_flag
+    );
+
+    let mut response = Redirect::to("/dashboard").into_response();
+    let headers = response.headers_mut();
+    headers.append("set-cookie", key_cookie.parse().unwrap());
+    headers.append("set-cookie", engineer_cookie.parse().unwrap());
+    response
+}
+
+// ── Logout ──
+
+pub async fn logout() -> Response {
+    let mut response = Redirect::to("/dashboard/login").into_response();
+    let headers = response.headers_mut();
+    headers.append(
+        "set-cookie",
+        "nautiloop_api_key=; HttpOnly; SameSite=Strict; Path=/; Max-Age=0"
+            .parse()
+            .unwrap(),
+    );
+    headers.append(
+        "set-cookie",
+        "nautiloop_engineer=; HttpOnly; SameSite=Strict; Path=/; Max-Age=0"
+            .parse()
+            .unwrap(),
+    );
+    response
+}
+
+// ── Card Grid (main dashboard) ──
+
+pub async fn dashboard_page(
+    State(state): State<DashboardState>,
+    headers: HeaderMap,
+) -> Result<Html<String>, NautiloopError> {
+    let viewer = extract_cookie_value(&headers, "nautiloop_engineer")
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let data = aggregate::build_dashboard_state(
+        state.app.store.as_ref(),
+        &state.app.config,
+        false, // default: mine
+        false, // only recent terminal
+        &viewer,
+        &state.fleet_cache,
+    )
+    .await?;
+
+    Ok(Html(templates::render_dashboard(&data, &viewer)))
+}
+
+// ── Dashboard State JSON ──
+
+#[derive(Deserialize)]
+pub struct StateQuery {
+    pub team: Option<bool>,
+    pub include_terminal: Option<String>,
+}
+
+pub async fn dashboard_state(
+    State(state): State<DashboardState>,
+    headers: HeaderMap,
+    Query(query): Query<StateQuery>,
+) -> Result<Json<aggregate::DashboardStateResponse>, NautiloopError> {
+    let viewer = extract_cookie_value(&headers, "nautiloop_engineer")
+        .unwrap_or_else(|| "unknown".to_string());
+    let team = query.team.unwrap_or(false);
+    let include_all = query.include_terminal.as_deref() == Some("all");
+
+    let data = aggregate::build_dashboard_state(
+        state.app.store.as_ref(),
+        &state.app.config,
+        team,
+        include_all,
+        &viewer,
+        &state.fleet_cache,
+    )
+    .await?;
+
+    Ok(Json(data))
+}
+
+// ── Loop Detail ──
+
+pub async fn loop_detail_page(
+    State(state): State<DashboardState>,
+    headers: HeaderMap,
+    Path(id): Path<Uuid>,
+) -> Result<Html<String>, NautiloopError> {
+    let viewer = extract_cookie_value(&headers, "nautiloop_engineer")
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let record = state
+        .app
+        .store
+        .get_loop(id)
+        .await?
+        .ok_or(NautiloopError::LoopNotFound { id })?;
+
+    let rounds = state.app.store.get_rounds(id).await?;
+
+    // Get last 200 log lines for the log pane
+    let logs = state.app.store.get_logs(id, None, None).await?;
+    let log_lines: Vec<String> = logs
+        .iter()
+        .rev()
+        .take(200)
+        .rev()
+        .map(|l| l.line.clone())
+        .collect();
+
+    Ok(Html(templates::render_loop_detail(
+        &record,
+        &rounds,
+        &log_lines,
+        &viewer,
+        &state.app.config,
+    )))
+}
+
+// ── Dashboard Stream (SSE for active, JSON for terminal) ──
+
+pub async fn dashboard_stream(
+    State(state): State<DashboardState>,
+    Path(id): Path<Uuid>,
+) -> Result<Response, NautiloopError> {
+    let record = state
+        .app
+        .store
+        .get_loop(id)
+        .await?
+        .ok_or(NautiloopError::LoopNotFound { id })?;
+
+    if record.state.is_terminal() {
+        // Return last 200 lines as JSON
+        let logs = state.app.store.get_logs(id, None, None).await?;
+        let lines: Vec<String> = logs
+            .iter()
+            .rev()
+            .take(200)
+            .rev()
+            .map(|l| l.line.clone())
+            .collect();
+        Ok(Json(lines).into_response())
+    } else {
+        // SSE stream for active loops
+        Ok(
+            crate::api::sse::stream_logs(state.app.store.clone(), id, None, None)
+                .await
+                .into_response(),
+        )
+    }
+}
+
+// ── Feed (FR-12) ──
+
+#[derive(Deserialize)]
+pub struct FeedQuery {
+    pub cursor: Option<String>,
+    pub limit: Option<usize>,
+    pub filter: Option<String>,
+}
+
+pub async fn feed_page(
+    State(state): State<DashboardState>,
+    headers: HeaderMap,
+    Query(query): Query<FeedQuery>,
+) -> Result<Response, NautiloopError> {
+    let accepts_json = wants_json(&headers);
+    let cursor = query
+        .cursor
+        .as_deref()
+        .and_then(|c| c.parse::<DateTime<Utc>>().ok());
+    let limit = query.limit.unwrap_or(50).min(100);
+
+    let data = aggregate::build_feed_response(
+        state.app.store.as_ref(),
+        &state.app.config,
+        cursor,
+        limit,
+        query.filter.as_deref(),
+    )
+    .await?;
+
+    if accepts_json {
+        Ok(Json(data).into_response())
+    } else {
+        let viewer = extract_cookie_value(&headers, "nautiloop_engineer")
+            .unwrap_or_else(|| "unknown".to_string());
+        Ok(Html(templates::render_feed(&data, &viewer)).into_response())
+    }
+}
+
+// ── Specs (FR-13) ──
+
+#[derive(Deserialize)]
+pub struct SpecsQuery {
+    pub path: Option<String>,
+    pub limit: Option<usize>,
+}
+
+pub async fn specs_page(
+    State(state): State<DashboardState>,
+    headers: HeaderMap,
+    Query(query): Query<SpecsQuery>,
+) -> Result<Response, NautiloopError> {
+    let accepts_json = wants_json(&headers);
+    let spec_path = query.path.as_deref().unwrap_or("");
+
+    if spec_path.is_empty() {
+        if accepts_json {
+            return Err(NautiloopError::BadRequest(
+                "path query parameter required".to_string(),
+            ));
+        }
+        let viewer = extract_cookie_value(&headers, "nautiloop_engineer")
+            .unwrap_or_else(|| "unknown".to_string());
+        return Ok(Html(templates::render_specs_empty(&viewer)).into_response());
+    }
+
+    let data = aggregate::build_specs_response(
+        state.app.store.as_ref(),
+        &state.app.config,
+        spec_path,
+        query.limit.unwrap_or(50),
+    )
+    .await?;
+
+    if accepts_json {
+        Ok(Json(data).into_response())
+    } else {
+        let viewer = extract_cookie_value(&headers, "nautiloop_engineer")
+            .unwrap_or_else(|| "unknown".to_string());
+        Ok(Html(templates::render_specs(&data, &viewer)).into_response())
+    }
+}
+
+// ── Stats (FR-14) ──
+
+#[derive(Deserialize)]
+pub struct StatsQuery {
+    pub window: Option<String>,
+}
+
+pub async fn stats_page(
+    State(state): State<DashboardState>,
+    headers: HeaderMap,
+    Query(query): Query<StatsQuery>,
+) -> Result<Response, NautiloopError> {
+    let accepts_json = wants_json(&headers);
+    let window = query.window.as_deref().unwrap_or("7d");
+    let data = get_or_compute_stats(&state, window).await?;
+
+    if accepts_json {
+        Ok(Json(data).into_response())
+    } else {
+        let viewer = extract_cookie_value(&headers, "nautiloop_engineer")
+            .unwrap_or_else(|| "unknown".to_string());
+        Ok(Html(templates::render_stats(&data, &viewer)).into_response())
+    }
+}
+
+async fn get_or_compute_stats(
+    state: &DashboardState,
+    window: &str,
+) -> Result<aggregate::StatsResponse, NautiloopError> {
+    // Check cache
+    if let Some(cached) = state.stats_cache.get(window).await {
+        return Ok(cached);
+    }
+
+    let data = aggregate::build_stats_response(
+        state.app.store.as_ref(),
+        &state.app.config,
+        window,
+    )
+    .await?;
+
+    state
+        .stats_cache
+        .set(window.to_string(), &data)
+        .await;
+
+    Ok(data)
+}
+
+// ── Static Assets ──
+
+pub async fn static_css() -> impl IntoResponse {
+    (
+        StatusCode::OK,
+        [
+            ("content-type", "text/css; charset=utf-8"),
+            ("cache-control", "public, max-age=3600"),
+        ],
+        include_str!("../../../assets/dashboard.css"),
+    )
+}
+
+pub async fn static_js() -> impl IntoResponse {
+    (
+        StatusCode::OK,
+        [
+            ("content-type", "application/javascript; charset=utf-8"),
+            ("cache-control", "public, max-age=3600"),
+        ],
+        include_str!("../../../assets/dashboard.js"),
+    )
+}
+
+// ── Helpers ──
+
+fn wants_json(headers: &HeaderMap) -> bool {
+    headers
+        .get("accept")
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| v.contains("application/json"))
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::dashboard;
+    use crate::config::NautiloopConfig;
+    use crate::git::mock::MockGitOperations;
+    use crate::state::memory::MemoryStateStore;
+    use crate::state::StateStore;
+    use crate::types::{LoopKind, LoopRecord, LoopState, RoundRecord, SubState};
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    fn make_test_loop(engineer: &str, state: LoopState) -> LoopRecord {
+        LoopRecord {
+            id: Uuid::new_v4(),
+            engineer: engineer.to_string(),
+            spec_path: "specs/test-feature.md".to_string(),
+            spec_content_hash: "abcd1234".to_string(),
+            branch: format!("agent/{}/test-feature-abcd1234", engineer),
+            kind: LoopKind::Implement,
+            state,
+            sub_state: if state.is_active_stage() {
+                Some(SubState::Running)
+            } else {
+                None
+            },
+            round: 3,
+            max_rounds: 15,
+            harden: false,
+            harden_only: false,
+            auto_approve: false,
+            cancel_requested: false,
+            approve_requested: false,
+            resume_requested: false,
+            paused_from_state: None,
+            reauth_from_state: None,
+            failed_from_state: None,
+            failure_reason: None,
+            current_sha: Some("abc123".to_string()),
+            opencode_session_id: None,
+            claude_session_id: None,
+            active_job_name: None,
+            retry_count: 0,
+            ship_mode: false,
+            model_implementor: Some("claude-sonnet-4-20250514".to_string()),
+            model_reviewer: Some("claude-opus-4-20250514".to_string()),
+            merge_sha: None,
+            merged_at: None,
+            hardened_spec_path: None,
+            spec_pr_url: None,
+            resolved_default_branch: Some("main".to_string()),
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
+    fn make_test_round(loop_id: Uuid, round: i32, stage: &str) -> RoundRecord {
+        RoundRecord {
+            id: Uuid::new_v4(),
+            loop_id,
+            round,
+            stage: stage.to_string(),
+            input: None,
+            output: Some(serde_json::json!({
+                "new_sha": "abc123",
+                "token_usage": {"input": 10000, "output": 2000},
+                "exit_code": 0,
+                "session_id": "test-session"
+            })),
+            started_at: Some(chrono::Utc::now()),
+            completed_at: Some(chrono::Utc::now()),
+            duration_secs: Some(120),
+            job_name: None,
+        }
+    }
+
+    fn build_test_app() -> (axum::Router, Arc<MemoryStateStore>) {
+        let store = Arc::new(MemoryStateStore::new());
+        let git = Arc::new(MockGitOperations::new());
+        let app_state = crate::api::AppState {
+            store: store.clone(),
+            git,
+            config: Arc::new(NautiloopConfig::default()),
+            kube_client: None,
+            pool: None,
+        };
+        let router = dashboard::build_dashboard_router(app_state.clone())
+            .with_state(app_state);
+        (router, store)
+    }
+
+    #[tokio::test]
+    async fn test_login_page_renders() {
+        let (app, _) = build_test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/dashboard/login")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 65536)
+            .await
+            .unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+        assert!(html.contains("nautiloop"));
+        assert!(html.contains("api_key"));
+        assert!(html.contains("engineer_name"));
+    }
+
+    #[tokio::test]
+    async fn test_login_submit_invalid_key() {
+        unsafe { std::env::set_var("NAUTILOOP_API_KEY", "test-secret-key") };
+        let (app, _) = build_test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/dashboard/login")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from("api_key=wrong-key&engineer_name=alice"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        // Should re-render login with error
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 65536)
+            .await
+            .unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+        assert!(html.contains("Invalid API key"));
+    }
+
+    #[tokio::test]
+    async fn test_login_submit_valid_key() {
+        unsafe { std::env::set_var("NAUTILOOP_API_KEY", "test-secret-key") };
+        let (app, _) = build_test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/dashboard/login")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from("api_key=test-secret-key&engineer_name=alice"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        // Should redirect to /dashboard
+        assert_eq!(response.status(), StatusCode::SEE_OTHER);
+        let location = response
+            .headers()
+            .get("location")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert_eq!(location, "/dashboard");
+        // Should set cookies
+        let cookies: Vec<&str> = response
+            .headers()
+            .get_all("set-cookie")
+            .iter()
+            .map(|v| v.to_str().unwrap())
+            .collect();
+        assert!(cookies.iter().any(|c| c.starts_with("nautiloop_api_key=")));
+        assert!(cookies.iter().any(|c| c.starts_with("nautiloop_engineer=")));
+    }
+
+    #[tokio::test]
+    async fn test_dashboard_redirects_without_auth() {
+        unsafe { std::env::set_var("NAUTILOOP_API_KEY", "test-secret-key") };
+        let (app, _) = build_test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/dashboard")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        // Should redirect to login
+        assert_eq!(response.status(), StatusCode::SEE_OTHER);
+    }
+
+    #[tokio::test]
+    async fn test_dashboard_renders_with_cookie() {
+        unsafe { std::env::set_var("NAUTILOOP_API_KEY", "test-secret-key") };
+        let (app, store) = build_test_app();
+
+        // Add a test loop
+        let loop_record = make_test_loop("alice", LoopState::Implementing);
+        store.create_loop(&loop_record).await.unwrap();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/dashboard")
+                    .header("cookie", "nautiloop_api_key=test-secret-key; nautiloop_engineer=alice")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 131072)
+            .await
+            .unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+        assert!(html.contains("nautiloop"));
+        assert!(html.contains("card-grid"));
+    }
+
+    #[tokio::test]
+    async fn test_dashboard_state_json() {
+        unsafe { std::env::set_var("NAUTILOOP_API_KEY", "test-secret-key") };
+        let (app, store) = build_test_app();
+
+        let loop_record = make_test_loop("alice", LoopState::Implementing);
+        let loop_id = loop_record.id;
+        store.create_loop(&loop_record).await.unwrap();
+        store
+            .create_round(&make_test_round(loop_id, 1, "implement"))
+            .await
+            .unwrap();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/dashboard/state?team=true&include_terminal=all")
+                    .header("cookie", "nautiloop_api_key=test-secret-key; nautiloop_engineer=alice")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 131072)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json["loops"].is_array());
+        assert_eq!(json["loops"].as_array().unwrap().len(), 1);
+        assert_eq!(json["viewer"], "alice");
+        assert!(json["aggregates"]["total_loops"].as_u64().unwrap() >= 1);
+    }
+
+    #[tokio::test]
+    async fn test_loop_detail_page() {
+        unsafe { std::env::set_var("NAUTILOOP_API_KEY", "test-secret-key") };
+        let (app, store) = build_test_app();
+
+        let loop_record = make_test_loop("alice", LoopState::Implementing);
+        let loop_id = loop_record.id;
+        store.create_loop(&loop_record).await.unwrap();
+        store
+            .create_round(&make_test_round(loop_id, 1, "implement"))
+            .await
+            .unwrap();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri(&format!("/dashboard/loops/{}", loop_id))
+                    .header("cookie", "nautiloop_api_key=test-secret-key; nautiloop_engineer=alice")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 131072)
+            .await
+            .unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+        assert!(html.contains("test-feature.md"));
+        assert!(html.contains("Rounds"));
+    }
+
+    #[tokio::test]
+    async fn test_feed_page() {
+        unsafe { std::env::set_var("NAUTILOOP_API_KEY", "test-secret-key") };
+        let (app, store) = build_test_app();
+
+        let mut loop_record = make_test_loop("alice", LoopState::Converged);
+        loop_record.state = LoopState::Converged;
+        store.create_loop(&loop_record).await.unwrap();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/dashboard/feed")
+                    .header("cookie", "nautiloop_api_key=test-secret-key; nautiloop_engineer=alice")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_feed_json() {
+        unsafe { std::env::set_var("NAUTILOOP_API_KEY", "test-secret-key") };
+        let (app, store) = build_test_app();
+
+        let mut loop_record = make_test_loop("alice", LoopState::Converged);
+        loop_record.state = LoopState::Converged;
+        store.create_loop(&loop_record).await.unwrap();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/dashboard/feed")
+                    .header("cookie", "nautiloop_api_key=test-secret-key; nautiloop_engineer=alice")
+                    .header("accept", "application/json")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 131072)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json["events"].is_array());
+    }
+
+    #[tokio::test]
+    async fn test_specs_page_no_path() {
+        unsafe { std::env::set_var("NAUTILOOP_API_KEY", "test-secret-key") };
+        let (app, _) = build_test_app();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/dashboard/specs")
+                    .header("cookie", "nautiloop_api_key=test-secret-key; nautiloop_engineer=alice")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 65536)
+            .await
+            .unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+        assert!(html.contains("No spec path"));
+    }
+
+    #[tokio::test]
+    async fn test_stats_page() {
+        unsafe { std::env::set_var("NAUTILOOP_API_KEY", "test-secret-key") };
+        let (app, _) = build_test_app();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/dashboard/stats?window=7d")
+                    .header("cookie", "nautiloop_api_key=test-secret-key; nautiloop_engineer=alice")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_stats_json() {
+        unsafe { std::env::set_var("NAUTILOOP_API_KEY", "test-secret-key") };
+        let (app, _) = build_test_app();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/dashboard/stats?window=7d")
+                    .header("cookie", "nautiloop_api_key=test-secret-key; nautiloop_engineer=alice")
+                    .header("accept", "application/json")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 131072)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json["headline"].is_object());
+        assert_eq!(json["window"], "7d");
+    }
+
+    #[tokio::test]
+    async fn test_static_css() {
+        let (app, _) = build_test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/dashboard/static/dashboard.css")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let ct = response
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(ct.starts_with("text/css"));
+    }
+
+    #[tokio::test]
+    async fn test_static_js() {
+        let (app, _) = build_test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/dashboard/static/dashboard.js")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let ct = response
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(ct.starts_with("application/javascript"));
+    }
+
+    #[tokio::test]
+    async fn test_logout() {
+        let (app, _) = build_test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/dashboard/logout")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::SEE_OTHER);
+        let cookies: Vec<&str> = response
+            .headers()
+            .get_all("set-cookie")
+            .iter()
+            .map(|v| v.to_str().unwrap())
+            .collect();
+        assert!(cookies.iter().any(|c| c.contains("Max-Age=0")));
+    }
+
+    #[tokio::test]
+    async fn test_dashboard_state_bearer_auth() {
+        unsafe { std::env::set_var("NAUTILOOP_API_KEY", "test-secret-key") };
+        let (app, _) = build_test_app();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/dashboard/state?team=true")
+                    .header("authorization", "Bearer test-secret-key")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[test]
+    fn test_wants_json() {
+        let mut headers = HeaderMap::new();
+        headers.insert("accept", "application/json".parse().unwrap());
+        assert!(wants_json(&headers));
+
+        let headers = HeaderMap::new();
+        assert!(!wants_json(&headers));
+
+        let mut headers = HeaderMap::new();
+        headers.insert("accept", "text/html".parse().unwrap());
+        assert!(!wants_json(&headers));
+    }
+}

--- a/control-plane/src/api/dashboard/handlers.rs
+++ b/control-plane/src/api/dashboard/handlers.rs
@@ -357,6 +357,14 @@ pub async fn dashboard_stream(
 pub struct FeedQuery {
     pub cursor: Option<String>,
     pub limit: Option<usize>,
+    /// State filter: "converged" or "failed". Separate from engineer filter
+    /// to avoid ambiguity if an engineer is named "converged" or "failed".
+    pub state_filter: Option<String>,
+    /// Engineer name filter.
+    pub engineer_filter: Option<String>,
+    /// Legacy combined filter param — maps to state_filter if "converged"/"failed",
+    /// otherwise maps to engineer_filter. Kept for backwards compatibility with
+    /// bookmarked URLs and localStorage-persisted filters.
     pub filter: Option<String>,
 }
 
@@ -381,21 +389,63 @@ pub async fn feed_page(
     });
     let limit = query.limit.unwrap_or(50).min(100);
 
+    // Resolve filter parameters: prefer explicit state_filter/engineer_filter,
+    // fall back to legacy `filter` param for backwards compat.
+    let (state_filter, engineer_filter) = resolve_feed_filters(
+        query.state_filter.as_deref(),
+        query.engineer_filter.as_deref(),
+        query.filter.as_deref(),
+    );
+
     let data = aggregate::build_feed_response(
         state.app.store.as_ref(),
         &state.app.config,
         cursor,
         limit,
-        query.filter.as_deref(),
+        state_filter.as_deref(),
+        engineer_filter.as_deref(),
     )
     .await?;
+
+    // Build a canonical filter string for template rendering (active chip highlighting).
+    let canonical_filter = canonical_feed_filter(state_filter.as_deref(), engineer_filter.as_deref());
 
     if accepts_json {
         Ok(Json(data).into_response())
     } else {
         let viewer = extract_cookie_value(&headers, "nautiloop_engineer")
             .unwrap_or_else(|| "unknown".to_string());
-        Ok(Html(templates::render_feed(&data, &viewer, query.filter.as_deref())).into_response())
+        Ok(Html(templates::render_feed(&data, &viewer, canonical_filter.as_deref())).into_response())
+    }
+}
+
+/// Resolve feed filter query params into separate state and engineer filters.
+/// Prefers explicit `state_filter`/`engineer_filter` over legacy `filter`.
+fn resolve_feed_filters(
+    state_filter: Option<&str>,
+    engineer_filter: Option<&str>,
+    legacy_filter: Option<&str>,
+) -> (Option<String>, Option<String>) {
+    if state_filter.is_some() || engineer_filter.is_some() {
+        return (
+            state_filter.map(|s| s.to_string()),
+            engineer_filter.map(|s| s.to_string()),
+        );
+    }
+    // Legacy: "converged"/"failed" → state filter; anything else → engineer filter.
+    match legacy_filter {
+        Some("converged") | Some("failed") => (legacy_filter.map(|s| s.to_string()), None),
+        Some(eng) if !eng.is_empty() => (None, Some(eng.to_string())),
+        _ => (None, None),
+    }
+}
+
+/// Build a canonical filter string for template rendering (chip highlighting + load-more data attr).
+fn canonical_feed_filter(state_filter: Option<&str>, engineer_filter: Option<&str>) -> Option<String> {
+    if let Some(sf) = state_filter {
+        Some(sf.to_string())
+    } else {
+        engineer_filter.map(|ef| ef.to_string())
     }
 }
 
@@ -1034,5 +1084,151 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("accept", "text/html".parse().unwrap());
         assert!(!wants_json(&headers));
+    }
+
+    #[tokio::test]
+    async fn test_stream_terminal_loop_returns_json() {
+        let _guard = set_test_api_key("test-secret-key");
+        let (app, store) = build_test_app();
+
+        // Create a terminal loop with some logs
+        let mut loop_rec = make_test_loop("alice", LoopState::Converged);
+        let loop_id = loop_rec.id;
+        loop_rec.state = LoopState::Converged;
+        loop_rec.sub_state = None;
+        store.create_loop(&loop_rec).await.unwrap();
+
+        // Add some log lines
+        for i in 0..5 {
+            let log = crate::types::LogEvent {
+                id: Uuid::new_v4(),
+                loop_id,
+                round: 1,
+                stage: "implement".to_string(),
+                timestamp: chrono::Utc::now() + chrono::Duration::milliseconds(i),
+                line: format!("log line {}", i),
+            };
+            store.append_log(&log).await.unwrap();
+        }
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri(&format!("/dashboard/stream/{}", loop_id))
+                    .header("cookie", "nautiloop_api_key=test-secret-key")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let ct = response
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(ct.contains("application/json"), "terminal loops return JSON, got: {}", ct);
+
+        let body = axum::body::to_bytes(response.into_body(), 65536)
+            .await
+            .unwrap();
+        let lines: Vec<String> = serde_json::from_slice(&body).unwrap();
+        assert_eq!(lines.len(), 5);
+        assert_eq!(lines[0], "log line 0");
+        assert_eq!(lines[4], "log line 4");
+    }
+
+    #[tokio::test]
+    async fn test_stream_active_loop_returns_sse() {
+        let _guard = set_test_api_key("test-secret-key");
+        let (app, store) = build_test_app();
+
+        // Create an active loop with some logs
+        let loop_rec = make_test_loop("alice", LoopState::Implementing);
+        let loop_id = loop_rec.id;
+        store.create_loop(&loop_rec).await.unwrap();
+
+        for i in 0..3 {
+            let log = crate::types::LogEvent {
+                id: Uuid::new_v4(),
+                loop_id,
+                round: 1,
+                stage: "implement".to_string(),
+                timestamp: chrono::Utc::now() + chrono::Duration::milliseconds(i),
+                line: format!("active line {}", i),
+            };
+            store.append_log(&log).await.unwrap();
+        }
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri(&format!("/dashboard/stream/{}", loop_id))
+                    .header("cookie", "nautiloop_api_key=test-secret-key")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let ct = response
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(
+            ct.contains("text/event-stream"),
+            "active loops return SSE, got: {}",
+            ct
+        );
+    }
+
+    #[tokio::test]
+    async fn test_stream_terminal_loop_caps_at_200_lines() {
+        let _guard = set_test_api_key("test-secret-key");
+        let (app, store) = build_test_app();
+
+        let mut loop_rec = make_test_loop("alice", LoopState::Failed);
+        loop_rec.sub_state = None;
+        let loop_id = loop_rec.id;
+        store.create_loop(&loop_rec).await.unwrap();
+
+        // Add 250 log lines
+        for i in 0..250 {
+            let log = crate::types::LogEvent {
+                id: Uuid::new_v4(),
+                loop_id,
+                round: 1,
+                stage: "implement".to_string(),
+                timestamp: chrono::Utc::now() + chrono::Duration::milliseconds(i),
+                line: format!("line {}", i),
+            };
+            store.append_log(&log).await.unwrap();
+        }
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri(&format!("/dashboard/stream/{}", loop_id))
+                    .header("cookie", "nautiloop_api_key=test-secret-key")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 65536)
+            .await
+            .unwrap();
+        let lines: Vec<String> = serde_json::from_slice(&body).unwrap();
+        // Should cap at 200 lines, showing the last 200
+        assert_eq!(lines.len(), 200);
+        assert_eq!(lines[0], "line 50");
+        assert_eq!(lines[199], "line 249");
     }
 }

--- a/control-plane/src/api/dashboard/handlers.rs
+++ b/control-plane/src/api/dashboard/handlers.rs
@@ -237,6 +237,10 @@ pub async fn dashboard_stream(
         Ok(Json(lines).into_response())
     } else {
         // SSE stream for active loops: send last 200 lines first, then tail new lines.
+        // Known limitation: there is a small race window between the get_recent_logs call
+        // and the SSE tail starting — logs arriving in that gap may be missed. This is
+        // acceptable for a dashboard log tail (not an audit log). The dedup set is bounded
+        // by the initial 200 logs so it's not a memory concern.
         // Get recent logs to determine the SSE start offset (uses LIMIT query, not full load).
         let recent_logs = state.app.store.get_recent_logs(id, 200).await?;
 

--- a/control-plane/src/api/dashboard/handlers.rs
+++ b/control-plane/src/api/dashboard/handlers.rs
@@ -50,17 +50,31 @@ pub async fn login_submit(
             .into_response();
     }
 
-    if !constant_time_eq(form.api_key.as_bytes(), expected_key.as_bytes()) {
+    if !crate::util::constant_time_eq(form.api_key.as_bytes(), expected_key.as_bytes()) {
         return Html(templates::render_login(Some("Invalid API key")))
             .into_response();
     }
 
-    // Determine if localhost (omit Secure flag)
+    // Validate engineer name: only allow alphanumeric, hyphens, underscores, dots
+    // to prevent cookie header injection via semicolons or CR/LF
+    if !form
+        .engineer_name
+        .chars()
+        .all(|c| c.is_alphanumeric() || c == '-' || c == '_' || c == '.')
+    {
+        return Html(templates::render_login(Some(
+            "Engineer name may only contain letters, numbers, hyphens, underscores, and dots",
+        )))
+        .into_response();
+    }
+
+    // Determine if localhost (omit Secure flag for local dev)
+    // Default to secure (Secure flag ON) — only omit when bind address is explicitly localhost
     let bind_addr = std::env::var("NAUTILOOP_BIND_ADDR").unwrap_or_default();
-    let is_localhost = bind_addr == "127.0.0.1"
-        || bind_addr == "[::1]"
-        || bind_addr == "localhost"
-        || bind_addr.is_empty(); // default for dev
+    let is_localhost = !bind_addr.is_empty()
+        && (bind_addr == "127.0.0.1"
+            || bind_addr == "[::1]"
+            || bind_addr == "localhost");
 
     let secure_flag = if is_localhost { "" } else { "; Secure" };
 
@@ -260,7 +274,7 @@ pub async fn feed_page(
     } else {
         let viewer = extract_cookie_value(&headers, "nautiloop_engineer")
             .unwrap_or_else(|| "unknown".to_string());
-        Ok(Html(templates::render_feed(&data, &viewer)).into_response())
+        Ok(Html(templates::render_feed(&data, &viewer, query.filter.as_deref())).into_response())
     }
 }
 
@@ -388,17 +402,6 @@ fn wants_json(headers: &HeaderMap) -> bool {
         .get("accept")
         .and_then(|v| v.to_str().ok())
         .is_some_and(|v| v.contains("application/json"))
-}
-
-fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    let mut diff = 0u8;
-    for (x, y) in a.iter().zip(b.iter()) {
-        diff |= x ^ y;
-    }
-    diff == 0
 }
 
 #[cfg(test)]

--- a/control-plane/src/api/dashboard/mod.rs
+++ b/control-plane/src/api/dashboard/mod.rs
@@ -1,0 +1,48 @@
+pub mod aggregate;
+pub mod auth;
+pub mod handlers;
+pub mod templates;
+
+use std::sync::Arc;
+
+use axum::Router;
+use axum::middleware;
+use axum::routing::{get, post};
+
+use super::AppState;
+use handlers::DashboardState;
+
+/// Build the dashboard sub-router.
+/// Public (unauthenticated) routes: /login, /static/*
+/// All other /dashboard/* routes require cookie or Bearer auth.
+pub fn build_dashboard_router(app_state: AppState) -> Router<AppState> {
+    let dash_state = DashboardState {
+        app: app_state,
+        fleet_cache: Arc::new(aggregate::FleetSummaryCache::new()),
+        stats_cache: Arc::new(aggregate::StatsCache::new()),
+    };
+
+    // Public routes (no auth)
+    let public: Router<AppState> = Router::new()
+        .route("/dashboard/login", get(handlers::login_page).post(handlers::login_submit))
+        .route("/dashboard/logout", post(handlers::logout))
+        .route("/dashboard/static/dashboard.css", get(handlers::static_css))
+        .route("/dashboard/static/dashboard.js", get(handlers::static_js));
+
+    // Authed routes — HTML pages and JSON endpoints.
+    // The /dashboard/state, /dashboard/feed (JSON), /dashboard/specs (JSON),
+    // /dashboard/stats (JSON) endpoints are handled by dedicated handlers
+    // that always return JSON. The page variants are separate routes.
+    let authed: Router<AppState> = Router::new()
+        .route("/dashboard", get(handlers::dashboard_page))
+        .route("/dashboard/state", get(handlers::dashboard_state))
+        .route("/dashboard/loops/{id}", get(handlers::loop_detail_page))
+        .route("/dashboard/stream/{id}", get(handlers::dashboard_stream))
+        .route("/dashboard/feed", get(handlers::feed_page))
+        .route("/dashboard/specs", get(handlers::specs_page))
+        .route("/dashboard/stats", get(handlers::stats_page))
+        .layer(middleware::from_fn(auth::dashboard_auth_middleware))
+        .with_state(dash_state);
+
+    public.merge(authed)
+}

--- a/control-plane/src/api/dashboard/mod.rs
+++ b/control-plane/src/api/dashboard/mod.rs
@@ -30,9 +30,17 @@ pub fn build_dashboard_router(app_state: AppState) -> Router<AppState> {
         .route("/dashboard/static/dashboard.js", get(handlers::static_js));
 
     // Authed routes — HTML pages and JSON endpoints.
-    // Handlers extract State<DashboardState>; .with_state(dash_state) provides
-    // the DashboardState and converts Router<DashboardState> → Router<AppState>
-    // since the parent build_router() will call .with_state(state) at the top level.
+    //
+    // Type conversion chain:
+    //   Router<DashboardState>  (handlers extract State<DashboardState>)
+    //     → .with_state(dash_state) → Router<()>
+    //     → merged into public Router<AppState> which becomes Router<()> when
+    //       the parent build_router() calls .with_state(app_state).
+    //
+    // Note: public routes above are Router<AppState> but their handlers don't
+    // extract State, so they work after the parent .with_state() call. If a
+    // future public handler needs AppState, it must be given its own
+    // .with_state(app_state.clone()) to avoid confusing type errors.
     let authed = Router::new()
         .route("/dashboard", get(handlers::dashboard_page))
         .route("/dashboard/state", get(handlers::dashboard_state))

--- a/control-plane/src/api/dashboard/mod.rs
+++ b/control-plane/src/api/dashboard/mod.rs
@@ -30,9 +30,9 @@ pub fn build_dashboard_router(app_state: AppState) -> Router<AppState> {
         .route("/dashboard/static/dashboard.js", get(handlers::static_js));
 
     // Authed routes — HTML pages and JSON endpoints.
-    // The /dashboard/state, /dashboard/feed (JSON), /dashboard/specs (JSON),
-    // /dashboard/stats (JSON) endpoints are handled by dedicated handlers
-    // that always return JSON. The page variants are separate routes.
+    // Handlers extract State<DashboardState>; .with_state(dash_state) provides
+    // the DashboardState and converts Router<DashboardState> → Router<AppState>
+    // since the parent build_router() will call .with_state(state) at the top level.
     let authed: Router<AppState> = Router::new()
         .route("/dashboard", get(handlers::dashboard_page))
         .route("/dashboard/state", get(handlers::dashboard_state))

--- a/control-plane/src/api/dashboard/mod.rs
+++ b/control-plane/src/api/dashboard/mod.rs
@@ -33,7 +33,7 @@ pub fn build_dashboard_router(app_state: AppState) -> Router<AppState> {
     // Handlers extract State<DashboardState>; .with_state(dash_state) provides
     // the DashboardState and converts Router<DashboardState> → Router<AppState>
     // since the parent build_router() will call .with_state(state) at the top level.
-    let authed: Router<AppState> = Router::new()
+    let authed = Router::new()
         .route("/dashboard", get(handlers::dashboard_page))
         .route("/dashboard/state", get(handlers::dashboard_state))
         .route("/dashboard/loops/{id}", get(handlers::loop_detail_page))

--- a/control-plane/src/api/dashboard/templates.rs
+++ b/control-plane/src/api/dashboard/templates.rs
@@ -16,6 +16,7 @@ fn html_escape(s: &str) -> String {
         .replace('<', "&lt;")
         .replace('>', "&gt;")
         .replace('"', "&quot;")
+        .replace('\'', "&#39;")
 }
 
 fn layout(title: &str, viewer: &str, body_content: Markup, extra_attrs: &str) -> String {
@@ -716,7 +717,14 @@ pub fn render_feed(data: &FeedResponse, viewer: &str, current_filter: Option<&st
 
         div #feed-list class="feed-list" {
             @if data.events.is_empty() {
-                div class="empty-state" { "No terminal events yet." }
+                div class="empty-state" {
+                    @if current_filter.is_some() {
+                        "No events match this filter. "
+                        a href="/dashboard/feed" { "Clear filter" }
+                    } @else {
+                        "No terminal events yet."
+                    }
+                }
             }
             @for ev in &data.events {
                 (render_feed_item(ev))
@@ -929,20 +937,20 @@ pub fn render_stats(data: &StatsResponse, viewer: &str) -> String {
         div class="stats-section" {
             h3 id="time-series" { "Daily Activity" }
             @for day in &data.time_series {
-                @let max_val = day.started.max(1);
+                @let max_val = day.started.max(1) as f64;
                 div class="ts-row" {
                     span class="ts-label" { (day.date) }
                     div class="ts-bars" {
                         div class="ts-bar ts-bar-converged"
-                            style=(format!("width:{}%", day.converged * 100 / max_val))
+                            style=(format!("width:{:.1}%", day.converged as f64 * 100.0 / max_val))
                             title=(format!("{} converged", day.converged)) {}
                         div class="ts-bar ts-bar-failed"
-                            style=(format!("width:{}%", day.failed * 100 / max_val))
+                            style=(format!("width:{:.1}%", day.failed as f64 * 100.0 / max_val))
                             title=(format!("{} failed", day.failed)) {}
-                        @let other = day.started.saturating_sub(day.converged + day.failed);
+                        @let other = day.started.saturating_sub(day.converged.saturating_add(day.failed));
                         @if other > 0 {
                             div class="ts-bar ts-bar-started"
-                                style=(format!("width:{}%", other * 100 / max_val))
+                                style=(format!("width:{:.1}%", other as f64 * 100.0 / max_val))
                                 title=(format!("{} other", other)) {}
                         }
                     }

--- a/control-plane/src/api/dashboard/templates.rs
+++ b/control-plane/src/api/dashboard/templates.rs
@@ -734,7 +734,8 @@ pub fn render_feed(data: &FeedResponse, viewer: &str, current_filter: Option<&st
         @if data.has_more {
             div class="load-more" {
                 button #feed-load-more class="btn"
-                    data-cursor=(data.events.last().map(|e| format!("{}|{}", e.updated_at.to_rfc3339(), e.id)).unwrap_or_default()) {
+                    data-cursor=(data.events.last().map(|e| format!("{}|{}", e.updated_at.to_rfc3339(), e.id)).unwrap_or_default())
+                    data-filter=(current_filter.unwrap_or("")) {
                     "Load more"
                 }
             }

--- a/control-plane/src/api/dashboard/templates.rs
+++ b/control-plane/src/api/dashboard/templates.rs
@@ -19,6 +19,9 @@ fn html_escape(s: &str) -> String {
         .replace('\'', "&#39;")
 }
 
+/// Build the outer HTML shell. `extra_attrs` is injected raw into the `<body>` tag —
+/// callers MUST only pass trusted values (e.g., data attributes derived from UUIDs or
+/// booleans). Never pass user-controlled strings without escaping.
 fn layout(title: &str, viewer: &str, body_content: Markup, extra_attrs: &str) -> String {
     // Build the full HTML string manually since maud doesn't support dynamic attributes
     let inner = html! {

--- a/control-plane/src/api/dashboard/templates.rs
+++ b/control-plane/src/api/dashboard/templates.rs
@@ -59,7 +59,7 @@ fn nav_bar(active: &str, viewer: &str) -> Markup {
             div class="header-menu" {
                 button #header-menu-toggle class="header-menu-btn" { "\u{22EF}" }
                 div #header-menu-dropdown class="header-menu-dropdown" {
-                    button #kill-switch-btn data-action="cancel-all" data-active-ids="" style="display:none" {
+                    button #kill-switch-btn data-action="cancel-all" style="display:none" {
                         "Cancel all active loops"
                     }
                     form action="/dashboard/logout" method="post" style="margin:0" {
@@ -523,12 +523,14 @@ fn render_round_detail(r: &RoundRecord) -> Markup {
     };
 
     match r.stage.as_str() {
-        "implement" | "revise" => {
+        "implement" => {
             if let Ok(d) = serde_json::from_value::<ImplResultData>(output.clone()) {
                 return html! {
                     "SHA: " (d.new_sha) " | exit: " (d.exit_code)
                 };
             }
+        }
+        "revise" => {
             if let Ok(d) = serde_json::from_value::<ReviseResultData>(output.clone()) {
                 return html! {
                     "SHA: " (d.new_sha) " | spec: " (d.revised_spec_path) " | exit: " (d.exit_code)
@@ -643,14 +645,17 @@ fn render_token_breakdown(
 
 // ── Feed Page ──
 
-pub fn render_feed(data: &FeedResponse, viewer: &str) -> String {
+pub fn render_feed(data: &FeedResponse, viewer: &str, current_filter: Option<&str>) -> String {
     let body = html! {
         (nav_bar("feed", viewer))
 
         div class="filter-bar" {
-            button class="chip active" onclick="location.href='/dashboard/feed'" { "All events" }
-            button class="chip" onclick="location.href='/dashboard/feed?filter=converged'" { "Converged" }
-            button class="chip" onclick="location.href='/dashboard/feed?filter=failed'" { "Failed" }
+            button class=(if current_filter.is_none() { "chip active" } else { "chip" })
+                onclick="location.href='/dashboard/feed'" { "All events" }
+            button class=(if current_filter == Some("converged") { "chip active" } else { "chip" })
+                onclick="location.href='/dashboard/feed?filter=converged'" { "Converged" }
+            button class=(if current_filter == Some("failed") { "chip active" } else { "chip" })
+                onclick="location.href='/dashboard/feed?filter=failed'" { "Failed" }
         }
 
         div #feed-list class="feed-list" {

--- a/control-plane/src/api/dashboard/templates.rs
+++ b/control-plane/src/api/dashboard/templates.rs
@@ -62,6 +62,9 @@ fn nav_bar(active: &str, viewer: &str) -> Markup {
                     button #kill-switch-btn data-action="cancel-all" style="display:none" {
                         "Cancel all active loops"
                     }
+                    button #bell-toggle style="color:var(--text)" {
+                        "Bell: off"
+                    }
                     form action="/dashboard/logout" method="post" style="margin:0" {
                         button type="submit" style="color:var(--text)" { "Logout (" (viewer) ")" }
                     }
@@ -234,13 +237,20 @@ fn render_card(l: &DashboardLoop, viewer: &str) -> Markup {
 
 fn render_fleet_summary_inline(fs: &super::aggregate::FleetSummary) -> Markup {
     html! {
-        a href="/dashboard/stats" {
-            "This week \u{00b7} " (fs.total_loops) " loops"
-            @if let Some(cost) = fs.total_cost {
-                " \u{00b7} " (format!("${:.2}", cost))
+        "This week \u{00b7} "
+        a href="/dashboard/stats#total-loops" class="fleet-link" {
+            (fs.total_loops) " loops"
+        }
+        @if let Some(cost) = fs.total_cost {
+            " \u{00b7} "
+            a href="/dashboard/stats#total-cost" class="fleet-link" {
+                (format!("${:.2}", cost))
             }
-            @if let Some(rate) = fs.converge_rate {
-                " \u{00b7} " (format!("{}%", (rate * 100.0).round() as i32))
+        }
+        @if let Some(rate) = fs.converge_rate {
+            " \u{00b7} "
+            a href="/dashboard/stats#converge-rate" class="fleet-link" {
+                (format!("{}%", (rate * 100.0).round() as i32))
                 @if let Some(ref trends) = fs.trends {
                     @if let Some(delta) = trends.converge_rate_delta {
                         @let d = (delta * 100.0).round() as i32;
@@ -253,11 +263,17 @@ fn render_fleet_summary_inline(fs: &super::aggregate::FleetSummary) -> Markup {
                 }
                 " converged"
             }
-            @if let Some(avg) = fs.avg_rounds {
-                " \u{00b7} avg " (format!("{:.1}", avg)) " rounds"
+        }
+        @if let Some(avg) = fs.avg_rounds {
+            " \u{00b7} "
+            a href="/dashboard/stats#avg-rounds" class="fleet-link" {
+                "avg " (format!("{:.1}", avg)) " rounds"
             }
-            @if let Some(ref ts) = fs.top_spender {
-                " \u{00b7} top: " (ts.engineer) " (" (format!("${:.2}", ts.cost)) ")"
+        }
+        @if let Some(ref ts) = fs.top_spender {
+            " \u{00b7} "
+            a href="/dashboard/stats#per-engineer" class="fleet-link" {
+                "top: " (ts.engineer) " (" (format!("${:.2}", ts.cost)) ")"
             }
         }
     }
@@ -383,6 +399,8 @@ fn render_rounds_table(
                     th { "#" }
                     th { "Stage" }
                     th { "Verdict" }
+                    th { "Issues" }
+                    th { "Confidence" }
                     th { "Tokens" }
                     th { "Cost" }
                     th { "Duration" }
@@ -416,6 +434,7 @@ fn render_round_row(
         .map(|t| format!("{}+{}", fmt_tokens(t.input), fmt_tokens(t.output)))
         .unwrap_or_else(|| "\u{2014}".to_string());
     let has_judge = check_judge_icon(r);
+    let (issues_count, confidence) = extract_review_metrics(r);
 
     let detail_html = render_round_detail(r);
 
@@ -429,15 +448,48 @@ fn render_round_row(
                     " " span class="judge-icon" title="Judge decision" { "\u{2696}" }
                 }
             }
+            td { (issues_count) }
+            td { (confidence) }
             td { (token_str) }
             td { (fmt_cost(cost)) }
             td { (duration) }
         }
         tr class="round-detail" {
-            td colspan="6" {
+            td colspan="8" {
                 (detail_html)
             }
         }
+    }
+}
+
+/// Extract issues count and confidence score from review/audit round output.
+/// Returns ("—", "—") for non-review stages.
+fn extract_review_metrics(r: &RoundRecord) -> (String, String) {
+    let dash = "\u{2014}".to_string();
+    let Some(ref output) = r.output else {
+        return (dash.clone(), dash);
+    };
+    match r.stage.as_str() {
+        "review" | "audit" => {
+            if let Ok(rd) = serde_json::from_value::<ReviewResultData>(output.clone()) {
+                let issues = rd
+                    .verdict
+                    .get("issues")
+                    .and_then(|v| v.as_array())
+                    .map(|a| a.len().to_string())
+                    .unwrap_or_else(|| dash.clone());
+                let conf = rd
+                    .verdict
+                    .get("confidence")
+                    .and_then(|v| v.as_f64())
+                    .map(|c| format!("{:.0}%", c * 100.0))
+                    .unwrap_or_else(|| dash.clone());
+                (issues, conf)
+            } else {
+                (dash.clone(), dash)
+            }
+        }
+        _ => (dash.clone(), dash),
     }
 }
 
@@ -656,6 +708,10 @@ pub fn render_feed(data: &FeedResponse, viewer: &str, current_filter: Option<&st
                 onclick="location.href='/dashboard/feed?filter=converged'" { "Converged" }
             button class=(if current_filter == Some("failed") { "chip active" } else { "chip" })
                 onclick="location.href='/dashboard/feed?filter=failed'" { "Failed" }
+            @for eng in &data.engineers {
+                button class=(if current_filter == Some(eng.as_str()) { "chip active" } else { "chip" })
+                    onclick=(format!("location.href='/dashboard/feed?filter={}'", urlencoding::encode(eng))) { (eng) }
+            }
         }
 
         div #feed-list class="feed-list" {
@@ -670,7 +726,7 @@ pub fn render_feed(data: &FeedResponse, viewer: &str, current_filter: Option<&st
         @if data.has_more {
             div class="load-more" {
                 button #feed-load-more class="btn"
-                    data-cursor=(data.events.last().map(|e| e.updated_at.to_rfc3339()).unwrap_or_default()) {
+                    data-cursor=(data.events.last().map(|e| format!("{}|{}", e.updated_at.to_rfc3339(), e.id)).unwrap_or_default()) {
                     "Load more"
                 }
             }

--- a/control-plane/src/api/dashboard/templates.rs
+++ b/control-plane/src/api/dashboard/templates.rs
@@ -698,27 +698,33 @@ fn render_token_breakdown(
 
 // ── Feed Page ──
 
-pub fn render_feed(data: &FeedResponse, viewer: &str, current_filter: Option<&str>) -> String {
+pub fn render_feed(
+    data: &FeedResponse,
+    viewer: &str,
+    state_filter: Option<&str>,
+    engineer_filter: Option<&str>,
+) -> String {
+    let has_filter = state_filter.is_some() || engineer_filter.is_some();
     let body = html! {
         (nav_bar("feed", viewer))
 
         div class="filter-bar" {
-            button class=(if current_filter.is_none() { "chip active" } else { "chip" })
-                onclick="location.href='/dashboard/feed'" { "All events" }
-            button class=(if current_filter == Some("converged") { "chip active" } else { "chip" })
-                onclick="location.href='/dashboard/feed?filter=converged'" { "Converged" }
-            button class=(if current_filter == Some("failed") { "chip active" } else { "chip" })
-                onclick="location.href='/dashboard/feed?filter=failed'" { "Failed" }
+            button class=(if !has_filter { "chip active" } else { "chip" })
+                data-feed-filter="" data-feed-filter-type="clear" { "All events" }
+            button class=(if state_filter == Some("converged") { "chip active" } else { "chip" })
+                data-feed-filter="converged" data-feed-filter-type="state" { "Converged" }
+            button class=(if state_filter == Some("failed") { "chip active" } else { "chip" })
+                data-feed-filter="failed" data-feed-filter-type="state" { "Failed" }
             @for eng in &data.engineers {
-                button class=(if current_filter == Some(eng.as_str()) { "chip active" } else { "chip" })
-                    onclick=(format!("location.href='/dashboard/feed?filter={}'", urlencoding::encode(eng))) { (eng) }
+                button class=(if engineer_filter == Some(eng.as_str()) { "chip active" } else { "chip" })
+                    data-feed-filter=(eng) data-feed-filter-type="engineer" { (eng) }
             }
         }
 
         div #feed-list class="feed-list" {
             @if data.events.is_empty() {
                 div class="empty-state" {
-                    @if current_filter.is_some() {
+                    @if has_filter {
                         "No events match this filter. "
                         a href="/dashboard/feed" { "Clear filter" }
                     } @else {
@@ -735,7 +741,8 @@ pub fn render_feed(data: &FeedResponse, viewer: &str, current_filter: Option<&st
             div class="load-more" {
                 button #feed-load-more class="btn"
                     data-cursor=(data.events.last().map(|e| format!("{}|{}", e.updated_at.to_rfc3339(), e.id)).unwrap_or_default())
-                    data-filter=(current_filter.unwrap_or("")) {
+                    data-state-filter=(state_filter.unwrap_or(""))
+                    data-engineer-filter=(engineer_filter.unwrap_or("")) {
                     "Load more"
                 }
             }

--- a/control-plane/src/api/dashboard/templates.rs
+++ b/control-plane/src/api/dashboard/templates.rs
@@ -1,0 +1,978 @@
+use maud::{html, Markup};
+
+use super::aggregate::{
+    DashboardLoop, DashboardStateResponse, FeedResponse, SpecsResponse, StatsResponse,
+};
+use crate::config::NautiloopConfig;
+use crate::types::verdict::{
+    ImplResultData, ReviewResultData, ReviseResultData, TestResultData,
+};
+use crate::types::{LoopRecord, LoopState, RoundRecord};
+
+// ── Helpers ──
+
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+fn layout(title: &str, viewer: &str, body_content: Markup, extra_attrs: &str) -> String {
+    // Build the full HTML string manually since maud doesn't support dynamic attributes
+    let inner = html! {
+        (body_content)
+        // Confirm modal
+        div #confirm-modal class="modal-overlay" {
+            div class="modal" {
+                h3 #modal-title { "" }
+                p #modal-body { "" }
+                div class="modal-actions" {
+                    button #modal-cancel class="btn" { "Cancel" }
+                    button #modal-confirm class="btn btn-danger" { "Confirm" }
+                }
+            }
+        }
+        // Toast container
+        div #toast-container class="toast-container" {}
+        script src="/dashboard/static/dashboard.js" {}
+    };
+
+    format!(
+        r#"<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>{title}</title><link rel="stylesheet" href="/dashboard/static/dashboard.css"></head><body data-viewer="{viewer}"{extra_attrs}>{inner}</body></html>"#,
+        title = html_escape(title),
+        viewer = html_escape(viewer),
+        extra_attrs = extra_attrs,
+        inner = inner.into_string(),
+    )
+}
+
+fn nav_bar(active: &str, viewer: &str) -> Markup {
+    html! {
+        header class="dash-header" {
+            h1 { a href="/dashboard" style="color:inherit;text-decoration:none" { "nautiloop" } }
+            nav {
+                a href="/dashboard" class=(if active == "grid" { "active" } else { "" }) { "Loops" }
+                a href="/dashboard/feed" class=(if active == "feed" { "active" } else { "" }) { "Feed" }
+                a href="/dashboard/stats" class=(if active == "stats" { "active" } else { "" }) { "Stats" }
+            }
+            div class="header-menu" {
+                button #header-menu-toggle class="header-menu-btn" { "\u{22EF}" }
+                div #header-menu-dropdown class="header-menu-dropdown" {
+                    button #kill-switch-btn data-action="cancel-all" data-active-ids="" style="display:none" {
+                        "Cancel all active loops"
+                    }
+                    form action="/dashboard/logout" method="post" style="margin:0" {
+                        button type="submit" style="color:var(--text)" { "Logout (" (viewer) ")" }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn badge_class(state: &str) -> &'static str {
+    match state {
+        "CONVERGED" | "HARDENED" | "SHIPPED" => "badge badge-green",
+        "FAILED" | "CANCELLED" => "badge badge-red",
+        "AWAITING_APPROVAL" | "PAUSED" | "AWAITING_REAUTH" => "badge badge-amber",
+        "IMPLEMENTING" | "TESTING" | "REVIEWING" | "HARDENING" => "badge badge-blue",
+        _ => "badge badge-gray",
+    }
+}
+
+fn fmt_cost(cost: Option<f64>) -> String {
+    match cost {
+        Some(c) => format!("${:.2}", c),
+        None => "\u{2014}".to_string(),
+    }
+}
+
+fn fmt_tokens(n: u64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1000 {
+        format!("{}K", n / 1000)
+    } else {
+        n.to_string()
+    }
+}
+
+fn fmt_rate(rate: Option<f64>) -> String {
+    match rate {
+        Some(r) => format!("{}%", (r * 100.0).round() as i32),
+        None => "\u{2014}".to_string(),
+    }
+}
+
+fn spec_filename(path: &str) -> &str {
+    path.rsplit('/').next().unwrap_or(path)
+}
+
+fn short_id(id: &str) -> &str {
+    if id.len() >= 8 {
+        &id[..8]
+    } else {
+        id
+    }
+}
+
+// ── Login Page ──
+
+pub fn render_login(error: Option<&str>) -> String {
+    let body = html! {
+        div class="login-container" {
+            h1 { "nautiloop" }
+            @if let Some(err) = error {
+                div class="login-error" { (err) }
+            }
+            form method="post" action="/dashboard/login" {
+                label for="api_key" { "API Key" }
+                input type="password" name="api_key" id="api_key" required placeholder="Enter API key" autocomplete="current-password";
+                label for="engineer_name" { "Engineer Name" }
+                input type="text" name="engineer_name" id="engineer_name" required placeholder="e.g. alice" autocomplete="username";
+                button type="submit" class="btn btn-primary" { "Sign in" }
+            }
+        }
+    };
+    layout("nautiloop \u{00b7} login", "", body, "")
+}
+
+// ── Dashboard Card Grid ──
+
+pub fn render_dashboard(data: &DashboardStateResponse, viewer: &str) -> String {
+    let body = html! {
+        (nav_bar("grid", viewer))
+
+        // Fleet summary (FR-9)
+        div class="fleet-summary" {
+            span #fleet-summary-content {
+                @if let Some(ref fs) = data.fleet_summary {
+                    (render_fleet_summary_inline(fs))
+                }
+            }
+        }
+
+        // Filter chips (FR-3e) — state row
+        div class="filter-bar" {
+            button class="chip active" data-state-filter="active" {
+                "Active (" span #chip-active-count { (count_active(&data.aggregates.counts_by_state)) } ")"
+            }
+            button class="chip" data-state-filter="converged" {
+                "Converged (" span #chip-converged-count { (count_converged(&data.aggregates.counts_by_state)) } ")"
+            }
+            button class="chip" data-state-filter="failed" {
+                "Failed (" span #chip-failed-count { (count_failed(&data.aggregates.counts_by_state)) } ")"
+            }
+            button class="chip" data-state-filter="all" {
+                "All (" span #chip-all-count { (data.aggregates.total_loops) } ")"
+            }
+        }
+
+        // Engineer row
+        div class="filter-bar" #engineer-chips {
+            button class="chip active" data-eng-filter="mine" { "Mine" }
+            button class="chip" data-eng-filter="team" { "Team" }
+            @for eng in &data.engineers {
+                @if eng != viewer {
+                    button class="chip" data-eng-individual=(eng) {
+                        (eng)
+                    }
+                }
+            }
+        }
+
+        // Card grid
+        div #card-grid class="card-grid" {
+            @for loop_item in &data.loops {
+                @if !is_terminal_state(&loop_item.state) {
+                    (render_card(loop_item, viewer))
+                }
+            }
+            @if data.loops.iter().all(|l| is_terminal_state(&l.state)) {
+                div class="empty-state" { "No active loops." }
+            }
+        }
+    };
+    layout("nautiloop", viewer, body, "")
+}
+
+fn render_card(l: &DashboardLoop, viewer: &str) -> Markup {
+    let show_engineer = l.engineer != viewer;
+    html! {
+        a class="card" href=(format!("/dashboard/loops/{}", l.id)) data-id=(l.id) {
+            @if show_engineer {
+                span class="card-engineer" style=(format!("background:{}", engineer_color(&l.engineer))) {
+                    (engineer_initials(&l.engineer))
+                }
+            }
+            div class="card-header" {
+                span class=(format!("pulse {}", pulse_class(l.sub_state.as_deref()))) {}
+                span class=(badge_class(&l.state)) { (l.state) }
+                span style="font-size:0.75rem;color:var(--text-muted)" { (short_id(&l.id)) }
+                span style="margin-left:auto;font-size:0.75rem;color:var(--text-muted)" {
+                    (fmt_elapsed(l.created_at))
+                }
+            }
+            div class="card-title" { (spec_filename(&l.spec_path)) }
+            div class="card-subtitle" { (l.branch) }
+            div class="card-progress" {
+                @if is_terminal_state(&l.state) {
+                    "round " (l.round)
+                } @else {
+                    "round " (l.round) "/" (l.max_rounds) " \u{00b7} stage: " (l.current_stage.as_deref().unwrap_or("\u{2014}"))
+                }
+            }
+            div class="card-metrics" {
+                span { (fmt_tokens(l.total_tokens.input + l.total_tokens.output)) " tok" }
+                span { (fmt_cost(l.total_cost)) }
+                span { (l.last_verdict.as_deref().unwrap_or("\u{2014}")) }
+            }
+        }
+    }
+}
+
+fn render_fleet_summary_inline(fs: &super::aggregate::FleetSummary) -> Markup {
+    html! {
+        a href="/dashboard/stats" {
+            "This week \u{00b7} " (fs.total_loops) " loops"
+            @if let Some(cost) = fs.total_cost {
+                " \u{00b7} " (format!("${:.2}", cost))
+            }
+            @if let Some(rate) = fs.converge_rate {
+                " \u{00b7} " (format!("{}%", (rate * 100.0).round() as i32))
+                @if let Some(ref trends) = fs.trends {
+                    @if let Some(delta) = trends.converge_rate_delta {
+                        @let d = (delta * 100.0).round() as i32;
+                        @if d > 0 {
+                            " " span class="trend-up" { "\u{2191}" (d) "%" }
+                        } @else if d < 0 {
+                            " " span class="trend-down" { "\u{2193}" (d.unsigned_abs()) "%" }
+                        }
+                    }
+                }
+                " converged"
+            }
+            @if let Some(avg) = fs.avg_rounds {
+                " \u{00b7} avg " (format!("{:.1}", avg)) " rounds"
+            }
+            @if let Some(ref ts) = fs.top_spender {
+                " \u{00b7} top: " (ts.engineer) " (" (format!("${:.2}", ts.cost)) ")"
+            }
+        }
+    }
+}
+
+// ── Loop Detail Page ──
+
+pub fn render_loop_detail(
+    record: &LoopRecord,
+    rounds: &[RoundRecord],
+    log_lines: &[String],
+    viewer: &str,
+    config: &NautiloopConfig,
+) -> String {
+    let state_str = record.state.to_string();
+    let is_terminal = record.state.is_terminal();
+    let id_str = record.id.to_string();
+
+    let body = html! {
+        (nav_bar("grid", viewer))
+
+        // Hero header
+        div class="detail-hero" {
+            h2 {
+                span class=(badge_class(&state_str)) { (state_str) }
+                " "
+                a href=(format!("/dashboard/specs?path={}", urlencoding::encode(&record.spec_path))) {
+                    (spec_filename(&record.spec_path))
+                }
+            }
+            div class="meta" {
+                span { (fmt_elapsed(record.created_at)) }
+                span { "round " (record.round) "/" (record.max_rounds) }
+                span { (record.branch) }
+                @if let Some(ref pr_url) = record.spec_pr_url {
+                    a href=(pr_url) target="_blank" { "PR" }
+                }
+            }
+        }
+
+        // Action buttons (FR-4a)
+        div class="detail-actions" {
+            @if record.state == LoopState::AwaitingApproval {
+                button class="btn btn-primary" data-action="approve" data-loop-id=(id_str) { "Approve" }
+            }
+            @if !is_terminal {
+                button class="btn btn-danger" data-action="cancel" data-loop-id=(id_str) { "Cancel" }
+            }
+            @if matches!(record.state, LoopState::Paused | LoopState::AwaitingReauth) || (record.state == LoopState::Failed && record.failed_from_state.is_some()) {
+                button class="btn" data-action="resume" data-loop-id=(id_str) { "Resume" }
+            }
+            @if record.state == LoopState::Failed && record.failed_from_state.is_some() {
+                button class="btn" data-action="extend" data-loop-id=(id_str) { "Extend +10" }
+            }
+            @if let Some(ref pr_url) = record.spec_pr_url {
+                a class="btn" href=(pr_url) target="_blank" { "Open PR" }
+            }
+        }
+
+        div class="detail-content" {
+            div class="detail-split" {
+                // Left: rounds table
+                div {
+                    h3 style="font-size:0.85rem;margin-bottom:0.5rem;color:var(--text-muted)" { "Rounds" }
+                    div class="table-wrap" {
+                        (render_rounds_table(rounds, record, config))
+                    }
+
+                    // Token/cost breakdown
+                    h3 style="font-size:0.85rem;margin:0.75rem 0 0.5rem;color:var(--text-muted)" { "Token Breakdown" }
+                    (render_token_breakdown(rounds, record, config))
+                }
+
+                // Right: log pane
+                div {
+                    h3 style="font-size:0.85rem;margin-bottom:0.5rem;color:var(--text-muted)" { "Logs" }
+                    div #log-pane class="log-pane" {
+                        @for line in log_lines {
+                            span class="log-line" { (line) "\n" }
+                        }
+                    }
+
+                    // Pod introspect (FR-5)
+                    @if !is_terminal {
+                        details #pod-introspect class="pod-introspect" {
+                            summary { "Inspect pod" }
+                            div #introspect-data class="pod-introspect-data" { "Loading..." }
+                        }
+                    }
+                }
+            }
+        }
+    };
+
+    let extra = format!(
+        " data-loop-id=\"{}\" data-loop-terminal=\"{}\"",
+        id_str, is_terminal
+    );
+    layout(
+        &format!("nautiloop \u{00b7} {}", spec_filename(&record.spec_path)),
+        viewer,
+        body,
+        &extra,
+    )
+}
+
+fn render_rounds_table(
+    rounds: &[RoundRecord],
+    record: &LoopRecord,
+    config: &NautiloopConfig,
+) -> Markup {
+    // Group by round number
+    let mut round_groups: std::collections::BTreeMap<i32, Vec<&RoundRecord>> =
+        std::collections::BTreeMap::new();
+    for r in rounds {
+        round_groups.entry(r.round).or_default().push(r);
+    }
+
+    html! {
+        table class="rounds-table" {
+            thead {
+                tr {
+                    th { "#" }
+                    th { "Stage" }
+                    th { "Verdict" }
+                    th { "Tokens" }
+                    th { "Cost" }
+                    th { "Duration" }
+                }
+            }
+            tbody {
+                @for (_round_num, stages) in &round_groups {
+                    @for stage_round in stages {
+                        (render_round_row(stage_round, record, config))
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn render_round_row(
+    r: &RoundRecord,
+    record: &LoopRecord,
+    config: &NautiloopConfig,
+) -> Markup {
+    let verdict = extract_round_verdict(r);
+    let tokens = extract_round_tokens(r);
+    let cost = compute_round_cost(r, record, config);
+    let duration = r
+        .duration_secs
+        .map(|d| format!("{}s", d))
+        .unwrap_or_else(|| "\u{2014}".to_string());
+    let token_str = tokens
+        .as_ref()
+        .map(|t| format!("{}+{}", fmt_tokens(t.input), fmt_tokens(t.output)))
+        .unwrap_or_else(|| "\u{2014}".to_string());
+    let has_judge = check_judge_icon(r);
+
+    let detail_html = render_round_detail(r);
+
+    html! {
+        tr class="round-row expandable" {
+            td { (r.round) }
+            td { (r.stage) }
+            td {
+                (verdict)
+                @if has_judge {
+                    " " span class="judge-icon" title="Judge decision" { "\u{2696}" }
+                }
+            }
+            td { (token_str) }
+            td { (fmt_cost(cost)) }
+            td { (duration) }
+        }
+        tr class="round-detail" {
+            td colspan="6" {
+                (detail_html)
+            }
+        }
+    }
+}
+
+fn extract_round_verdict(r: &RoundRecord) -> String {
+    let Some(ref output) = r.output else {
+        return "\u{2014}".to_string();
+    };
+    match r.stage.as_str() {
+        "review" | "audit" => {
+            if let Ok(rd) = serde_json::from_value::<ReviewResultData>(output.clone())
+                && let Some(clean) = rd.verdict.get("clean").and_then(|v| v.as_bool()) {
+                    return if clean {
+                        "clean".to_string()
+                    } else {
+                        "not clean".to_string()
+                    };
+                }
+            "\u{2014}".to_string()
+        }
+        "test" => {
+            if let Ok(td) = serde_json::from_value::<TestResultData>(output.clone()) {
+                return if td.all_passed {
+                    "passed".to_string()
+                } else {
+                    "failed".to_string()
+                };
+            }
+            "\u{2014}".to_string()
+        }
+        _ => "\u{2014}".to_string(),
+    }
+}
+
+fn extract_round_tokens(r: &RoundRecord) -> Option<crate::types::verdict::TokenUsage> {
+    let output = r.output.as_ref()?;
+    match r.stage.as_str() {
+        "implement" => serde_json::from_value::<ImplResultData>(output.clone())
+            .ok()
+            .map(|d| d.token_usage),
+        "test" => serde_json::from_value::<TestResultData>(output.clone())
+            .ok()
+            .map(|d| d.token_usage),
+        "review" | "audit" => serde_json::from_value::<ReviewResultData>(output.clone())
+            .ok()
+            .map(|d| d.token_usage),
+        "revise" => serde_json::from_value::<ReviseResultData>(output.clone())
+            .ok()
+            .map(|d| d.token_usage),
+        _ => None,
+    }
+}
+
+fn compute_round_cost(
+    r: &RoundRecord,
+    record: &LoopRecord,
+    config: &NautiloopConfig,
+) -> Option<f64> {
+    let tu = extract_round_tokens(r)?;
+    let pricing = config.pricing.as_ref()?;
+    let model = match r.stage.as_str() {
+        "implement" | "revise" | "test" => record
+            .model_implementor
+            .clone()
+            .unwrap_or_else(|| config.models.implementor.clone()),
+        "review" | "audit" => record
+            .model_reviewer
+            .clone()
+            .unwrap_or_else(|| config.models.reviewer.clone()),
+        _ => return None,
+    };
+    super::aggregate::compute_cost(&tu, &model, pricing)
+}
+
+fn check_judge_icon(_r: &RoundRecord) -> bool {
+    // FR-11b: Only render if judge_decisions exist (post-#128).
+    // For now, return false since the judge feature is not yet shipped.
+    false
+}
+
+fn render_round_detail(r: &RoundRecord) -> Markup {
+    let Some(ref output) = r.output else {
+        return html! { "\u{2014}" };
+    };
+
+    match r.stage.as_str() {
+        "implement" | "revise" => {
+            if let Ok(d) = serde_json::from_value::<ImplResultData>(output.clone()) {
+                return html! {
+                    "SHA: " (d.new_sha) " | exit: " (d.exit_code)
+                };
+            }
+            if let Ok(d) = serde_json::from_value::<ReviseResultData>(output.clone()) {
+                return html! {
+                    "SHA: " (d.new_sha) " | spec: " (d.revised_spec_path) " | exit: " (d.exit_code)
+                };
+            }
+        }
+        "test" => {
+            if let Ok(d) = serde_json::from_value::<TestResultData>(output.clone()) {
+                let status = if d.all_passed { "passed" } else { "failed" };
+                return html! {
+                    "Status: " (status) " | services: " (d.services.len())
+                    @for svc in &d.services {
+                        br;
+                        "  " (svc.name) ": exit " (svc.exit_code)
+                    }
+                };
+            }
+        }
+        "review" | "audit" => {
+            if let Ok(d) = serde_json::from_value::<ReviewResultData>(output.clone()) {
+                let clean = d.verdict.get("clean").and_then(|v| v.as_bool());
+                let summary = d
+                    .verdict
+                    .get("summary")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                let issues_count = d
+                    .verdict
+                    .get("issues")
+                    .and_then(|v| v.as_array())
+                    .map(|a| a.len())
+                    .unwrap_or(0);
+                let confidence = d
+                    .verdict
+                    .get("confidence")
+                    .and_then(|v| v.as_f64());
+
+                return html! {
+                    @if let Some(c) = clean {
+                        "Verdict: " (if c { "clean" } else { "not clean" })
+                    }
+                    @if let Some(conf) = confidence {
+                        " | confidence: " (format!("{:.0}%", conf * 100.0))
+                    }
+                    " | issues: " (issues_count)
+                    @if !summary.is_empty() {
+                        br;
+                        (summary)
+                    }
+                };
+            }
+        }
+        _ => {}
+    }
+    html! { pre { (serde_json::to_string_pretty(output).unwrap_or_default()) } }
+}
+
+fn render_token_breakdown(
+    rounds: &[RoundRecord],
+    record: &LoopRecord,
+    config: &NautiloopConfig,
+) -> Markup {
+    let mut max_total = 0u64;
+    let mut rows: Vec<(i32, &str, u64, u64, Option<f64>)> = Vec::new();
+
+    for r in rounds {
+        if let Some(tu) = extract_round_tokens(r) {
+            let total = tu.input + tu.output;
+            if total > max_total {
+                max_total = total;
+            }
+            let cost = compute_round_cost(r, record, config);
+            rows.push((r.round, &r.stage, tu.input, tu.output, cost));
+        }
+    }
+
+    if rows.is_empty() {
+        return html! { div class="empty-state" { "No token data available." } };
+    }
+
+    html! {
+        table class="token-table" {
+            thead {
+                tr {
+                    th { "Round" }
+                    th { "Stage" }
+                    th { "Input" }
+                    th { "Output" }
+                    th { "Cost" }
+                    th class="bar-cell" { "" }
+                }
+            }
+            tbody {
+                @for (round, stage, input, output, cost) in &rows {
+                    @let total = input + output;
+                    @let pct = if max_total > 0 { (total as f64 / max_total as f64 * 100.0) as u32 } else { 0 };
+                    tr {
+                        td { (round) }
+                        td { (stage) }
+                        td { (fmt_tokens(*input)) }
+                        td { (fmt_tokens(*output)) }
+                        td { (fmt_cost(*cost)) }
+                        td class="bar-cell" {
+                            div class="bar" style=(format!("width:{}%", pct)) {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ── Feed Page ──
+
+pub fn render_feed(data: &FeedResponse, viewer: &str) -> String {
+    let body = html! {
+        (nav_bar("feed", viewer))
+
+        div class="filter-bar" {
+            button class="chip active" onclick="location.href='/dashboard/feed'" { "All events" }
+            button class="chip" onclick="location.href='/dashboard/feed?filter=converged'" { "Converged" }
+            button class="chip" onclick="location.href='/dashboard/feed?filter=failed'" { "Failed" }
+        }
+
+        div #feed-list class="feed-list" {
+            @if data.events.is_empty() {
+                div class="empty-state" { "No terminal events yet." }
+            }
+            @for ev in &data.events {
+                (render_feed_item(ev))
+            }
+        }
+
+        @if data.has_more {
+            div class="load-more" {
+                button #feed-load-more class="btn"
+                    data-cursor=(data.events.last().map(|e| e.updated_at.to_rfc3339()).unwrap_or_default()) {
+                    "Load more"
+                }
+            }
+        }
+    };
+    layout("nautiloop \u{00b7} feed", viewer, body, "")
+}
+
+fn render_feed_item(ev: &super::aggregate::FeedEvent) -> Markup {
+    let time = ev.updated_at.format("%H:%M").to_string();
+    let ext = if ev.extensions > 0 {
+        format!(" [extended \u{00d7}{}]", ev.extensions)
+    } else {
+        String::new()
+    };
+
+    html! {
+        a class="feed-item" href=(format!("/dashboard/loops/{}", ev.id)) {
+            span class="feed-time" { (time) }
+            span { (ev.engineer) }
+            span class="feed-spec" { (spec_filename(&ev.spec_path)) }
+            span class=(badge_class(&ev.state)) { (ev.state) }
+            @if ev.spec_pr_url.is_some() {
+                span class="feed-detail" { "PR" }
+            }
+            span class="feed-detail" { (ev.rounds) " rounds" }
+            span class="feed-detail" { (fmt_cost(ev.total_cost)) }
+            @if !ext.is_empty() {
+                span class="feed-detail" { (ext) }
+            }
+        }
+    }
+}
+
+// ── Specs Page ──
+
+pub fn render_specs(data: &SpecsResponse, viewer: &str) -> String {
+    let body = html! {
+        (nav_bar("grid", viewer))
+
+        div class="spec-header" {
+            h2 { (spec_filename(&data.spec_path)) }
+            div class="spec-aggregates" {
+                span { (data.aggregates.total_runs) " runs" }
+                span { "\u{00b7} " (fmt_rate(data.aggregates.converge_rate)) " converge rate" }
+                @if let Some(avg) = data.aggregates.avg_rounds {
+                    span { "\u{00b7} avg " (format!("{:.1}", avg)) " rounds" }
+                }
+                span { "\u{00b7} total cost " (fmt_cost(data.aggregates.total_cost)) }
+            }
+        }
+
+        div class="section" {
+            div class="table-wrap" {
+                table class="data-table" {
+                    thead {
+                        tr {
+                            th { "Date" }
+                            th { "Engineer" }
+                            th { "Result" }
+                            th { "Rounds" }
+                            th { "Cost" }
+                            th { "Branch" }
+                        }
+                    }
+                    tbody {
+                        @for run in &data.runs {
+                            tr {
+                                td { (run.created_at.format("%Y-%m-%d %H:%M")) }
+                                td { (run.engineer) }
+                                td { span class=(badge_class(&run.state)) { (run.state) } }
+                                td { (run.rounds) }
+                                td { (fmt_cost(run.total_cost)) }
+                                td style="font-size:0.7rem;word-break:break-all" { (run.branch) }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    };
+    layout(
+        &format!("nautiloop \u{00b7} {}", spec_filename(&data.spec_path)),
+        viewer,
+        body,
+        "",
+    )
+}
+
+pub fn render_specs_empty(viewer: &str) -> String {
+    let body = html! {
+        (nav_bar("grid", viewer))
+        div class="empty-state" { "No spec path specified." }
+    };
+    layout("nautiloop \u{00b7} specs", viewer, body, "")
+}
+
+// ── Stats Page ──
+
+pub fn render_stats(data: &StatsResponse, viewer: &str) -> String {
+    let body = html! {
+        (nav_bar("stats", viewer))
+
+        // Window toggle
+        div class="filter-bar" {
+            @for w in &["24h", "7d", "30d"] {
+                button class=(if data.window == *w { "chip active" } else { "chip" }) data-window=(w) { (w) }
+            }
+        }
+
+        // Headline cards
+        div class="stats-cards" {
+            div class="stat-card" id="total-loops" {
+                div class="label" { "Total Loops" }
+                div class="value" { (data.headline.total_loops) }
+            }
+            div class="stat-card" id="total-cost" {
+                div class="label" { "Total Cost" }
+                div class="value" { (fmt_cost(data.headline.total_cost)) }
+            }
+            div class="stat-card" id="converge-rate" {
+                div class="label" { "Converge Rate" }
+                div class="value" { (fmt_rate(data.headline.converge_rate)) }
+            }
+            div class="stat-card" id="avg-rounds" {
+                div class="label" { "Avg Rounds" }
+                div class="value" {
+                    @if let Some(avg) = data.headline.avg_rounds {
+                        (format!("{:.1}", avg))
+                    } @else {
+                        "\u{2014}"
+                    }
+                }
+            }
+        }
+
+        // Per-engineer table
+        div class="stats-section" {
+            h3 id="per-engineer" { "Per Engineer" }
+            div class="table-wrap" {
+                table class="data-table" {
+                    thead {
+                        tr {
+                            th { "Engineer" }
+                            th { "Loops" }
+                            th { "Cost" }
+                            th { "Converge Rate" }
+                        }
+                    }
+                    tbody {
+                        @for eng in &data.per_engineer {
+                            tr {
+                                td { (eng.engineer) }
+                                td { (eng.loops) }
+                                td { (fmt_cost(eng.cost)) }
+                                td { (fmt_rate(eng.converge_rate)) }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Per-spec table
+        div class="stats-section" {
+            h3 id="per-spec" { "Top Specs" }
+            div class="table-wrap" {
+                table class="data-table" {
+                    thead {
+                        tr {
+                            th { "Spec" }
+                            th { "Runs" }
+                            th { "Cost" }
+                            th { "Converge Rate" }
+                            th { "Avg Rounds" }
+                        }
+                    }
+                    tbody {
+                        @for spec in &data.per_spec {
+                            tr {
+                                td { (spec_filename(&spec.spec_path)) }
+                                td { (spec.runs) }
+                                td { (fmt_cost(spec.cost)) }
+                                td { (fmt_rate(spec.converge_rate)) }
+                                td {
+                                    @if let Some(avg) = spec.avg_rounds {
+                                        (format!("{:.1}", avg))
+                                    } @else {
+                                        "\u{2014}"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Time series
+        div class="stats-section" {
+            h3 id="time-series" { "Daily Activity" }
+            @for day in &data.time_series {
+                @let max_val = day.started.max(1);
+                div class="ts-row" {
+                    span class="ts-label" { (day.date) }
+                    div class="ts-bars" {
+                        div class="ts-bar ts-bar-converged"
+                            style=(format!("width:{}%", day.converged * 100 / max_val))
+                            title=(format!("{} converged", day.converged)) {}
+                        div class="ts-bar ts-bar-failed"
+                            style=(format!("width:{}%", day.failed * 100 / max_val))
+                            title=(format!("{} failed", day.failed)) {}
+                        @let other = day.started.saturating_sub(day.converged + day.failed);
+                        @if other > 0 {
+                            div class="ts-bar ts-bar-started"
+                                style=(format!("width:{}%", other * 100 / max_val))
+                                title=(format!("{} other", other)) {}
+                        }
+                    }
+                    span class="ts-count" { (day.started) }
+                }
+            }
+        }
+    };
+    layout("nautiloop \u{00b7} stats", viewer, body, "")
+}
+
+// ── Utility Helpers ──
+
+fn is_terminal_state(state: &str) -> bool {
+    matches!(
+        state,
+        "CONVERGED" | "FAILED" | "CANCELLED" | "HARDENED" | "SHIPPED"
+    )
+}
+
+fn pulse_class(sub_state: Option<&str>) -> &'static str {
+    match sub_state {
+        Some("RUNNING") => "pulse-running",
+        Some("DISPATCHED") => "pulse-dispatched",
+        _ => "pulse-completed",
+    }
+}
+
+fn engineer_color(name: &str) -> String {
+    let mut h: i32 = 0;
+    for b in name.bytes() {
+        h = ((h << 5).wrapping_sub(h)).wrapping_add(b as i32);
+    }
+    let hue = h.rem_euclid(360);
+    format!("hsl({},55%,45%)", hue)
+}
+
+fn engineer_initials(name: &str) -> String {
+    name.chars().take(2).collect::<String>().to_uppercase()
+}
+
+fn fmt_elapsed(created: chrono::DateTime<chrono::Utc>) -> String {
+    let elapsed = chrono::Utc::now() - created;
+    let secs = elapsed.num_seconds();
+    if secs < 60 {
+        format!("{}s", secs)
+    } else if secs < 3600 {
+        format!("{}m {}s", secs / 60, secs % 60)
+    } else {
+        format!("{}h {}m", secs / 3600, (secs % 3600) / 60)
+    }
+}
+
+fn count_active(counts: &std::collections::HashMap<String, u64>) -> u64 {
+    counts
+        .iter()
+        .filter(|(k, _)| !is_terminal_state(k))
+        .map(|(_, v)| v)
+        .sum()
+}
+
+fn count_converged(counts: &std::collections::HashMap<String, u64>) -> u64 {
+    counts.get("CONVERGED").copied().unwrap_or(0)
+        + counts.get("HARDENED").copied().unwrap_or(0)
+        + counts.get("SHIPPED").copied().unwrap_or(0)
+}
+
+fn count_failed(counts: &std::collections::HashMap<String, u64>) -> u64 {
+    counts.get("FAILED").copied().unwrap_or(0)
+        + counts.get("CANCELLED").copied().unwrap_or(0)
+}
+
+// URL encoding helper
+mod urlencoding {
+    pub fn encode(s: &str) -> String {
+        let mut result = String::new();
+        for b in s.bytes() {
+            match b {
+                b'A'..=b'Z'
+                | b'a'..=b'z'
+                | b'0'..=b'9'
+                | b'-'
+                | b'_'
+                | b'.'
+                | b'~' => result.push(b as char),
+                _ => {
+                    result.push('%');
+                    result.push_str(&format!("{:02X}", b));
+                }
+            }
+        }
+        result
+    }
+}

--- a/control-plane/src/api/mod.rs
+++ b/control-plane/src/api/mod.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+pub mod dashboard;
 pub mod handlers;
 pub mod introspect;
 pub mod sse;
@@ -33,11 +34,14 @@ pub struct AppState {
 
 /// Build the axum router with all endpoints and auth middleware.
 /// The /health endpoint is outside the auth layer so K8s probes work without an API key.
+/// Dashboard routes live under /dashboard/* with their own cookie-based auth.
 pub fn build_router(state: AppState) -> Router {
     let authed = build_routes(state.clone()).layer(middleware::from_fn(auth::auth_middleware));
+    let dashboard = dashboard::build_dashboard_router(state.clone());
 
     Router::new()
         .route("/health", get(health))
+        .merge(dashboard)
         .merge(authed)
         .with_state(state)
 }

--- a/control-plane/src/api/mod.rs
+++ b/control-plane/src/api/mod.rs
@@ -150,6 +150,9 @@ mod tests {
         ) -> crate::error::Result<Vec<LoopRecord>> {
             unimplemented!()
         }
+        async fn get_all_loops(&self, _: bool) -> crate::error::Result<Vec<LoopRecord>> {
+            unimplemented!()
+        }
         async fn update_loop_state(
             &self,
             _: Uuid,

--- a/control-plane/src/api/mod.rs
+++ b/control-plane/src/api/mod.rs
@@ -204,11 +204,38 @@ mod tests {
         ) -> crate::error::Result<Vec<LogEvent>> {
             unimplemented!()
         }
+        async fn get_recent_logs(
+            &self,
+            _: Uuid,
+            _: usize,
+        ) -> crate::error::Result<Vec<LogEvent>> {
+            unimplemented!()
+        }
         async fn get_logs_after(
             &self,
             _: Uuid,
             _: chrono::DateTime<chrono::Utc>,
         ) -> crate::error::Result<Vec<LogEvent>> {
+            unimplemented!()
+        }
+        async fn get_loops_by_spec_path(
+            &self,
+            _: &str,
+            _: usize,
+        ) -> crate::error::Result<Vec<LoopRecord>> {
+            unimplemented!()
+        }
+        async fn get_terminal_loops(
+            &self,
+            _: Option<chrono::DateTime<chrono::Utc>>,
+            _: Option<&str>,
+            _: Option<&str>,
+            _: usize,
+            _: Option<(chrono::DateTime<chrono::Utc>, Uuid)>,
+        ) -> crate::error::Result<Vec<LoopRecord>> {
+            unimplemented!()
+        }
+        async fn get_terminal_engineers(&self) -> crate::error::Result<Vec<String>> {
             unimplemented!()
         }
         async fn get_credentials(

--- a/control-plane/src/api/mod.rs
+++ b/control-plane/src/api/mod.rs
@@ -150,7 +150,7 @@ mod tests {
         ) -> crate::error::Result<Vec<LoopRecord>> {
             unimplemented!()
         }
-        async fn get_all_loops(&self, _: bool) -> crate::error::Result<Vec<LoopRecord>> {
+        async fn get_all_loops(&self, _: bool, _: Option<chrono::DateTime<chrono::Utc>>) -> crate::error::Result<Vec<LoopRecord>> {
             unimplemented!()
         }
         async fn update_loop_state(

--- a/control-plane/src/api/mod.rs
+++ b/control-plane/src/api/mod.rs
@@ -184,6 +184,12 @@ mod tests {
         async fn get_rounds(&self, _: Uuid) -> crate::error::Result<Vec<RoundRecord>> {
             unimplemented!()
         }
+        async fn get_rounds_batch(
+            &self,
+            _: &[Uuid],
+        ) -> crate::error::Result<std::collections::HashMap<Uuid, Vec<RoundRecord>>> {
+            unimplemented!()
+        }
         async fn append_log(&self, _: &LogEvent) -> crate::error::Result<()> {
             unimplemented!()
         }

--- a/control-plane/src/config/mod.rs
+++ b/control-plane/src/config/mod.rs
@@ -34,6 +34,10 @@ pub struct NautiloopConfig {
     /// Observability configuration from `[observability]` in nemo.toml.
     #[serde(default)]
     pub observability: ObservabilityConfig,
+    /// Optional pricing configuration from `[pricing]` in nemo.toml (FR-15e).
+    /// When absent, all cost fields across the dashboard display `—`.
+    #[serde(default)]
+    pub pricing: Option<PricingConfig>,
 }
 
 /// Configuration for a single service in the monorepo.
@@ -421,6 +425,23 @@ fn default_reconcile_interval() -> u64 {
 }
 fn default_branch_name() -> String {
     "main".to_string()
+}
+
+/// Pricing configuration from `[pricing]` in nemo.toml (FR-15).
+/// Maps model names to per-token costs for computing dollar amounts.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PricingConfig {
+    /// Per-model pricing: model name → input/output costs per million tokens.
+    pub models: HashMap<String, ModelPricing>,
+}
+
+/// Per-token costs for a single model (FR-15a).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelPricing {
+    /// Cost in USD per million input tokens.
+    pub input_per_million: f64,
+    /// Cost in USD per million output tokens.
+    pub output_per_million: f64,
 }
 
 /// Engineer-level configuration loaded from `~/.nemo/config.toml`.

--- a/control-plane/src/lib.rs
+++ b/control-plane/src/lib.rs
@@ -6,3 +6,4 @@ pub mod k8s;
 pub mod loop_engine;
 pub mod state;
 pub mod types;
+pub mod util;

--- a/control-plane/src/state/mod.rs
+++ b/control-plane/src/state/mod.rs
@@ -65,6 +65,13 @@ pub trait StateStore: Send + Sync + 'static {
     /// Get all rounds for a loop.
     async fn get_rounds(&self, loop_id: Uuid) -> Result<Vec<RoundRecord>>;
 
+    /// Get all rounds for multiple loops in a single query.
+    /// Returns a map of loop_id -> Vec<RoundRecord>.
+    async fn get_rounds_batch(
+        &self,
+        loop_ids: &[Uuid],
+    ) -> Result<std::collections::HashMap<Uuid, Vec<RoundRecord>>>;
+
     /// Append a log event.
     async fn append_log(&self, event: &LogEvent) -> Result<()>;
 
@@ -343,6 +350,20 @@ pub mod memory {
                 .filter(|r| r.loop_id == loop_id)
                 .cloned()
                 .collect())
+        }
+
+        async fn get_rounds_batch(
+            &self,
+            loop_ids: &[Uuid],
+        ) -> Result<HashMap<Uuid, Vec<RoundRecord>>> {
+            let rounds = self.rounds.read().await;
+            let mut result: HashMap<Uuid, Vec<RoundRecord>> = HashMap::new();
+            for r in rounds.iter() {
+                if loop_ids.contains(&r.loop_id) {
+                    result.entry(r.loop_id).or_default().push(r.clone());
+                }
+            }
+            Ok(result)
         }
 
         async fn append_log(&self, event: &LogEvent) -> Result<()> {

--- a/control-plane/src/state/mod.rs
+++ b/control-plane/src/state/mod.rs
@@ -97,6 +97,15 @@ pub trait StateStore: Send + Sync + 'static {
         stage: Option<&str>,
     ) -> Result<Vec<LogEvent>>;
 
+    /// Get the most recent N log events for a loop (ordered ASC).
+    /// Uses `ORDER BY timestamp DESC, id DESC LIMIT N` in SQL then reverses,
+    /// avoiding loading the entire log history for loops with thousands of lines.
+    async fn get_recent_logs(
+        &self,
+        loop_id: Uuid,
+        limit: usize,
+    ) -> Result<Vec<LogEvent>>;
+
     /// Get log events at or after a given timestamp for SSE tailing.
     /// Uses inclusive `>=` query; caller deduplicates by seen IDs.
     async fn get_logs_after(
@@ -104,6 +113,29 @@ pub trait StateStore: Send + Sync + 'static {
         loop_id: Uuid,
         after: chrono::DateTime<chrono::Utc>,
     ) -> Result<Vec<LogEvent>>;
+
+    /// Get loops filtered by spec_path, ordered by created_at DESC, with a limit.
+    /// Pushes the WHERE clause to SQL instead of loading all loops and filtering in Rust.
+    async fn get_loops_by_spec_path(
+        &self,
+        spec_path: &str,
+        limit: usize,
+    ) -> Result<Vec<LoopRecord>>;
+
+    /// Get terminal loops ordered by updated_at DESC for the feed endpoint.
+    /// Accepts optional state and engineer filters pushed to SQL.
+    /// `since` bounds the query to a reasonable time window.
+    async fn get_terminal_loops(
+        &self,
+        since: Option<chrono::DateTime<chrono::Utc>>,
+        state_filter: Option<&str>,
+        engineer_filter: Option<&str>,
+        limit: usize,
+        cursor: Option<(chrono::DateTime<chrono::Utc>, Uuid)>,
+    ) -> Result<Vec<LoopRecord>>;
+
+    /// Get distinct engineer names from terminal loops (for feed filter chips).
+    async fn get_terminal_engineers(&self) -> Result<Vec<String>>;
 
     /// Get or create engineer credentials.
     async fn get_credentials(&self, engineer: &str) -> Result<Vec<EngineerCredential>>;
@@ -424,6 +456,22 @@ pub mod memory {
                 .collect())
         }
 
+        async fn get_recent_logs(
+            &self,
+            loop_id: Uuid,
+            limit: usize,
+        ) -> Result<Vec<LogEvent>> {
+            let logs = self.logs.read().await;
+            let mut matching: Vec<LogEvent> = logs
+                .iter()
+                .filter(|l| l.loop_id == loop_id)
+                .cloned()
+                .collect();
+            matching.sort_by(|a, b| a.timestamp.cmp(&b.timestamp).then_with(|| a.id.cmp(&b.id)));
+            let skip = matching.len().saturating_sub(limit);
+            Ok(matching.into_iter().skip(skip).collect())
+        }
+
         async fn get_logs_after(
             &self,
             loop_id: Uuid,
@@ -435,6 +483,87 @@ pub mod memory {
                 .filter(|l| l.loop_id == loop_id && l.timestamp >= after)
                 .cloned()
                 .collect())
+        }
+
+        async fn get_loops_by_spec_path(
+            &self,
+            spec_path: &str,
+            limit: usize,
+        ) -> Result<Vec<LoopRecord>> {
+            let loops = self.loops.read().await;
+            let mut matching: Vec<LoopRecord> = loops
+                .values()
+                .filter(|l| l.spec_path == spec_path)
+                .cloned()
+                .collect();
+            matching.sort_by_key(|r| std::cmp::Reverse(r.created_at));
+            matching.truncate(limit);
+            Ok(matching)
+        }
+
+        async fn get_terminal_loops(
+            &self,
+            since: Option<chrono::DateTime<chrono::Utc>>,
+            state_filter: Option<&str>,
+            engineer_filter: Option<&str>,
+            limit: usize,
+            cursor: Option<(chrono::DateTime<chrono::Utc>, Uuid)>,
+        ) -> Result<Vec<LoopRecord>> {
+            let loops = self.loops.read().await;
+            let mut matching: Vec<LoopRecord> = loops
+                .values()
+                .filter(|l| {
+                    if !l.state.is_terminal() {
+                        return false;
+                    }
+                    if let Some(cutoff) = since
+                        && l.updated_at < cutoff
+                    {
+                        return false;
+                    }
+                    let passes_state = match state_filter {
+                        Some("converged") => matches!(
+                            l.state,
+                            LoopState::Converged | LoopState::Hardened | LoopState::Shipped
+                        ),
+                        Some("failed") => matches!(l.state, LoopState::Failed | LoopState::Cancelled),
+                        _ => true,
+                    };
+                    let passes_engineer = match engineer_filter {
+                        Some(eng) => l.engineer == eng,
+                        None => true,
+                    };
+                    if !passes_state || !passes_engineer {
+                        return false;
+                    }
+                    if let Some((cursor_ts, cursor_id)) = cursor {
+                        if l.updated_at > cursor_ts {
+                            return false;
+                        }
+                        if l.updated_at == cursor_ts && l.id >= cursor_id {
+                            return false;
+                        }
+                    }
+                    true
+                })
+                .cloned()
+                .collect();
+            matching.sort_by(|a, b| b.updated_at.cmp(&a.updated_at).then_with(|| b.id.cmp(&a.id)));
+            matching.truncate(limit);
+            Ok(matching)
+        }
+
+        async fn get_terminal_engineers(&self) -> Result<Vec<String>> {
+            let loops = self.loops.read().await;
+            let mut engineers: std::collections::HashSet<String> = std::collections::HashSet::new();
+            for l in loops.values() {
+                if l.state.is_terminal() {
+                    engineers.insert(l.engineer.clone());
+                }
+            }
+            let mut result: Vec<String> = engineers.into_iter().collect();
+            result.sort();
+            Ok(result)
         }
 
         async fn get_credentials(&self, engineer: &str) -> Result<Vec<EngineerCredential>> {

--- a/control-plane/src/state/mod.rs
+++ b/control-plane/src/state/mod.rs
@@ -1,6 +1,7 @@
 pub mod postgres;
 
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
 use crate::error::Result;
@@ -38,10 +39,16 @@ pub trait StateStore: Send + Sync + 'static {
         include_terminal: bool,
     ) -> Result<Vec<LoopRecord>>;
 
-    /// Get all loops without a row limit, for aggregation endpoints that must
-    /// compute over the full dataset (fleet summary, stats, feed, specs).
+    /// Get all loops for aggregation endpoints.
     /// If `include_terminal` is false, only returns active (non-terminal) loops.
-    async fn get_all_loops(&self, include_terminal: bool) -> Result<Vec<LoopRecord>>;
+    /// If `since` is provided, only returns loops created after that timestamp
+    /// (plus all active loops regardless of creation time). This limits the
+    /// result set for long-lived deployments with thousands of historical loops.
+    async fn get_all_loops(
+        &self,
+        include_terminal: bool,
+        since: Option<DateTime<Utc>>,
+    ) -> Result<Vec<LoopRecord>>;
 
     /// Update loop state and sub-state. Also updates `updated_at`.
     async fn update_loop_state(
@@ -272,11 +279,22 @@ pub mod memory {
                 .collect())
         }
 
-        async fn get_all_loops(&self, include_terminal: bool) -> Result<Vec<LoopRecord>> {
+        async fn get_all_loops(
+            &self,
+            include_terminal: bool,
+            since: Option<DateTime<Utc>>,
+        ) -> Result<Vec<LoopRecord>> {
             let loops = self.loops.read().await;
             Ok(loops
                 .values()
-                .filter(|l| include_terminal || !l.state.is_terminal())
+                .filter(|l| {
+                    let terminal_ok = include_terminal || !l.state.is_terminal();
+                    let time_ok = match since {
+                        Some(cutoff) => l.created_at > cutoff || !l.state.is_terminal(),
+                        None => true,
+                    };
+                    terminal_ok && time_ok
+                })
                 .cloned()
                 .collect())
         }

--- a/control-plane/src/state/mod.rs
+++ b/control-plane/src/state/mod.rs
@@ -29,12 +29,19 @@ pub trait StateStore: Send + Sync + 'static {
 
     /// Get loops for an engineer, optionally filtered by team (all engineers).
     /// If `include_terminal` is false, only returns active (non-terminal) loops.
+    /// Limited to 100 results for CLI/UI display. For aggregation (dashboard
+    /// fleet summary, stats, feed), use `get_all_loops` instead.
     async fn get_loops_for_engineer(
         &self,
         engineer: Option<&str>,
         team: bool,
         include_terminal: bool,
     ) -> Result<Vec<LoopRecord>>;
+
+    /// Get all loops without a row limit, for aggregation endpoints that must
+    /// compute over the full dataset (fleet summary, stats, feed, specs).
+    /// If `include_terminal` is false, only returns active (non-terminal) loops.
+    async fn get_all_loops(&self, include_terminal: bool) -> Result<Vec<LoopRecord>>;
 
     /// Update loop state and sub-state. Also updates `updated_at`.
     async fn update_loop_state(
@@ -261,6 +268,15 @@ pub mod memory {
                     };
                     eng_match && (include_terminal || !l.state.is_terminal())
                 })
+                .cloned()
+                .collect())
+        }
+
+        async fn get_all_loops(&self, include_terminal: bool) -> Result<Vec<LoopRecord>> {
+            let loops = self.loops.read().await;
+            Ok(loops
+                .values()
+                .filter(|l| include_terminal || !l.state.is_terminal())
                 .cloned()
                 .collect())
         }

--- a/control-plane/src/state/postgres.rs
+++ b/control-plane/src/state/postgres.rs
@@ -459,6 +459,20 @@ impl StateStore for PgStateStore {
         rows.iter().map(row_to_loop_record).collect()
     }
 
+    async fn get_all_loops(&self, include_terminal: bool) -> Result<Vec<LoopRecord>> {
+        let terminal_filter = if include_terminal {
+            ""
+        } else {
+            " AND state NOT IN ('CONVERGED', 'FAILED', 'CANCELLED', 'HARDENED', 'SHIPPED')"
+        };
+
+        let q = format!(
+            "SELECT * FROM loops WHERE true{terminal_filter} ORDER BY created_at DESC"
+        );
+        let rows = sqlx::query(&q).fetch_all(&self.pool).await?;
+        rows.iter().map(row_to_loop_record).collect()
+    }
+
     async fn update_loop_state(
         &self,
         id: Uuid,

--- a/control-plane/src/state/postgres.rs
+++ b/control-plane/src/state/postgres.rs
@@ -479,9 +479,21 @@ impl StateStore for PgStateStore {
                 .await?
             }
             (true, None) => {
-                sqlx::query("SELECT * FROM loops ORDER BY created_at DESC")
-                    .fetch_all(&self.pool)
-                    .await?
+                // Safety LIMIT to prevent unbounded queries on long-lived deployments.
+                // Callers needing filtered subsets should use get_loops_by_spec_path or
+                // get_terminal_loops instead. 10000 is well above any reasonable deployment.
+                let rows = sqlx::query(
+                    "SELECT * FROM loops ORDER BY created_at DESC LIMIT 10000",
+                )
+                .fetch_all(&self.pool)
+                .await?;
+                if rows.len() >= 10000 {
+                    tracing::warn!(
+                        "get_all_loops(true, None) hit 10000-row safety limit; \
+                         consider using a time-bounded query"
+                    );
+                }
+                rows
             }
             (false, _) => {
                 // Active only — `since` is irrelevant when excluding terminal loops.
@@ -744,6 +756,26 @@ impl StateStore for PgStateStore {
         Ok(rows.iter().map(row_to_log_event).collect())
     }
 
+    async fn get_recent_logs(
+        &self,
+        loop_id: Uuid,
+        limit: usize,
+    ) -> Result<Vec<LogEvent>> {
+        // Fetch the last N logs by ordering DESC with LIMIT, then reverse in Rust.
+        let rows = sqlx::query(
+            "SELECT * FROM log_events WHERE loop_id = $1 \
+             ORDER BY timestamp DESC, id DESC LIMIT $2",
+        )
+        .bind(loop_id)
+        .bind(limit as i64)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let mut logs: Vec<LogEvent> = rows.iter().map(row_to_log_event).collect();
+        logs.reverse();
+        Ok(logs)
+    }
+
     async fn get_logs_after(&self, loop_id: Uuid, after: DateTime<Utc>) -> Result<Vec<LogEvent>> {
         let rows = sqlx::query(
             "SELECT * FROM log_events WHERE loop_id = $1 AND timestamp >= $2 ORDER BY timestamp ASC, id ASC",
@@ -754,6 +786,97 @@ impl StateStore for PgStateStore {
         .await?;
 
         Ok(rows.iter().map(row_to_log_event).collect())
+    }
+
+    async fn get_loops_by_spec_path(
+        &self,
+        spec_path: &str,
+        limit: usize,
+    ) -> Result<Vec<LoopRecord>> {
+        let rows = sqlx::query(
+            "SELECT * FROM loops WHERE spec_path = $1 ORDER BY created_at DESC LIMIT $2",
+        )
+        .bind(spec_path)
+        .bind(limit as i64)
+        .fetch_all(&self.pool)
+        .await?;
+        rows.iter().map(row_to_loop_record).collect()
+    }
+
+    async fn get_terminal_loops(
+        &self,
+        since: Option<DateTime<Utc>>,
+        state_filter: Option<&str>,
+        engineer_filter: Option<&str>,
+        limit: usize,
+        cursor: Option<(DateTime<Utc>, Uuid)>,
+    ) -> Result<Vec<LoopRecord>> {
+        // Build a parameterized query for the feed endpoint.
+        // We use a single query with conditional WHERE clauses via COALESCE/boolean logic
+        // to avoid dynamic SQL string building while keeping it efficient.
+        let terminal_states = vec!["CONVERGED", "FAILED", "CANCELLED", "HARDENED", "SHIPPED"];
+
+        let state_whitelist: Option<Vec<&str>> = match state_filter {
+            Some("converged") => Some(vec!["CONVERGED", "HARDENED", "SHIPPED"]),
+            Some("failed") => Some(vec!["FAILED", "CANCELLED"]),
+            _ => None, // all terminal
+        };
+        let filter_states = state_whitelist.as_deref().unwrap_or(&terminal_states);
+
+        // Build query dynamically but safely with bind parameters.
+        // sqlx doesn't natively support IN ($1...) with Vec, so we use ANY($1).
+        let mut query_str = String::from(
+            "SELECT * FROM loops WHERE state::text = ANY($1)",
+        );
+        let mut param_idx = 2;
+
+        if since.is_some() {
+            query_str.push_str(&format!(" AND updated_at >= ${param_idx}"));
+            param_idx += 1;
+        }
+        if engineer_filter.is_some() {
+            query_str.push_str(&format!(" AND engineer = ${param_idx}"));
+            param_idx += 1;
+        }
+        if cursor.is_some() {
+            query_str.push_str(&format!(
+                " AND (updated_at < ${} OR (updated_at = ${} AND id < ${}))",
+                param_idx,
+                param_idx,
+                param_idx + 1,
+            ));
+            param_idx += 2;
+        }
+        let _ = param_idx; // suppress unused warning
+        query_str.push_str(&format!(" ORDER BY updated_at DESC, id DESC LIMIT {limit}"));
+
+        let filter_states_strings: Vec<String> = filter_states.iter().map(|s| s.to_string()).collect();
+        let mut q = sqlx::query(&query_str).bind(&filter_states_strings);
+
+        if let Some(cutoff) = since {
+            q = q.bind(cutoff);
+        }
+        if let Some(eng) = engineer_filter {
+            q = q.bind(eng);
+        }
+        if let Some((cursor_ts, cursor_id)) = cursor {
+            q = q.bind(cursor_ts);
+            q = q.bind(cursor_id);
+        }
+
+        let rows = q.fetch_all(&self.pool).await?;
+        rows.iter().map(row_to_loop_record).collect()
+    }
+
+    async fn get_terminal_engineers(&self) -> Result<Vec<String>> {
+        let rows = sqlx::query_scalar::<_, String>(
+            "SELECT DISTINCT engineer FROM loops \
+             WHERE state IN ('CONVERGED', 'FAILED', 'CANCELLED', 'HARDENED', 'SHIPPED') \
+             ORDER BY engineer",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
     }
 
     async fn get_credentials(&self, engineer: &str) -> Result<Vec<EngineerCredential>> {

--- a/control-plane/src/state/postgres.rs
+++ b/control-plane/src/state/postgres.rs
@@ -441,6 +441,9 @@ impl StateStore for PgStateStore {
             " AND state NOT IN ('CONVERGED', 'FAILED', 'CANCELLED', 'HARDENED', 'SHIPPED')"
         };
 
+        // Runtime sqlx::query() because the WHERE clause varies based on terminal_filter
+        // (conditional state exclusion) and engineer scoping — not expressible in a single
+        // compile-time sqlx::query!().
         let rows = match engineer {
             Some(eng) if !team => {
                 let q = format!(
@@ -464,15 +467,19 @@ impl StateStore for PgStateStore {
         include_terminal: bool,
         since: Option<DateTime<Utc>>,
     ) -> Result<Vec<LoopRecord>> {
-        // Use separate static queries for each combination instead of
-        // runtime format!() string interpolation.
+        // Runtime sqlx::query() for each branch because the WHERE clause structure differs
+        // based on include_terminal and since — not expressible in a single compile-time
+        // sqlx::query!().
         let rows = match (include_terminal, since) {
             (true, Some(cutoff)) => {
-                // All loops created after cutoff, plus all active loops regardless of age.
+                // All loops created OR updated after cutoff, plus all active loops regardless
+                // of age. Using (created_at > $1 OR updated_at > $1) ensures that long-running
+                // loops which terminated recently (updated_at within window but created_at
+                // outside it) are still included — important for Converged/Failed filter chips.
                 // Safety LIMIT of 10000 to prevent unbounded result sets on long-lived
                 // deployments with high loop throughput.
                 let rows = sqlx::query(
-                    "SELECT * FROM loops WHERE created_at > $1 \
+                    "SELECT * FROM loops WHERE (created_at > $1 OR updated_at > $1) \
                      OR state NOT IN ('CONVERGED', 'FAILED', 'CANCELLED', 'HARDENED', 'SHIPPED') \
                      ORDER BY created_at DESC LIMIT 10000",
                 )
@@ -773,6 +780,7 @@ impl StateStore for PgStateStore {
         limit: usize,
     ) -> Result<Vec<LogEvent>> {
         // Fetch the last N logs by ordering DESC with LIMIT, then reverse in Rust.
+        // Runtime sqlx::query() because the LIMIT is a dynamic parameter.
         let rows = sqlx::query(
             "SELECT * FROM log_events WHERE loop_id = $1 \
              ORDER BY timestamp DESC, id DESC LIMIT $2",
@@ -804,6 +812,9 @@ impl StateStore for PgStateStore {
         spec_path: &str,
         limit: usize,
     ) -> Result<Vec<LoopRecord>> {
+        // Runtime sqlx::query() because the LIMIT is a dynamic parameter.
+        // Callers (e.g. build_specs_response) pass limit=10000 as a safety bound;
+        // aggregates are computed in Rust over the full result set.
         let rows = sqlx::query(
             "SELECT * FROM loops WHERE spec_path = $1 ORDER BY created_at DESC LIMIT $2",
         )
@@ -834,8 +845,9 @@ impl StateStore for PgStateStore {
         };
         let filter_states = state_whitelist.as_deref().unwrap_or(&terminal_states);
 
-        // Build query dynamically but safely with bind parameters.
-        // sqlx doesn't natively support IN ($1...) with Vec, so we use ANY($1).
+        // Runtime sqlx::query() because the WHERE clause is built dynamically based on
+        // optional filters (since, engineer, cursor) — not expressible in compile-time
+        // sqlx::query!(). All values are bound as parameters, never interpolated.
         let mut query_str = String::from(
             "SELECT * FROM loops WHERE state::text = ANY($1)",
         );
@@ -850,6 +862,9 @@ impl StateStore for PgStateStore {
             param_idx += 1;
         }
         if cursor.is_some() {
+            // Cursor clause: $param_idx is intentionally referenced twice (in both < and =
+            // comparisons) because it binds cursor_ts once. The bind order is:
+            // $1=states, [$2=since], [$N=engineer], [$N=cursor_ts, $N+1=cursor_id], $last=limit
             query_str.push_str(&format!(
                 " AND (updated_at < ${} OR (updated_at = ${} AND id < ${}))",
                 param_idx,

--- a/control-plane/src/state/postgres.rs
+++ b/control-plane/src/state/postgres.rs
@@ -621,6 +621,28 @@ impl StateStore for PgStateStore {
         Ok(rows.iter().map(row_to_round_record).collect())
     }
 
+    async fn get_rounds_batch(
+        &self,
+        loop_ids: &[Uuid],
+    ) -> Result<HashMap<Uuid, Vec<RoundRecord>>> {
+        if loop_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let rows = sqlx::query(
+            "SELECT * FROM rounds WHERE loop_id = ANY($1) ORDER BY round ASC, started_at ASC",
+        )
+        .bind(loop_ids)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let mut result: HashMap<Uuid, Vec<RoundRecord>> = HashMap::new();
+        for row in &rows {
+            let record = row_to_round_record(row);
+            result.entry(record.loop_id).or_default().push(record);
+        }
+        Ok(result)
+    }
+
     async fn append_log(&self, event: &LogEvent) -> Result<()> {
         sqlx::query(
             "INSERT INTO log_events (id, loop_id, round, stage, timestamp, line) VALUES ($1, $2, $3, $4, $5, $6)",

--- a/control-plane/src/state/postgres.rs
+++ b/control-plane/src/state/postgres.rs
@@ -459,17 +459,41 @@ impl StateStore for PgStateStore {
         rows.iter().map(row_to_loop_record).collect()
     }
 
-    async fn get_all_loops(&self, include_terminal: bool) -> Result<Vec<LoopRecord>> {
-        let terminal_filter = if include_terminal {
-            ""
-        } else {
-            " AND state NOT IN ('CONVERGED', 'FAILED', 'CANCELLED', 'HARDENED', 'SHIPPED')"
+    async fn get_all_loops(
+        &self,
+        include_terminal: bool,
+        since: Option<DateTime<Utc>>,
+    ) -> Result<Vec<LoopRecord>> {
+        // Use separate static queries for each combination instead of
+        // runtime format!() string interpolation.
+        let rows = match (include_terminal, since) {
+            (true, Some(cutoff)) => {
+                // All loops created after cutoff, plus all active loops regardless of age.
+                sqlx::query(
+                    "SELECT * FROM loops WHERE created_at > $1 \
+                     OR state NOT IN ('CONVERGED', 'FAILED', 'CANCELLED', 'HARDENED', 'SHIPPED') \
+                     ORDER BY created_at DESC",
+                )
+                .bind(cutoff)
+                .fetch_all(&self.pool)
+                .await?
+            }
+            (true, None) => {
+                sqlx::query("SELECT * FROM loops ORDER BY created_at DESC")
+                    .fetch_all(&self.pool)
+                    .await?
+            }
+            (false, _) => {
+                // Active only — `since` is irrelevant when excluding terminal loops.
+                sqlx::query(
+                    "SELECT * FROM loops \
+                     WHERE state NOT IN ('CONVERGED', 'FAILED', 'CANCELLED', 'HARDENED', 'SHIPPED') \
+                     ORDER BY created_at DESC",
+                )
+                .fetch_all(&self.pool)
+                .await?
+            }
         };
-
-        let q = format!(
-            "SELECT * FROM loops WHERE true{terminal_filter} ORDER BY created_at DESC"
-        );
-        let rows = sqlx::query(&q).fetch_all(&self.pool).await?;
         rows.iter().map(row_to_loop_record).collect()
     }
 

--- a/control-plane/src/state/postgres.rs
+++ b/control-plane/src/state/postgres.rs
@@ -469,14 +469,23 @@ impl StateStore for PgStateStore {
         let rows = match (include_terminal, since) {
             (true, Some(cutoff)) => {
                 // All loops created after cutoff, plus all active loops regardless of age.
-                sqlx::query(
+                // Safety LIMIT of 10000 to prevent unbounded result sets on long-lived
+                // deployments with high loop throughput.
+                let rows = sqlx::query(
                     "SELECT * FROM loops WHERE created_at > $1 \
                      OR state NOT IN ('CONVERGED', 'FAILED', 'CANCELLED', 'HARDENED', 'SHIPPED') \
-                     ORDER BY created_at DESC",
+                     ORDER BY created_at DESC LIMIT 10000",
                 )
                 .bind(cutoff)
                 .fetch_all(&self.pool)
-                .await?
+                .await?;
+                if rows.len() >= 10000 {
+                    tracing::warn!(
+                        "get_all_loops(true, Some(cutoff)) hit 10000-row safety limit; \
+                         consider narrowing the time window"
+                    );
+                }
+                rows
             }
             (true, None) => {
                 // Safety LIMIT to prevent unbounded queries on long-lived deployments.
@@ -678,6 +687,8 @@ impl StateStore for PgStateStore {
         if loop_ids.is_empty() {
             return Ok(HashMap::new());
         }
+        // Runtime sqlx::query() instead of compile-time sqlx::query!() because
+        // ANY($1) with a dynamic array input makes compile-time checking awkward.
         let rows = sqlx::query(
             "SELECT * FROM rounds WHERE loop_id = ANY($1) ORDER BY round ASC, started_at ASC",
         )
@@ -847,8 +858,9 @@ impl StateStore for PgStateStore {
             ));
             param_idx += 2;
         }
-        let _ = param_idx; // suppress unused warning
-        query_str.push_str(&format!(" ORDER BY updated_at DESC, id DESC LIMIT {limit}"));
+        query_str.push_str(&format!(
+            " ORDER BY updated_at DESC, id DESC LIMIT ${param_idx}"
+        ));
 
         let filter_states_strings: Vec<String> = filter_states.iter().map(|s| s.to_string()).collect();
         let mut q = sqlx::query(&query_str).bind(&filter_states_strings);
@@ -863,6 +875,7 @@ impl StateStore for PgStateStore {
             q = q.bind(cursor_ts);
             q = q.bind(cursor_id);
         }
+        q = q.bind(limit as i64);
 
         let rows = q.fetch_all(&self.pool).await?;
         rows.iter().map(row_to_loop_record).collect()

--- a/control-plane/src/util.rs
+++ b/control-plane/src/util.rs
@@ -10,6 +10,46 @@ pub fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     diff == 0
 }
 
+/// Extract a cookie value by name from the Cookie header.
+pub fn extract_cookie_value(
+    headers: &axum::http::HeaderMap,
+    name: &str,
+) -> Option<String> {
+    headers
+        .get("cookie")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|cookies| {
+            cookies.split(';').find_map(|pair| {
+                let pair = pair.trim();
+                let (k, v) = pair.split_once('=')?;
+                if k.trim() == name {
+                    Some(v.trim().to_string())
+                } else {
+                    None
+                }
+            })
+        })
+}
+
+/// Extract API key from Authorization: Bearer <key> header.
+pub fn extract_bearer(headers: &axum::http::HeaderMap) -> Option<String> {
+    headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|header| {
+            if header.len() > 7 && header[..7].eq_ignore_ascii_case("bearer ") {
+                let key = &header[7..];
+                if key.is_empty() {
+                    None
+                } else {
+                    Some(key.to_string())
+                }
+            } else {
+                None
+            }
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -21,5 +61,39 @@ mod tests {
         assert!(!constant_time_eq(b"abc", b"ab"));
         assert!(!constant_time_eq(b"", b"a"));
         assert!(constant_time_eq(b"", b""));
+    }
+
+    #[test]
+    fn test_extract_cookie_value() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(
+            "cookie",
+            "nautiloop_api_key=secret123; nautiloop_engineer=alice"
+                .parse()
+                .unwrap(),
+        );
+        assert_eq!(
+            extract_cookie_value(&headers, "nautiloop_api_key"),
+            Some("secret123".to_string())
+        );
+        assert_eq!(
+            extract_cookie_value(&headers, "nautiloop_engineer"),
+            Some("alice".to_string())
+        );
+        assert_eq!(extract_cookie_value(&headers, "missing"), None);
+    }
+
+    #[test]
+    fn test_extract_bearer() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert("authorization", "Bearer mykey".parse().unwrap());
+        assert_eq!(extract_bearer(&headers), Some("mykey".to_string()));
+    }
+
+    #[test]
+    fn test_extract_bearer_empty() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert("authorization", "Bearer ".parse().unwrap());
+        assert_eq!(extract_bearer(&headers), None);
     }
 }

--- a/control-plane/src/util.rs
+++ b/control-plane/src/util.rs
@@ -1,0 +1,25 @@
+/// Constant-time byte comparison to prevent timing side-channel attacks.
+pub fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_constant_time_eq() {
+        assert!(constant_time_eq(b"abc", b"abc"));
+        assert!(!constant_time_eq(b"abc", b"abd"));
+        assert!(!constant_time_eq(b"abc", b"ab"));
+        assert!(!constant_time_eq(b"", b"a"));
+        assert!(constant_time_eq(b"", b""));
+    }
+}

--- a/docs/dashboard-setup.md
+++ b/docs/dashboard-setup.md
@@ -1,0 +1,62 @@
+# Dashboard Setup
+
+The nautiloop mobile dashboard is a server-rendered web interface served by the control plane at `/dashboard/*`. It provides loop monitoring, one-tap actions (approve/cancel/extend), fleet-level analytics, and a notification feed — all optimized for mobile.
+
+## Security Model
+
+### Primary defense: network-level isolation
+
+The dashboard inherits its security posture from the deployment. **Do not expose `/dashboard` to the public internet without fronting it with an auth proxy.**
+
+The recommended deployment uses Tailscale to restrict access to devices on your tailnet:
+
+1. The control plane binds to a Tailscale IPv4 address (configured in `terraform/examples/hetzner`).
+2. Only devices joined to your tailnet can reach the dashboard.
+3. Add your phone to Tailscale, then bookmark `https://<nautiloop-ts-ipv4>/dashboard`.
+
+This gives you a private surface with zero additional auth infrastructure.
+
+### Secondary defense: API key cookie
+
+The dashboard requires the same shared API key used by `nemo` CLI. On first visit, `/dashboard/login` prompts for the key and an engineer name. On success, an HttpOnly, Secure, SameSite=Strict cookie is set (7-day expiry).
+
+- The cookie is **not readable by JavaScript** (HttpOnly) — XSS cannot exfiltrate the key.
+- The `Secure` flag ensures the cookie is only sent over HTTPS (automatically relaxed for `localhost`/`127.0.0.1` binds during local development).
+- `SameSite=Strict` prevents CSRF from external origins.
+
+Programmatic access via `Authorization: Bearer <key>` header is also supported, matching existing CLI behavior.
+
+### What this is NOT
+
+- **Not a user database.** There are no per-engineer accounts, passwords, or SSO. The cluster has a single shared API key.
+- **Not a permission boundary.** The `Mine` vs `Team` toggle is a view filter. Any authenticated user can see all loops. This matches the CLI's behavior and is appropriate for small, trusted teams.
+
+## Alternative deployments
+
+If you cannot use Tailscale, front the control plane with an auth proxy:
+
+- **oauth2-proxy** — adds Google/GitHub/OIDC sign-in upstream of the dashboard.
+- **Authelia** — self-hosted MFA gateway.
+- **Cloudflare Access / AWS ALB with Cognito** — managed alternatives.
+
+In all cases, the API key cookie remains as defense in depth.
+
+## Pricing configuration
+
+To display cost figures (instead of `—`) throughout the dashboard, add a `[pricing]` section to `nemo.toml`:
+
+```toml
+[pricing]
+[pricing.models]
+"claude-sonnet-4-20250514" = { input_per_million = 3.00, output_per_million = 15.00 }
+"claude-opus-4-20250514"  = { input_per_million = 15.00, output_per_million = 75.00 }
+```
+
+Without this section, token counts are still displayed but all cost fields show `—`. The pricing config is loaded at startup; restart the control plane to pick up changes.
+
+## Quick start
+
+1. Ensure the control plane is running and reachable from your device.
+2. Open `https://<host>/dashboard` in a mobile browser.
+3. Enter the API key and your engineer name on the login page.
+4. The card grid loads with your active loops. Tap any card for details.

--- a/specs/mobile-dashboard.md
+++ b/specs/mobile-dashboard.md
@@ -45,7 +45,7 @@ Today's approve / cancel / extend require the CLI. If the operator is AFK and a 
 | `/dashboard/login` | GET/POST | Login form (API key) + set cookie, then redirect |
 | `/dashboard/logout` | POST | Clear auth cookie |
 | `/dashboard/loops/:id` | GET | Loop detail HTML (drawer or full page) |
-| `/dashboard/stream/:id` | GET (SSE) | Existing `/logs/:id` SSE, re-exposed under dashboard namespace |
+| `/dashboard/stream/:id` | GET (SSE or JSON) | Mirrors existing `/logs/:id` behavior: SSE stream for active loops, JSON array (full log dump) for terminal loops |
 | `/dashboard/static/*` | GET | Embedded CSS + JS assets |
 
 **FR-1b.** Static assets (CSS, single JS file, optional icon/font) are **embedded in the binary** via `include_str!`/`include_bytes!`. No filesystem dependencies at runtime. Total asset budget: <50 KB gzipped.
@@ -56,9 +56,11 @@ Today's approve / cancel / extend require the CLI. If the operator is AFK and a 
 
 **FR-2a.** The dashboard requires the same API key used by `nemo` CLI. Two acceptance paths:
 - **Cookie** `nautiloop_api_key=<key>` (HttpOnly, Secure, SameSite=Strict). Set by `/dashboard/login` form POST. Expires in 7 days.
-- **Bearer header** for API endpoints called from the dashboard JS (same as current CLI → API auth).
+- **Bearer header** (`Authorization: Bearer <key>`) for programmatic access (e.g., curl, external scripts) — same as current CLI → API auth.
 
-**FR-2b.** `/dashboard/login` renders a trivial form: one input (`api_key`), one submit. On POST, validates the key by making an internal `/status` call; if 200, sets the cookie and redirects to `/dashboard`. If invalid, re-renders with an error.
+The dashboard auth middleware accepts **either** a valid cookie **or** a valid Bearer header on any `/dashboard/*` route (except `/login` and `/static/*`). Dashboard JS does **not** read the cookie value; instead, same-origin `fetch()` calls automatically include the HttpOnly cookie. The middleware checks the cookie first, falls back to Bearer. This preserves XSS protection (JS never touches the key) while keeping programmatic access viable.
+
+**FR-2b.** `/dashboard/login` renders a form with two inputs: `api_key` (password field) and `engineer_name` (text field, used for the `Mine` filter — see FR-3e). On POST, validates the API key via constant-time comparison against the `NAUTILOOP_API_KEY` environment variable (same logic as the existing auth middleware — no internal HTTP call). If valid, sets two cookies: `nautiloop_api_key=<key>` (HttpOnly, Secure, SameSite=Strict, 7-day expiry) and `nautiloop_engineer=<name>` (HttpOnly, Secure, SameSite=Strict, 7-day expiry), then redirects to `/dashboard`. If invalid, re-renders the form with an error message. The `engineer_name` field is required; it must match one of the engineer names present in loop data (or be accepted as free-text if no loops exist yet).
 
 **FR-2c.** Unauthenticated requests to any `/dashboard/*` route (other than `/login` and `/static/*`) redirect to `/dashboard/login`.
 
@@ -76,7 +78,7 @@ Today's approve / cancel / extend require the CLI. If the operator is AFK and a 
 - **Title**: spec filename (`health-json-body.md`).
 - **Sub-title**: branch name (muted).
 - **Progress line**: `round N/M · stage: <current_stage>` for active loops; `round N` for terminal.
-- **Metrics row**: tokens (`52K`), cost (`$0.18`), last-round verdict (one of `clean`/`not clean`/`—`).
+- **Metrics row**: tokens (`52K`), cost (`$0.18` — requires `[pricing]` config, see FR-15; displays `—` if pricing is not configured), last-round verdict (one of `clean`/`not clean`/`—`).
 - **Pulse indicator**: small animated dot if state is RUNNING, solid otherwise.
 
 **FR-3c.** Clicking/tapping a card navigates (not modal — actual route change) to `/dashboard/loops/:id`.
@@ -85,7 +87,7 @@ Today's approve / cancel / extend require the CLI. If the operator is AFK and a 
 
 **FR-3e.** Two rows of filter/segment chips at the top of the grid:
 - **State row**: `Active (N)`, `Converged (N)`, `Failed (N)`, `All`. Tapping filters by state.
-- **Engineer row**: one chip per engineer with at least one loop in the current view, plus `Mine` (default) and `Team`. `Mine` scopes to the viewer's own loops (derived from API-key → engineer mapping). `Team` flips the `/dashboard/state?team=true` query and shows all engineers. Individual-engineer chips scope to one engineer.
+- **Engineer row**: one chip per engineer with at least one loop in the current view, plus `Mine` (default) and `Team`. `Mine` scopes to the viewer's own loops, matched by the `nautiloop_engineer` cookie value set at login (see FR-2b) against the loop's `engineer` field. `Team` flips the `/dashboard/state?team=true` query and shows all engineers. Individual-engineer chips scope to one engineer.
 
 Chips are independent: selecting `Active` + `alice` shows Alice's active loops. Default landing state is `Active` + `Mine` — engineers see their own work first.
 
@@ -106,9 +108,9 @@ Chips are independent: selecting `Active` + `alice` shows Alice's active loops. 
   - `Open PR` if spec_pr_url is set (opens in new tab)
 - **Rounds table** (mirrors FR-9 of the helm TUI phase 2 spec): one row per round, columns for stages/verdict/issues/confidence/tokens/cost/duration. Tapping a row expands full verdict details inline.
 - **Live log pane**: last 200 lines, auto-scrolls. SSE stream via `/dashboard/stream/:id` for active loops; static dump for terminal loops.
-- **Token/cost breakdown**: per-stage, per-round (bar chart optional; data table mandatory).
+- **Token/cost breakdown**: per-stage, per-round (bar chart optional; data table mandatory). Token data is extracted from the JSONB `output` column of each round's row: each stage type (`ReviewResultData`, `ImplResultData`, `HardenResultData`) embeds a `token_usage` struct with `input_tokens` and `output_tokens`. The aggregation logic must handle each stage type's struct shape and gracefully display `—` when a stage's output lacks `token_usage`. Cost is computed from token counts using the `[pricing]` config (see FR-15); if pricing is not configured, only raw token counts are shown.
 
-**FR-4b.** The action buttons call the existing API endpoints (`POST /approve/:id`, `DELETE /cancel/:id`, etc.) via fetch with the bearer header derived from the auth cookie. Responses update the card in-place.
+**FR-4b.** The action buttons call the existing API endpoints (`POST /approve/:id`, `DELETE /cancel/:id`, etc.) via same-origin `fetch()`. The HttpOnly auth cookie is sent automatically by the browser; no Bearer header construction is needed (see FR-2a). The existing API auth middleware is extended to accept the cookie in addition to Bearer headers, so these requests authenticate transparently. Responses update the card in-place.
 
 **FR-4c.** Layout on mobile: hero → actions (horizontal scroll if >3 buttons) → rounds table (scrollable) → log tail. On desktop: two-column layout (rounds table left, log tail right).
 
@@ -122,7 +124,7 @@ Chips are independent: selecting `Active` + `alice` shows Alice's active loops. 
 
 **FR-6a.** Dashboard defaults to **system color scheme** (`prefers-color-scheme` media query). Dark by default on mobile operating systems that default dark at night.
 
-**FR-6b.** CSS uses custom properties for all colors, same palette as helm themes (dark/light/high-contrast). Inherits from `[helm] theme` in nemo.toml if set.
+**FR-6b.** CSS uses custom properties for all colors, same palette as helm themes (dark/light/high-contrast). In v1, system `prefers-color-scheme` is the sole source of truth for theme selection — no inheritance from `[helm] theme` in nemo.toml. (The helm TUI theme is a terminal concept with no direct mapping to web CSS custom properties; bridging this is a follow-up if operators request it.)
 
 **FR-6c.** No theme-switcher UI in v1. System-level preference is the source of truth.
 
@@ -143,7 +145,7 @@ Chips are independent: selecting `Active` + `alice` shows Alice's active loops. 
 
 **FR-8a.** Reuses existing endpoints: `/status`, `/inspect?branch=<>`, `/logs/:id`, `/pod-introspect/:id`, `/approve/:id`, `/cancel/:id`, `/resume/:id`, `/extend/:id`.
 
-**FR-8b.** One new JSON endpoint: `GET /dashboard/state` returns a single roll-up object combining all active loops plus aggregates (total tokens, total cost, counts per state). Lets the card grid refresh in one request instead of N+1 (one `/status` + N `/inspect`). Polled every 5s.
+**FR-8b.** One new JSON endpoint: `GET /dashboard/state` returns a single roll-up object combining **all active loops and recently-terminal loops** (terminal within the last 24 hours), plus aggregates (total tokens, total cost, counts per state). Accepts an optional `?include_terminal=all` query parameter to include all terminal loops regardless of age. This ensures that the card grid's filter chips (FR-3e: `Converged`, `Failed`) have data to display after a poll refresh. Lets the card grid refresh in one request instead of N+1 (one `/status` + N `/inspect`). Polled every 5s.
 
 **FR-8c.** `/dashboard/state` is auth-protected same as other `/dashboard/*` routes.
 
@@ -164,13 +166,13 @@ Aggregates all non-terminal + terminal loops in the rolling 7-day window. Fields
 
 **FR-9b.** A subtle trend indicator after each numeric field when a prior-period comparison is available: `82% ↑8% converged` means 8 percentage points higher than the prior 7-day window. First week of data has no trend; don't render the arrow.
 
-**FR-9c.** Tapping any field of the summary navigates to `/dashboard/stats` (FR-12) with that field pre-focused.
+**FR-9c.** Tapping any field of the summary navigates to `/dashboard/stats` (FR-14) with that field pre-focused. Pre-focused means: the URL includes an anchor fragment (e.g., `/dashboard/stats#converge-rate`), the page scrolls to the corresponding section, and a brief highlight animation (CSS `outline` pulse, 2s) draws attention to the relevant headline card or table.
 
 ### FR-10: Kill switch
 
 **FR-10a.** A hidden-by-default `⋯` menu in the header has a destructive `Cancel all active loops` item. Tapping opens a modal: `Cancel N active loops? This cannot be undone.` Two buttons: `Cancel` (aborts) / `Confirm cancel all` (proceeds).
 
-**FR-10b.** On confirm, the dashboard issues `DELETE /cancel/:id` for every active (non-terminal) loop in parallel. Reports `Cancelled N/M loops` in the status bar; failures (rare — usually a race with a loop terminating naturally) are listed with their reasons.
+**FR-10b.** On confirm, the dashboard issues `DELETE /cancel/:id` for every active (non-terminal) loop in parallel. Reports `Cancelled N/M loops` via a dismissible toast notification at the top of the page (auto-dismisses after 10s); failures (rare — usually a race with a loop terminating naturally) are listed inline within the toast with their reasons.
 
 **FR-10c.** Rationale: the dashboard exists precisely because the CTO is AFK. If cost is spiking, credentials are suspected compromised, or a bug is producing runaway loops, the kill switch needs to be one tap from the phone. No new server endpoint; the dashboard fans out to the existing per-loop cancel.
 
@@ -235,6 +237,36 @@ Plus aggregates at the top: `3 runs · 67% converge rate · avg 10.7 rounds · t
 
 **FR-14c.** Cache-friendly: the aggregation is expensive relative to the rest of the dashboard, so the endpoint caches results for 60s server-side (the time-window granularity makes this trivially safe).
 
+### FR-15: Pricing configuration
+
+**FR-15a.** Token-to-cost conversion requires a `[pricing]` section in `nemo.toml`:
+
+```toml
+[pricing]
+# Per-token costs in USD. Supports multiple models since model_implementor
+# and model_reviewer may differ.
+[pricing.models]
+"claude-sonnet-4-20250514" = { input_per_million = 3.00, output_per_million = 15.00 }
+"claude-opus-4-20250514"  = { input_per_million = 15.00, output_per_million = 75.00 }
+```
+
+**FR-15b.** A helper function `compute_cost(token_usage: &TokenUsage, model: &str, pricing: &PricingConfig) -> Option<f64>` lives in the dashboard aggregate module. Returns `None` if the model is not found in the pricing config (graceful degradation — no panic, no default guess).
+
+**FR-15c.** When `[pricing]` is absent from `nemo.toml`, **all cost fields across the dashboard display `—` instead of a dollar amount**. Token counts (raw numbers) are always shown regardless of pricing config. This applies to: FR-3b metrics row, FR-4a token/cost breakdown, FR-9a fleet summary (cost and top-spender fields omitted), FR-12a feed rows, FR-13a history table, FR-14a headline cards and per-engineer/per-spec tables.
+
+**FR-15d.** The pricing config is loaded once at startup and cached in the app state. No hot-reload required in v1; restart the control plane to pick up pricing changes.
+
+### FR-16: JS feature tiers
+
+**FR-16a.** Dashboard JS features are classified into two tiers to guide implementation priority:
+
+| Tier | Features | Required for v1 |
+|---|---|---|
+| **Mandatory** | Card grid polling + diff re-render, action button fetch wiring, SSE log stream subscription, filter chip state, confirm modals | Yes |
+| **Progressive enhancement** | Tab title badge (`(2) nautiloop`), web audio bell on convergence, 1s color fade animation on state transitions, localStorage persistence for feed filters | No — implement if budget allows, skip without blocking launch |
+
+**FR-16b.** All progressive-enhancement features degrade silently: if the JS for them fails or is stripped, the mandatory features continue working. No feature in the progressive tier may block a mandatory feature.
+
 ### NFR-1: Security inherits from deployment
 
 The dashboard is as private as the host. Documented as such. Tailscale-on-Hetzner deployments are private by default; other deployments can front with oauth2-proxy, Authelia, or similar. **Do NOT add sign-in-with-Google or a user database** — that's explicitly out of scope.
@@ -265,8 +297,8 @@ Dashboard routes live under `/dashboard/*`. All existing `/status`, `/inspect`, 
 
 A reviewer can verify by:
 
-1. On a deployed nautiloop, browse to `https://<ts-ipv4>/dashboard` from a phone on the same tailnet. Login form prompts for API key.
-2. Enter the API key. Land on the card grid. At least one loop card is visible with live state.
+1. On a deployed nautiloop, browse to `https://<ts-ipv4>/dashboard` from a phone on the same tailnet. Login form prompts for API key and engineer name.
+2. Enter the API key and engineer name. Land on the card grid. `Mine` filter is active, showing only the logged-in engineer's loops. At least one loop card is visible with live state.
 3. Tap a card. Detail page loads with hero / actions / rounds table / log tail.
 4. On an active loop: live log lines stream in. On a terminal loop: full log dump, no streaming.
 5. Tap Approve on an AWAITING_APPROVAL loop. Response flashes success; card state updates.
@@ -280,6 +312,7 @@ A reviewer can verify by:
 13. `/dashboard/feed` (FR-12) shows chronological terminal events with engineer + outcome + cost. Filter chips work. `Load more` paginates.
 14. Tap a spec filename on any loop detail page → `/dashboard/specs/<path>` (FR-13). Shows all past runs + aggregate metrics.
 15. `/dashboard/stats?window=30d` (FR-14) renders per-engineer + per-spec tables + daily time-series bars. Subsequent loads within 60s hit the cache (observe response time).
+16. With `[pricing]` configured in `nemo.toml`, cost figures appear as dollar amounts throughout the dashboard. Without `[pricing]`, all cost fields show `—` and token counts are still displayed (FR-15).
 
 ## Out of Scope
 
@@ -301,7 +334,7 @@ A reviewer can verify by:
 - `control-plane/src/api/dashboard/mod.rs` — new module.
 - `control-plane/src/api/dashboard/handlers.rs` — per-route handlers.
 - `control-plane/src/api/dashboard/auth.rs` — cookie middleware.
-- `control-plane/src/api/dashboard/aggregate.rs` — `/dashboard/state` roll-up + FR-9 fleet summary + FR-14 stats aggregator (with 60s cache).
+- `control-plane/src/api/dashboard/aggregate.rs` — `/dashboard/state` roll-up + FR-9 fleet summary + FR-14 stats aggregator (with 60s cache) + FR-15 pricing helper (`compute_cost`).
 - `control-plane/src/api/dashboard/feed.rs` — FR-12 notification feed endpoint.
 - `control-plane/src/api/dashboard/specs.rs` — FR-13 per-spec history endpoint.
 - `control-plane/src/api/dashboard/kill_switch.rs` — FR-10 fan-out cancel helper.

--- a/specs/mobile-dashboard.md
+++ b/specs/mobile-dashboard.md
@@ -46,9 +46,13 @@ Today's approve / cancel / extend require the CLI. If the operator is AFK and a 
 | `/dashboard/logout` | POST | Clear auth cookie |
 | `/dashboard/loops/:id` | GET | Loop detail HTML (drawer or full page) |
 | `/dashboard/stream/:id` | GET (SSE or JSON) | Dashboard-specific log proxy: returns the last 200 lines as SSE for active loops (auto-scrolling tail), or a JSON array (full log dump) for terminal loops. Unlike `/logs/:id` which streams the complete log, this endpoint is optimized for the dashboard's live log pane (FR-4a) with a line cap and HTML-safe escaping. |
+| `/dashboard/state` | GET | JSON roll-up of all loops + aggregates (see FR-8b for response schema) |
+| `/dashboard/feed` | GET | JSON feed of terminal events, paginated (see FR-12c for response schema) |
+| `/dashboard/specs` | GET | JSON per-spec history (see FR-13b for response schema) |
+| `/dashboard/stats` | GET | JSON stats deep-dive with aggregation (see FR-14b for response schema) |
 | `/dashboard/static/*` | GET | Embedded CSS + JS assets |
 
-**FR-1b.** Static assets (CSS, single JS file, optional icon/font) are **embedded in the binary** via `include_str!`/`include_bytes!`. No filesystem dependencies at runtime. Total asset budget: <50 KB gzipped.
+**FR-1b.** Static assets (CSS, single JS file, optional icon/font) are **embedded in the binary** via `include_str!`/`include_bytes!`. No filesystem dependencies at runtime. Total asset budget: <25 KB gzipped (leaving headroom for HTML within the NFR-2 page-weight budget of <30 KB gzipped).
 
 **FR-1c.** All dashboard HTML is server-rendered (axum handler returns `Html<String>`). Templating via `askama` (compile-time, already a family of the rust ecosystem) or `maud` — pick one, stick with it. No SPA framework. No React/Vue/Svelte.
 
@@ -60,7 +64,7 @@ Today's approve / cancel / extend require the CLI. If the operator is AFK and a 
 
 The dashboard auth middleware accepts **either** a valid cookie **or** a valid Bearer header on any `/dashboard/*` route (except `/login` and `/static/*`). Dashboard JS does **not** read the cookie value; instead, same-origin `fetch()` calls automatically include the HttpOnly cookie. The middleware checks the cookie first, falls back to Bearer. This preserves XSS protection (JS never touches the key) while keeping programmatic access viable.
 
-**Local development note:** The `Secure` flag prevents cookies from being sent over plain HTTP. When the bind address is `127.0.0.1` or `localhost`, the `Secure` flag should be conditionally omitted so that authentication works without TLS. Production deployments (non-localhost bind) MUST always set `Secure`.
+**Local development note:** The `Secure` flag prevents cookies from being sent over plain HTTP. When the configured bind address (from `NautiloopConfig` or `NAUTILOOP_BIND_ADDR`) is `127.0.0.1`, `[::1]`, or `localhost`, the `Secure` flag should be conditionally omitted so that authentication works without TLS. Production deployments (non-localhost bind) MUST always set `Secure`.
 
 **FR-2b.** `/dashboard/login` renders a form with two inputs: `api_key` (password field) and `engineer_name` (text field, used for the `Mine` filter — see FR-3e). On POST, validates the API key via constant-time comparison against the `NAUTILOOP_API_KEY` environment variable (same logic as the existing auth middleware — no internal HTTP call). If valid, sets two cookies: `nautiloop_api_key=<key>` (HttpOnly, Secure, SameSite=Strict, 7-day expiry) and `nautiloop_engineer=<name>` (HttpOnly, Secure, SameSite=Strict, 7-day expiry), then redirects to `/dashboard`. If invalid, re-renders the form with an error message. The `engineer_name` field is required; it is always accepted as free-text (self-declared, not validated against loop data). This is consistent with the CLI, which accepts any engineer name on `nemo start`. The value is used solely for the `Mine` filter (FR-3e).
 
@@ -95,7 +99,7 @@ The dashboard auth middleware accepts **either** a valid cookie **or** a valid B
 
 **FR-3c.** Clicking/tapping a card navigates (not modal — actual route change) to `/dashboard/loops/:id`.
 
-**FR-3d.** Card grid auto-refreshes every 5s via a small vanilla-JS poll that fetches `/status` and re-renders card fields in place (no full page reload). State transitions animate with a 1s color fade on the badge.
+**FR-3d.** Card grid auto-refreshes every 5s via a small vanilla-JS poll that fetches `/dashboard/state` (FR-8b) and re-renders card fields in place (no full page reload). State transitions animate with a 1s color fade on the badge.
 
 **FR-3e.** Two rows of filter/segment chips at the top of the grid:
 - **State row**: `Active (N)`, `Converged (N)`, `Failed (N)`, `All`. Tapping filters by state.
@@ -118,7 +122,7 @@ Chips are independent: selecting `Active` + `alice` shows Alice's active loops. 
   - `Resume` if state in {PAUSED, AWAITING_REAUTH, transient FAILED}
   - `Extend +10` if state == FAILED with failed_from_state
   - `Open PR` if spec_pr_url is set (opens in new tab)
-- **Rounds table**: one row per round. Columns: round number, stage (Implement/Test/Review/Revise/Harden), verdict (`clean`/`not clean`/`—`), issues count, confidence score, tokens (input + output), cost (or `—`), duration. Tapping a row expands full verdict details inline.
+- **Rounds table**: one row per round. Columns: round number, stage (Implement/Test/Review/Revise/Harden), verdict (`clean`/`not clean`/`—`), issues count, confidence score, tokens (input + output), cost (or `—`), duration. Tapping a row expands full verdict details inline. **Note:** The `/dashboard/loops/:id` handler queries the `rounds` table directly (not via `/inspect`) to access `duration_secs`, `started_at`, and `completed_at` fields that `/inspect` does not currently expose.
 - **Live log pane**: last 200 lines, auto-scrolls. SSE stream via `/dashboard/stream/:id` for active loops; static dump for terminal loops.
 - **Token/cost breakdown**: per-stage, per-round (bar chart optional; data table mandatory). Token data is extracted from the JSONB `output` column of each round's row. The five stage output types that may contain token data are: `ImplResultData`, `TestResultData`, `ReviewResultData`, `ReviseResultData`, and `AuditVerdict`. Each embeds a `token_usage: TokenUsage` struct with fields `input: u64` and `output: u64` (matching the `TokenUsage` struct in `control-plane/src/types/verdict.rs`). The aggregation logic must handle all five stage types and gracefully display `—` when a stage's output lacks `token_usage`. Cost is computed from token counts using the `[pricing]` config (see FR-15); if pricing is not configured, only raw token counts are shown.
 
@@ -136,7 +140,7 @@ Chips are independent: selecting `Active` + `alice` shows Alice's active loops. 
 
 **FR-6a.** Dashboard defaults to **system color scheme** (`prefers-color-scheme` media query). Dark by default on mobile operating systems that default dark at night.
 
-**FR-6b.** CSS uses custom properties for all colors, same palette as helm themes (dark/light/high-contrast). In v1, system `prefers-color-scheme` is the sole source of truth for theme selection — no inheritance from `[helm] theme` in nemo.toml. (The helm TUI theme is a terminal concept with no direct mapping to web CSS custom properties; bridging this is a follow-up if operators request it.)
+**FR-6b.** CSS uses custom properties for all colors. The dark palette is inspired by the helm TUI dark theme (`BG #0f0f0e`, `SURFACE #1a1918`, `TEAL #1b6b5a`, `AMBER #e8a838`, `GREEN #2d7a4f`, `RED #c4392d`, `BLUE #3b7bc0`). The light palette inverts luminance (light backgrounds, dark text) — the dashboard defines its own light-mode values since no light theme exists in the helm TUI. High-contrast is a follow-up. In v1, system `prefers-color-scheme` is the sole source of truth for theme selection — no inheritance from `[helm] theme` in nemo.toml. (The helm TUI theme is a terminal concept with no direct mapping to web CSS custom properties; bridging this is a follow-up if operators request it.)
 
 **FR-6c.** No theme-switcher UI in v1. System-level preference is the source of truth.
 
@@ -281,7 +285,7 @@ Fields with `total_cost` or per-loop `total_cost` are `null` when `[pricing]` is
 }
 ```
 
-**FR-8c.** `/dashboard/state` is auth-protected same as other `/dashboard/*` routes.
+**FR-8c.** All `/dashboard/*` JSON endpoints (`/dashboard/state`, `/dashboard/feed`, `/dashboard/specs`, `/dashboard/stats`) are auth-protected same as other `/dashboard/*` routes (see FR-2a, FR-2c).
 
 ### FR-9: CTO kit — fleet summary header
 
@@ -385,6 +389,12 @@ Plus aggregates at the top: `3 runs · 67% converge rate · avg 10.7 rounds · t
 ```
 
 **FR-15b.** A helper function `compute_cost(token_usage: &TokenUsage, model: &str, pricing: &PricingConfig) -> Option<f64>` lives in the dashboard aggregate module. Returns `None` if the model is not found in the pricing config (graceful degradation — no panic, no default guess).
+
+**Stage→model mapping for per-round cost computation:** Each round's cost requires knowing which model was used. The mapping is:
+- **Implement, Revise, Test** stages → use the loop's `model_implementor` field
+- **Review, Audit (Harden)** stages → use the loop's `model_reviewer` field
+
+**Fallback chain:** loop-level field (`model_implementor` or `model_reviewer`) → `NautiloopConfig` default model for that role → `None` (display `—`). If the resolved model string is not present in the `[pricing.models]` table, `compute_cost` returns `None`.
 
 **FR-15c.** When `[pricing]` is absent from `nemo.toml`, **all cost fields across the dashboard display `—` instead of a dollar amount**. Token counts (raw numbers) are always shown regardless of pricing config. This applies to: FR-3b metrics row, FR-4a token/cost breakdown, FR-9a fleet summary (cost and top-spender fields omitted), FR-12a feed rows, FR-13a history table, FR-14a headline cards and per-engineer/per-spec tables.
 

--- a/specs/mobile-dashboard.md
+++ b/specs/mobile-dashboard.md
@@ -68,6 +68,8 @@ The dashboard auth middleware accepts **either** a valid cookie **or** a valid B
 
 **FR-2b.** `/dashboard/login` renders a form with two inputs: `api_key` (password field) and `engineer_name` (text field, used for the `Mine` filter — see FR-3e). On POST, validates the API key via constant-time comparison against the `NAUTILOOP_API_KEY` environment variable (same logic as the existing auth middleware — no internal HTTP call). If valid, sets two cookies: `nautiloop_api_key=<key>` (HttpOnly, Secure, SameSite=Strict, 7-day expiry) and `nautiloop_engineer=<name>` (HttpOnly, Secure, SameSite=Strict, 7-day expiry), then redirects to `/dashboard`. If invalid, re-renders the form with an error message. The `engineer_name` field is required; it is always accepted as free-text (self-declared, not validated against loop data). This is consistent with the CLI, which accepts any engineer name on `nemo start`. The value is used solely for the `Mine` filter (FR-3e).
 
+**Engineer identity for client-side JS:** The `nautiloop_engineer` cookie is HttpOnly and cannot be read by JavaScript. To allow the dashboard JS to know the current viewer's engineer name (needed for client-side filter chip rendering and "Mine" highlighting), the `/dashboard/state` response includes a `viewer` field containing the requesting engineer's name (read server-side from the cookie). See FR-8b response schema. The server-rendered HTML also embeds the engineer name as a `data-viewer` attribute on the `<body>` element for initial page load before the first poll.
+
 **FR-2c.** Unauthenticated requests to any `/dashboard/*` route (other than `/login` and `/static/*`) redirect to `/dashboard/login`.
 
 **FR-2d.** Deployment-level security (Tailscale, VPN, or an external auth proxy like oauth2-proxy) is the primary defense. The API-key cookie is defense in depth, not the only barrier. Documented explicitly in the dashboard README: **do not expose `/dashboard` to the public internet without fronting it with auth.**
@@ -95,7 +97,7 @@ The dashboard auth middleware accepts **either** a valid cookie **or** a valid B
 - **Sub-title**: branch name (muted).
 - **Progress line**: `round N/M · stage: <current_stage>` for active loops; `round N` for terminal.
 - **Metrics row**: tokens (`52K`), cost (`$0.18` — requires `[pricing]` config, see FR-15; displays `—` if pricing is not configured), last-round verdict (one of `clean`/`not clean`/`—`).
-- **Pulse indicator**: small animated dot if `sub_state` is `Running` (i.e., the loop is in an active stage with a dispatched job currently executing), solid dot for all other states.
+- **Pulse indicator**: animated dot if `sub_state` is `Running` (i.e., the loop is in an active stage with a dispatched job currently executing); slow-pulsing hollow dot if `sub_state` is `Dispatched` (job submitted to k8s but not yet running — distinguishes "waiting for pod" from "actively executing"); solid dot for `Completed` and all terminal states.
 
 **FR-3c.** Clicking/tapping a card navigates (not modal — actual route change) to `/dashboard/loops/:id`.
 
@@ -122,9 +124,9 @@ Chips are independent: selecting `Active` + `alice` shows Alice's active loops. 
   - `Resume` if state in {PAUSED, AWAITING_REAUTH, transient FAILED}
   - `Extend +10` if state == FAILED with failed_from_state
   - `Open PR` if spec_pr_url is set (opens in new tab)
-- **Rounds table**: one row per round. Columns: round number, stage (Implement/Test/Review/Revise/Harden), verdict (`clean`/`not clean`/`—`), issues count, confidence score, tokens (input + output), cost (or `—`), duration. Tapping a row expands full verdict details inline. **Note:** The `/dashboard/loops/:id` handler queries the `rounds` table directly (not via `/inspect`) to access `duration_secs`, `started_at`, and `completed_at` fields that `/inspect` does not currently expose.
+- **Rounds table**: one row per round. Columns: round number, stage (Implement/Test/Review/Revise/Harden), verdict (`clean`/`not clean`/`—`), issues count, confidence score, tokens (input + output), cost (or `—`), duration. Tapping a row expands stage-specific details inline: for `review` and `audit` stages, this shows the full verdict (issues array, confidence score, summary text); for `implement` and `revise` stages, shows `new_sha` and exit code; for `test` stages, shows test result summary and exit code. Stages whose output lacks structured detail expand to show raw output fields or a `—` placeholder. **Note:** The `/dashboard/loops/:id` handler queries the `rounds` table directly (not via `/inspect`) to access `duration_secs`, `started_at`, and `completed_at` fields that `/inspect` does not currently expose.
 - **Live log pane**: last 200 lines, auto-scrolls. SSE stream via `/dashboard/stream/:id` for active loops; static dump for terminal loops.
-- **Token/cost breakdown**: per-stage, per-round (bar chart optional; data table mandatory). Token data is extracted from the JSONB `output` column of each round's row. The five stage output types that may contain token data are: `ImplResultData`, `TestResultData`, `ReviewResultData`, `ReviseResultData`, and `AuditVerdict`. Each embeds a `token_usage: TokenUsage` struct with fields `input: u64` and `output: u64` (matching the `TokenUsage` struct in `control-plane/src/types/verdict.rs`). The aggregation logic must handle all five stage types and gracefully display `—` when a stage's output lacks `token_usage`. Cost is computed from token counts using the `[pricing]` config (see FR-15); if pricing is not configured, only raw token counts are shown.
+- **Token/cost breakdown**: per-stage, per-round (bar chart optional; data table mandatory). Token data is extracted from the JSONB `output` column of each round's row. The five stage output types that may contain token data are: `ImplResultData`, `TestResultData`, `ReviewResultData` (used for both review and audit/harden stages), and `ReviseResultData`. Note: audit-stage rounds store their output as `ReviewResultData` wrapping an `AuditVerdict` inner struct — deserialize as `ReviewResultData`, not `AuditVerdict` directly. Each embeds a `token_usage: TokenUsage` struct with fields `input: u64` and `output: u64` (matching the `TokenUsage` struct in `control-plane/src/types/verdict.rs`). The aggregation logic must handle all five stage types and gracefully display `—` when a stage's output lacks `token_usage`. Cost is computed from token counts using the `[pricing]` config (see FR-15); if pricing is not configured, only raw token counts are shown.
 
 **FR-4b.** The action buttons call the existing API endpoints (`POST /approve/:id`, `DELETE /cancel/:id`, etc.) via same-origin `fetch()`. The HttpOnly auth cookie is sent automatically by the browser; no Bearer header construction is needed (see FR-2a). The existing API auth middleware is extended to accept the cookie in addition to Bearer headers, so these requests authenticate transparently. Responses update the card in-place.
 
@@ -209,11 +211,14 @@ Chips are independent: selecting `Active` + `alice` shows Alice's active loops. 
       "avg_rounds_delta": -0.3
     }
   },
-  "engineers": ["alice", "bob", "dev"]
+  "engineers": ["alice", "bob", "dev"],
+  "viewer": "alice"
 }
 ```
 
 Fields with `total_cost` or per-loop `total_cost` are `null` when `[pricing]` is not configured. `trends` is `null` when insufficient historical data exists (first week).
+
+**Caching note:** The `fleet_summary` block within `/dashboard/state` involves an expensive 7-day window aggregation, but this endpoint is polled every 5s (FR-3d). To avoid redundant computation, the server MUST cache the `fleet_summary` portion for 60s (same strategy as FR-14c for `/dashboard/stats`). The per-loop `loops` array, `aggregates`, and `engineers` fields are recomputed on every poll (these are cheap queries over active + recent-terminal loops). The cached `fleet_summary` is refreshed independently on a 60s TTL.
 
 **Response schema for `/dashboard/feed`:**
 
@@ -343,7 +348,7 @@ Each row is tappable → navigates to the loop detail page.
 
 **FR-12b.** Filters at the top: `All events` / `Converged only` / `Failed only` / per-engineer. Persists selection in localStorage across visits.
 
-**FR-12c.** Pagination: loads the 50 most recent; `Load more` button at the bottom fetches the next 50. Backed by a new endpoint `GET /dashboard/feed?cursor=<timestamp>&limit=50` that returns terminal loops ordered by `updated_at DESC`.
+**FR-12c.** Pagination: loads the 50 most recent; `Load more` button at the bottom fetches the next 50. Backed by a new endpoint `GET /dashboard/feed?cursor=<timestamp>&limit=50` (note: `&` is a literal ampersand query-parameter separator) that returns terminal loops ordered by `updated_at DESC`.
 
 **FR-12d.** This is the CTO's morning-coffee surface: skim, see what shipped overnight, note what failed, close the tab. Must load in under a second on a mobile connection.
 
@@ -359,7 +364,7 @@ Each row is tappable → navigates to the loop detail page.
 
 Plus aggregates at the top: `3 runs · 67% converge rate · avg 10.7 rounds · total cost $4.52`.
 
-**FR-13b.** Backed by a new endpoint `GET /dashboard/specs?path=<>&limit=50` returning loops filtered by `spec_path`. Existing schema already has `spec_path`, no migration.
+**FR-13b.** Backed by a new endpoint `GET /dashboard/specs?path=<url-encoded-path>&limit=50` (note: `&` is a literal ampersand query-parameter separator) returning loops filtered by `spec_path`. Existing schema already has `spec_path`, no migration.
 
 **FR-13c.** Use case: a spec that fails 3x in a row or consistently takes 15 rounds is a spec-quality problem, not an implementor problem. Visibility surfaces this. Helps engineers tighten specs before submitting again.
 
@@ -390,15 +395,17 @@ Plus aggregates at the top: `3 runs · 67% converge rate · avg 10.7 rounds · t
 
 **FR-15b.** A helper function `compute_cost(token_usage: &TokenUsage, model: &str, pricing: &PricingConfig) -> Option<f64>` lives in the dashboard aggregate module. Returns `None` if the model is not found in the pricing config (graceful degradation — no panic, no default guess).
 
-**Stage→model mapping for per-round cost computation:** Each round's cost requires knowing which model was used. The mapping is:
-- **Implement, Revise, Test** stages → use the loop's `model_implementor` field
-- **Review, Audit (Harden)** stages → use the loop's `model_reviewer` field
+**Stage→model mapping for per-round cost computation:** Each round's cost requires knowing which model was used. The round `stage` column stores lowercase strings: `"implement"`, `"test"`, `"review"`, `"audit"`, `"revise"`. The mapping is:
+- **`implement`, `revise`, `test`** stages → use the loop's `model_implementor` field
+- **`review` and `audit`** stages → use the loop's `model_reviewer` field. (The `"audit"` stage runs during the `Hardening` LoopState — these are distinct concepts: `stage` is the rounds-table value, `Hardening` is the loop-level state.)
 
 **Fallback chain:** loop-level field (`model_implementor` or `model_reviewer`) → `NautiloopConfig` default model for that role → `None` (display `—`). If the resolved model string is not present in the `[pricing.models]` table, `compute_cost` returns `None`.
 
 **FR-15c.** When `[pricing]` is absent from `nemo.toml`, **all cost fields across the dashboard display `—` instead of a dollar amount**. Token counts (raw numbers) are always shown regardless of pricing config. This applies to: FR-3b metrics row, FR-4a token/cost breakdown, FR-9a fleet summary (cost and top-spender fields omitted), FR-12a feed rows, FR-13a history table, FR-14a headline cards and per-engineer/per-spec tables.
 
 **FR-15d.** The pricing config is loaded once at startup and cached in the app state. No hot-reload required in v1; restart the control plane to pick up pricing changes.
+
+**FR-15e.** `NautiloopConfig` in `control-plane/src/config/mod.rs` must be extended with an optional `pricing: Option<PricingConfig>` field. `PricingConfig` contains a `models: HashMap<String, ModelPricing>` where `ModelPricing` has `input_per_million: f64` and `output_per_million: f64`. The field is `Option` so that existing `nemo.toml` files without `[pricing]` continue to deserialize without error. No database migration required — this is config-only.
 
 ### FR-16: JS feature tiers
 
@@ -485,6 +492,7 @@ A reviewer can verify by:
 - `control-plane/src/api/dashboard/templates/` — new dir, Askama `.html` templates (or `maud!{}` macros in `.rs` files).
 - `control-plane/assets/dashboard.css` — embedded via `include_str!`.
 - `control-plane/assets/dashboard.js` — embedded via `include_str!`.
+- `control-plane/src/config/mod.rs` — add optional `pricing: Option<PricingConfig>` field to `NautiloopConfig` + `PricingConfig` / `ModelPricing` structs (FR-15e).
 - `control-plane/Cargo.toml` — add `askama` (use latest compatible 0.12.x or newer) and `askama_axum` for response helpers. Or `maud` if that was chosen per FR-1c.
 - Tests per NFR-6.
 - `docs/dashboard-setup.md` — new doc covering the security model (Tailscale as default, explicit warning about public exposure).

--- a/specs/mobile-dashboard.md
+++ b/specs/mobile-dashboard.md
@@ -45,7 +45,7 @@ Today's approve / cancel / extend require the CLI. If the operator is AFK and a 
 | `/dashboard/login` | GET/POST | Login form (API key) + set cookie, then redirect |
 | `/dashboard/logout` | POST | Clear auth cookie |
 | `/dashboard/loops/:id` | GET | Loop detail HTML (drawer or full page) |
-| `/dashboard/stream/:id` | GET (SSE or JSON) | Mirrors existing `/logs/:id` behavior: SSE stream for active loops, JSON array (full log dump) for terminal loops |
+| `/dashboard/stream/:id` | GET (SSE or JSON) | Dashboard-specific log proxy: returns the last 200 lines as SSE for active loops (auto-scrolling tail), or a JSON array (full log dump) for terminal loops. Unlike `/logs/:id` which streams the complete log, this endpoint is optimized for the dashboard's live log pane (FR-4a) with a line cap and HTML-safe escaping. |
 | `/dashboard/static/*` | GET | Embedded CSS + JS assets |
 
 **FR-1b.** Static assets (CSS, single JS file, optional icon/font) are **embedded in the binary** via `include_str!`/`include_bytes!`. No filesystem dependencies at runtime. Total asset budget: <50 KB gzipped.
@@ -60,7 +60,9 @@ Today's approve / cancel / extend require the CLI. If the operator is AFK and a 
 
 The dashboard auth middleware accepts **either** a valid cookie **or** a valid Bearer header on any `/dashboard/*` route (except `/login` and `/static/*`). Dashboard JS does **not** read the cookie value; instead, same-origin `fetch()` calls automatically include the HttpOnly cookie. The middleware checks the cookie first, falls back to Bearer. This preserves XSS protection (JS never touches the key) while keeping programmatic access viable.
 
-**FR-2b.** `/dashboard/login` renders a form with two inputs: `api_key` (password field) and `engineer_name` (text field, used for the `Mine` filter — see FR-3e). On POST, validates the API key via constant-time comparison against the `NAUTILOOP_API_KEY` environment variable (same logic as the existing auth middleware — no internal HTTP call). If valid, sets two cookies: `nautiloop_api_key=<key>` (HttpOnly, Secure, SameSite=Strict, 7-day expiry) and `nautiloop_engineer=<name>` (HttpOnly, Secure, SameSite=Strict, 7-day expiry), then redirects to `/dashboard`. If invalid, re-renders the form with an error message. The `engineer_name` field is required; it must match one of the engineer names present in loop data (or be accepted as free-text if no loops exist yet).
+**Local development note:** The `Secure` flag prevents cookies from being sent over plain HTTP. When the bind address is `127.0.0.1` or `localhost`, the `Secure` flag should be conditionally omitted so that authentication works without TLS. Production deployments (non-localhost bind) MUST always set `Secure`.
+
+**FR-2b.** `/dashboard/login` renders a form with two inputs: `api_key` (password field) and `engineer_name` (text field, used for the `Mine` filter — see FR-3e). On POST, validates the API key via constant-time comparison against the `NAUTILOOP_API_KEY` environment variable (same logic as the existing auth middleware — no internal HTTP call). If valid, sets two cookies: `nautiloop_api_key=<key>` (HttpOnly, Secure, SameSite=Strict, 7-day expiry) and `nautiloop_engineer=<name>` (HttpOnly, Secure, SameSite=Strict, 7-day expiry), then redirects to `/dashboard`. If invalid, re-renders the form with an error message. The `engineer_name` field is required; it is always accepted as free-text (self-declared, not validated against loop data). This is consistent with the CLI, which accepts any engineer name on `nemo start`. The value is used solely for the `Mine` filter (FR-3e).
 
 **FR-2c.** Unauthenticated requests to any `/dashboard/*` route (other than `/login` and `/static/*`) redirect to `/dashboard/login`.
 
@@ -74,12 +76,22 @@ The dashboard auth middleware accepts **either** a valid cookie **or** a valid B
 - **Desktop (> 1024px)**: three or four columns, adjusts on viewport.
 
 **FR-3b.** Each card shows for one loop:
-- **Header row**: state badge (colored pill: IMPLEMENTING/REVIEWING/CONVERGED/FAILED/etc.), loop_id short form (first 8 chars), elapsed time since `created_at` (`3m 22s` / `1h 14m`).
+- **Header row**: state badge (colored pill — see badge color map below), loop_id short form (first 8 chars), elapsed time since `created_at` (`3m 22s` / `1h 14m`).
+
+**Badge color map** — all 13 `LoopState` variants must have an assigned color:
+
+| Color | States |
+|---|---|
+| Green | `Converged`, `Hardened`, `Shipped` |
+| Red | `Failed`, `Cancelled` |
+| Amber | `AwaitingApproval`, `Paused`, `AwaitingReauth` |
+| Blue | `Implementing`, `Testing`, `Reviewing`, `Hardening` |
+| Gray | `Pending` |
 - **Title**: spec filename (`health-json-body.md`).
 - **Sub-title**: branch name (muted).
 - **Progress line**: `round N/M · stage: <current_stage>` for active loops; `round N` for terminal.
 - **Metrics row**: tokens (`52K`), cost (`$0.18` — requires `[pricing]` config, see FR-15; displays `—` if pricing is not configured), last-round verdict (one of `clean`/`not clean`/`—`).
-- **Pulse indicator**: small animated dot if state is RUNNING, solid otherwise.
+- **Pulse indicator**: small animated dot if `sub_state` is `Running` (i.e., the loop is in an active stage with a dispatched job currently executing), solid dot for all other states.
 
 **FR-3c.** Clicking/tapping a card navigates (not modal — actual route change) to `/dashboard/loops/:id`.
 
@@ -106,9 +118,9 @@ Chips are independent: selecting `Active` + `alice` shows Alice's active loops. 
   - `Resume` if state in {PAUSED, AWAITING_REAUTH, transient FAILED}
   - `Extend +10` if state == FAILED with failed_from_state
   - `Open PR` if spec_pr_url is set (opens in new tab)
-- **Rounds table** (mirrors FR-9 of the helm TUI phase 2 spec): one row per round, columns for stages/verdict/issues/confidence/tokens/cost/duration. Tapping a row expands full verdict details inline.
+- **Rounds table**: one row per round. Columns: round number, stage (Implement/Test/Review/Revise/Harden), verdict (`clean`/`not clean`/`—`), issues count, confidence score, tokens (input + output), cost (or `—`), duration. Tapping a row expands full verdict details inline.
 - **Live log pane**: last 200 lines, auto-scrolls. SSE stream via `/dashboard/stream/:id` for active loops; static dump for terminal loops.
-- **Token/cost breakdown**: per-stage, per-round (bar chart optional; data table mandatory). Token data is extracted from the JSONB `output` column of each round's row: each stage type (`ReviewResultData`, `ImplResultData`, `HardenResultData`) embeds a `token_usage` struct with `input_tokens` and `output_tokens`. The aggregation logic must handle each stage type's struct shape and gracefully display `—` when a stage's output lacks `token_usage`. Cost is computed from token counts using the `[pricing]` config (see FR-15); if pricing is not configured, only raw token counts are shown.
+- **Token/cost breakdown**: per-stage, per-round (bar chart optional; data table mandatory). Token data is extracted from the JSONB `output` column of each round's row. The five stage output types that may contain token data are: `ImplResultData`, `TestResultData`, `ReviewResultData`, `ReviseResultData`, and `AuditVerdict`. Each embeds a `token_usage: TokenUsage` struct with fields `input: u64` and `output: u64` (matching the `TokenUsage` struct in `control-plane/src/types/verdict.rs`). The aggregation logic must handle all five stage types and gracefully display `—` when a stage's output lacks `token_usage`. Cost is computed from token counts using the `[pricing]` config (see FR-15); if pricing is not configured, only raw token counts are shown.
 
 **FR-4b.** The action buttons call the existing API endpoints (`POST /approve/:id`, `DELETE /cancel/:id`, etc.) via same-origin `fetch()`. The HttpOnly auth cookie is sent automatically by the browser; no Bearer header construction is needed (see FR-2a). The existing API auth middleware is extended to accept the cookie in addition to Bearer headers, so these requests authenticate transparently. Responses update the card in-place.
 
@@ -145,7 +157,129 @@ Chips are independent: selecting `Active` + `alice` shows Alice's active loops. 
 
 **FR-8a.** Reuses existing endpoints: `/status`, `/inspect?branch=<>`, `/logs/:id`, `/pod-introspect/:id`, `/approve/:id`, `/cancel/:id`, `/resume/:id`, `/extend/:id`.
 
-**FR-8b.** One new JSON endpoint: `GET /dashboard/state` returns a single roll-up object combining **all active loops and recently-terminal loops** (terminal within the last 24 hours), plus aggregates (total tokens, total cost, counts per state). Accepts an optional `?include_terminal=all` query parameter to include all terminal loops regardless of age. This ensures that the card grid's filter chips (FR-3e: `Converged`, `Failed`) have data to display after a poll refresh. Lets the card grid refresh in one request instead of N+1 (one `/status` + N `/inspect`). Polled every 5s.
+**FR-8b.** One new JSON endpoint: `GET /dashboard/state` returns a single roll-up object combining **all active loops and recently-terminal loops** (terminal within the last 24 hours), plus aggregates (total tokens, total cost, counts per state). Accepts optional query parameters: `?include_terminal=all` to include all terminal loops regardless of age, `?team=true` to include all engineers' loops (default: scoped to the requesting engineer via cookie). This ensures that the card grid's filter chips (FR-3e: `Converged`, `Failed`) have data to display after a poll refresh. Lets the card grid refresh in one request instead of N+1 (one `/status` + N `/inspect`). Polled every 5s.
+
+**Response schema for `/dashboard/state`:**
+
+```json
+{
+  "loops": [
+    {
+      "id": "uuid",
+      "spec_path": "specs/foo.md",
+      "branch": "agent/alice/foo-a1b2c3d4",
+      "engineer": "alice",
+      "state": "Implementing",
+      "sub_state": "Running",
+      "round": 3,
+      "max_rounds": 15,
+      "current_stage": "implement",
+      "created_at": "2026-04-18T12:00:00Z",
+      "updated_at": "2026-04-18T12:05:00Z",
+      "spec_pr_url": "https://github.com/org/repo/pull/147",
+      "failed_from_state": null,
+      "last_verdict": "not clean",
+      "total_tokens": { "input": 42000, "output": 10000 },
+      "total_cost": 0.18
+    }
+  ],
+  "aggregates": {
+    "counts_by_state": {
+      "Implementing": 2,
+      "Converged": 5,
+      "Failed": 1
+    },
+    "total_tokens": { "input": 500000, "output": 120000 },
+    "total_cost": 12.40,
+    "total_loops": 8
+  },
+  "fleet_summary": {
+    "window_days": 7,
+    "total_loops": 47,
+    "total_cost": 12.40,
+    "converge_rate": 0.82,
+    "avg_rounds": 4.2,
+    "top_spender": { "engineer": "alice", "cost": 4.80 },
+    "trends": {
+      "converge_rate_delta": 0.08,
+      "avg_rounds_delta": -0.3
+    }
+  },
+  "engineers": ["alice", "bob", "dev"]
+}
+```
+
+Fields with `total_cost` or per-loop `total_cost` are `null` when `[pricing]` is not configured. `trends` is `null` when insufficient historical data exists (first week).
+
+**Response schema for `/dashboard/feed`:**
+
+```json
+{
+  "events": [
+    {
+      "id": "uuid",
+      "spec_path": "specs/foo.md",
+      "engineer": "alice",
+      "state": "Converged",
+      "rounds": 2,
+      "total_tokens": { "input": 42000, "output": 10000 },
+      "total_cost": 0.18,
+      "spec_pr_url": "https://github.com/org/repo/pull/147",
+      "updated_at": "2026-04-18T15:47:00Z",
+      "extensions": 0
+    }
+  ],
+  "has_more": true
+}
+```
+
+**Response schema for `/dashboard/specs`:**
+
+```json
+{
+  "spec_path": "specs/foo.md",
+  "runs": [
+    {
+      "id": "uuid",
+      "engineer": "alice",
+      "state": "Converged",
+      "rounds": 2,
+      "total_cost": 0.18,
+      "branch": "agent/alice/foo-a1b2c3d4",
+      "created_at": "2026-04-18T15:47:00Z"
+    }
+  ],
+  "aggregates": {
+    "total_runs": 3,
+    "converge_rate": 0.67,
+    "avg_rounds": 10.7,
+    "total_cost": 4.52
+  }
+}
+```
+
+**Response schema for `/dashboard/stats`:**
+
+```json
+{
+  "window": "7d",
+  "headline": {
+    "total_loops": 47,
+    "total_cost": 12.40,
+    "converge_rate": 0.82,
+    "avg_rounds": 4.2
+  },
+  "per_engineer": [
+    { "engineer": "alice", "loops": 20, "cost": 4.80, "converge_rate": 0.90 }
+  ],
+  "per_spec": [
+    { "spec_path": "specs/foo.md", "runs": 5, "cost": 2.10, "converge_rate": 0.80, "avg_rounds": 3.5 }
+  ],
+  "time_series": [
+    { "date": "2026-04-18", "started": 8, "converged": 5, "failed": 1 }
+  ]
+}
+```
 
 **FR-8c.** `/dashboard/state` is auth-protected same as other `/dashboard/*` routes.
 
@@ -211,7 +345,7 @@ Each row is tappable → navigates to the loop detail page.
 
 ### FR-13: Per-spec history
 
-**FR-13a.** In the loop detail view, the spec filename is a link. Tapping navigates to `/dashboard/specs/<path>` which shows all past loops that ran on that spec:
+**FR-13a.** In the loop detail view, the spec filename is a link. Tapping navigates to `/dashboard/specs?path=<url-encoded-path>` (query-parameter form, consistent with the backing endpoint in FR-13b, avoids multi-segment path routing issues in axum). Shows all past loops that ran on that spec:
 
 | Date | Engineer | Result | Rounds | Cost | Branch |
 |---|---|---|---|---|---|
@@ -310,7 +444,7 @@ A reviewer can verify by:
 11. `⋯` menu → `Cancel all active loops` (FR-10). Modal confirms; on proceed, N cancel requests fire and complete within 10s. Hidden in `Mine` mode.
 12. For any loop where the judge fired (post-#128), rounds table shows ⚖ icon on those rows (FR-11). Tapping opens reasoning drawer.
 13. `/dashboard/feed` (FR-12) shows chronological terminal events with engineer + outcome + cost. Filter chips work. `Load more` paginates.
-14. Tap a spec filename on any loop detail page → `/dashboard/specs/<path>` (FR-13). Shows all past runs + aggregate metrics.
+14. Tap a spec filename on any loop detail page → `/dashboard/specs?path=<spec>` (FR-13). Shows all past runs + aggregate metrics.
 15. `/dashboard/stats?window=30d` (FR-14) renders per-engineer + per-spec tables + daily time-series bars. Subsequent loads within 60s hit the cache (observe response time).
 16. With `[pricing]` configured in `nemo.toml`, cost figures appear as dollar amounts throughout the dashboard. Without `[pricing]`, all cost fields show `—` and token counts are still displayed (FR-15).
 
@@ -341,7 +475,7 @@ A reviewer can verify by:
 - `control-plane/src/api/dashboard/templates/` — new dir, Askama `.html` templates (or `maud!{}` macros in `.rs` files).
 - `control-plane/assets/dashboard.css` — embedded via `include_str!`.
 - `control-plane/assets/dashboard.js` — embedded via `include_str!`.
-- `control-plane/Cargo.toml` — add `askama = "0.12"` (or `maud`) and `askama_axum` for response helpers.
+- `control-plane/Cargo.toml` — add `askama` (use latest compatible 0.12.x or newer) and `askama_axum` for response helpers. Or `maud` if that was chosen per FR-1c.
 - Tests per NFR-6.
 - `docs/dashboard-setup.md` — new doc covering the security model (Tailscale as default, explicit warning about public exposure).
 


### PR DESCRIPTION
Salvaged from loop 1713e10e. 12 rounds of harden+implement+review work; agent branch is substantial. Loop could not finalize because the dev cluster's review-stage pod kept failing k8s init (`PodInitializing` stuck after auth-sidecar container created, agent container never started). Pushed manually from the cluster's bare repo.

Review r11 verdict flagged 10 issues (LIMIT 100 on primary endpoint, bar overflow, env var races in tests, etc.) — those were being addressed in r12 implementation when infra failed. Some may already be fixed in commit 0770162 'fix(dashboard): address round-11 review findings', others may remain.

Needs human review + possibly one more revise pass. Do NOT merge blindly.