### PR TITLE
fix(cli): auth falls back to keychain on missing disk file

### DIFF
--- a/cli/src/commands/auth.rs
+++ b/cli/src/commands/auth.rs
@@ -103,7 +103,27 @@ pub async fn run(
             _ => continue,
         };
 
-        if !std::path::Path::new(&cred_path).exists() {
+        // For claude on macOS: if the disk file is missing but the keychain has a
+        // fresh entry (Claude Code 2.x writes to keychain and only periodically
+        // flushes to disk), use the keychain as a fallback rather than erroring.
+        let claude_keychain_fallback: Option<String> = if *provider == "claude"
+            && !std::path::Path::new(&cred_path).exists()
+        {
+            let now = crate::claude_creds::now_ms();
+            match crate::claude_creds::extract_from_keychain() {
+                Some(kc) if !crate::claude_creds::is_bundle_stale(&kc, now) => {
+                    eprintln!(
+                        "Note: no disk credentials at {cred_path}; using fresh keychain entry."
+                    );
+                    Some(kc)
+                }
+                _ => None,
+            }
+        } else {
+            None
+        };
+
+        if !std::path::Path::new(&cred_path).exists() && claude_keychain_fallback.is_none() {
             if !json {
                 eprintln!("No {provider} credentials found at {cred_path}");
                 match *provider {


### PR DESCRIPTION
PR #154 added keychain fallback for STALE disk files, but not for MISSING files. Claude Code 2.x flushes the disk file less eagerly than the keychain, so a fresh install or cleared-state case leaves the disk file absent while the keychain has a perfectly good token. Before: nemo auth --claude errored 'run claude login'. After: uses keychain silently if fresh.