### PR TITLE
chore: release 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-control-plane"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-sidecar"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2721,7 +2721,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["control-plane", "cli", "sidecar", "sidecar/tests/parity"]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -65,9 +65,9 @@ module "nautiloop" {
   acme_email = "me@mydomain.com"     # required if domain is set
 
   # Optional: images (defaults to latest public GHCR)
-  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.6.0"
-  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.6.0"
-  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.6.0"
+  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.0"
+  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.0"
+  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.0"
 }
 ```
 
@@ -83,9 +83,9 @@ module "nautiloop" {
 | `repo_ssh_private_key` | no | auto-generated | SSH deploy key. If null, generates ED25519 |
 | `domain` | no | `null` | Domain for TLS. null = HTTP on raw IP:8080 |
 | `acme_email` | no | `null` | Let's Encrypt email. Required if domain is set |
-| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.6.0` | Control plane image |
-| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.6.0` | Agent base image |
-| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.6.0` | Auth sidecar image |
+| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.0` | Control plane image |
+| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.0` | Agent base image |
+| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.0` | Auth sidecar image |
 | `k3s_version` | no | `v1.32.13+k3s1` | k3s version (v1.32+ required) |
 | `postgres_password` | no | auto-generated | Postgres password |
 | `postgres_volume_size` | no | `20` | Postgres volume size (Gi) |
@@ -232,9 +232,9 @@ nemo auth                    # pushes credentials (Claude, OpenAI, SSH) to clust
 ```bash
 ./build-images.sh --tag 0.2.0
 terraform apply \
-  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.6.0" \
-  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.6.0" \
-  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.6.0"
+  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.0" \
+  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.0" \
+  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.0"
 ```
 
 All three images must be updated together to avoid version skew.

--- a/terraform/examples/existing-server/variables.tf
+++ b/terraform/examples/existing-server/variables.tf
@@ -50,17 +50,17 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.6.0"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.0"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.6.0"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.0"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.6.0"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.0"
 }

--- a/terraform/examples/hetzner/variables.tf
+++ b/terraform/examples/hetzner/variables.tf
@@ -77,19 +77,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.6.0"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.0"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.6.0"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.0"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.6.0"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.0"
 }
 
 variable "k3s_version" {

--- a/terraform/modules/nautiloop/variables.tf
+++ b/terraform/modules/nautiloop/variables.tf
@@ -79,19 +79,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.6.0"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.0"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.6.0"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.0"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.6.0"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.0"
 }
 
 # --- Optional: tuning ---

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -71,19 +71,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.6.0"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.0"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.6.0"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.0"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.6.0"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.0"
 }
 
 variable "k3s_version" {


### PR DESCRIPTION
## Summary

Ship the orchestrator judge. Dashboard contrast + theme toggle. Keychain-fallback edge case.

## Features

- **Judge actually running** (#178) — `control-plane/src/loop_engine/judge.rs` was merged in v0.6.0 but never wired into `main.rs`. Diagnostic run on 2026-04-20 confirmed zero rows in `judge_decisions` across 30+ loops. Now: if `NAUTILOOP_JUDGE_API_KEY` or the credentials file is set, judge fires on every eligible transition.
- **Dashboard contrast** (#176) — palette aligned with helm phase-2 values. No more washed-out look vs the TUI.
- **Theme toggle** (#176) — `⋯` menu in the dashboard header has Dark/Light/System options. Persists in localStorage; no flash on reload.
- **README refresh** (#169) — updated for v0.6.0/v0.7.0 features.

## Fixes

- `nemo auth --claude` falls back to macOS keychain when disk file is MISSING (not just stale) (#165)
- Mobile dashboard salvaged on fresh cluster after first attempt stranded commits on a k8s-init failure (#166)

## Known-not-in-this-release

- Dashboard state filter chips returning empty (#174 spec merged, impl FAILED at max_rounds; retry in v0.7.1)
- Dashboard persistent auth sliding window (#175 spec merged, impl FAILED at max_rounds; retry in v0.7.1)
- Dashboard spec preview (cancelled during session)

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (111+ tests)
- [x] Judge will be dogfooded on fresh cluster post-release