### PR TITLE
chore: release 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2581,7 +2581,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-control-plane"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2612,7 +2612,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-sidecar"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["control-plane", "cli", "sidecar", "sidecar/tests/parity"]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -57,9 +57,9 @@ module "nautiloop" {
   acme_email = "me@mydomain.com"     # required if domain is set
 
   # Optional: images (defaults to latest public GHCR)
-  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.5.0"
-  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.5.0"
-  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.5.0"
+  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.6.0"
+  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.6.0"
+  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.6.0"
 }
 ```
 
@@ -75,9 +75,9 @@ module "nautiloop" {
 | `repo_ssh_private_key` | no | auto-generated | SSH deploy key. If null, generates ED25519 |
 | `domain` | no | `null` | Domain for TLS. null = HTTP on raw IP:8080 |
 | `acme_email` | no | `null` | Let's Encrypt email. Required if domain is set |
-| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.5.0` | Control plane image |
-| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.5.0` | Agent base image |
-| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.5.0` | Auth sidecar image |
+| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.6.0` | Control plane image |
+| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.6.0` | Agent base image |
+| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.6.0` | Auth sidecar image |
 | `k3s_version` | no | `v1.32.13+k3s1` | k3s version (v1.32+ required) |
 | `postgres_password` | no | auto-generated | Postgres password |
 | `postgres_volume_size` | no | `20` | Postgres volume size (Gi) |
@@ -175,9 +175,9 @@ nemo auth                    # pushes credentials (Claude, OpenAI, SSH) to clust
 ```bash
 ./build-images.sh --tag 0.2.0
 terraform apply \
-  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.5.0" \
-  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.5.0" \
-  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.5.0"
+  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.6.0" \
+  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.6.0" \
+  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.6.0"
 ```
 
 All three images must be updated together to avoid version skew.

--- a/terraform/examples/existing-server/variables.tf
+++ b/terraform/examples/existing-server/variables.tf
@@ -50,17 +50,17 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.5.0"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.6.0"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.5.0"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.6.0"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.5.0"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.6.0"
 }

--- a/terraform/examples/hetzner/variables.tf
+++ b/terraform/examples/hetzner/variables.tf
@@ -77,19 +77,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.5.0"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.6.0"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.5.0"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.6.0"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.5.0"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.6.0"
 }
 
 variable "k3s_version" {

--- a/terraform/modules/nautiloop/variables.tf
+++ b/terraform/modules/nautiloop/variables.tf
@@ -79,19 +79,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.5.0"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.6.0"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.5.0"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.6.0"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.5.0"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.6.0"
 }
 
 # --- Optional: tuning ---

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -71,19 +71,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.5.0"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.6.0"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.5.0"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.6.0"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.5.0"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.6.0"
 }
 
 variable "k3s_version" {


### PR DESCRIPTION
## Summary

Major session release. 12+ machine-produced end-to-end convergent PRs, infrastructure hardened, CLI and TUI polished, mobile dashboard shipped, orchestrator judge landed.

## Features

- **Mobile dashboard** (#166) — `/dashboard` web UI served by control plane. Card grid, loop detail with rounds table + logs + actions, feed of terminal events, per-spec history, stats deep-dive, kill switch, CTO-focused fleet summary. Tailscale-native (private by default on standard deployments).
- **Orchestrator judge** (#157) — LLM at transition points (review-clean, max_rounds, recurring findings) decides continue / exit_clean / exit_escalate / exit_fail. Logs every decision to `judge_decisions` table for future fine-tune.
- **Helm TUI phase 2** (#155) — rounds table (`R`), diff pane (`d`), multi-loop split (`m`), themes (`T`), token/cost columns, convergence notifications + flash, approve/cancel/extend keybinds.
- **LLM-friendly CLI** (#162) — `nemo help ai` primer, per-command examples, `--json` output, error recovery hints, `nemo capabilities` for feature detection.
- **Pluggable cache** (#158) — one `/cache` PVC, passthrough env vars in nemo.toml `[cache.env]`. Covers sccache, ccache, npm, pnpm, yarn, bun, pip, poetry, uv, turbo, go, gradle.
- **`nemo start` defaults to harden** (#156) — audit-first catches ambiguous specs before implement. `--no-harden` opts out.
- **Local spec upload** (#136) — submit drafts from local disk without pre-merging.
- **Pod live introspection** (#137) — `nemo ps` + helm introspect pane + `/pod-introspect/:id`.
- **`nemo extend`** — recover FAILED loops by bumping max_rounds and resuming.
- **Stricter reviewer prompts** — `clean: true` forbidden when critical/high/medium issues listed.

## Fixes

- `max_rounds` persists in `update_loop` — extend actually sticks (#161)
- `has_diverged` two-sided ancestry check — local-ahead-of-origin is not divergence (#144)
- Spec commit is skipped when content already matches branch (no-op guard) (#142)
- Agent Claude creds mounted at `/secrets/claude-creds/` + entrypoint copies to writable `~/.claude/`
- `nemo auth --claude` falls back to macOS keychain when disk file is stale OR missing (#154, #165)
- Worktree mount includes full `/bare-repo` so `.git` pointer files resolve
- Empty-commit PR guard on the review convergence path
- Rust toolchain in dev agent image via `INCLUDE_RUST=true` build-arg
- SSE cursor uses `UNIX_EPOCH` (was `MIN_UTC`, blew Postgres timestamp range)

## Specs landed for future implementation

- `specs/qa-stage.md` — runtime verification of acceptance criteria (QA stage)
- `specs/push-during-implement.md` — push agent branch after every commit
- `specs/local-dev-quickstart.md` — 10-min k3d setup for self-hosting

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] Full end-to-end convergence verified twice on fresh k3d cluster (mobile-dashboard r13, multiple specs r2-r12)
- [x] `nemo auth --claude` keychain fallback tested on missing + stale disk file cases
- [x] `nemo extend` persists max_rounds in DB (verified via psql)