### PR TITLE
fix(terraform): dashboard_secure_cookie for Tailscale-HTTP deployments

### DIFF
--- a/terraform/modules/nautiloop/control-plane.tf
+++ b/terraform/modules/nautiloop/control-plane.tf
@@ -1,12 +1,23 @@
 # Control plane: nemo.toml config, repo-init job, API server, loop engine — applied via SSH+kubectl.
 
 locals {
+  # dashboard_secure_cookie resolution:
+  # - If operator explicitly set it, use that.
+  # - Otherwise, default to false when no TLS-terminating domain is configured
+  #   (IP-only / Tailscale HTTP deployments — Secure cookies get dropped over HTTP).
+  # - When a domain is set, leave unset (binary auto-detects and defaults to Secure).
+  _dashboard_secure_cookie_resolved = (
+    var.dashboard_secure_cookie != null ? var.dashboard_secure_cookie :
+    ((var.domain == null || var.domain == "") ? false : null)
+  )
+
   nautiloop_toml = <<-TOML
 [cluster]
 git_repo_url = "${var.git_repo_url}"
 agent_image = "${var.agent_base_image}"
 sidecar_image = "${var.sidecar_image}"
 ${var.image_pull_secret_dockerconfigjson != null ? "image_pull_secret = \"nautiloop-registry-creds\"" : ""}
+${local._dashboard_secure_cookie_resolved != null ? "dashboard_secure_cookie = ${local._dashboard_secure_cookie_resolved}" : ""}
 TOML
 
   config_checksum = sha256(local.nautiloop_toml)

--- a/terraform/modules/nautiloop/variables.tf
+++ b/terraform/modules/nautiloop/variables.tf
@@ -118,6 +118,21 @@ variable "cert_manager_version" {
   }
 }
 
+variable "dashboard_secure_cookie" {
+  description = <<-EOT
+    Controls the `Secure` flag on dashboard session cookies.
+    - null (default): auto-detect. When domain is unset (IP-only Tailscale
+      deployments), defaults to false so browsers accept cookies over plain HTTP.
+      When domain is set (TLS-fronted), defaults to true.
+    - false: never set Secure. Required for plain-HTTP deployments. Browsers
+      silently drop Secure cookies over HTTP; without this override, users
+      bounce off /dashboard/login forever.
+    - true: always set Secure. Use when you terminate TLS in front of the server.
+  EOT
+  type        = bool
+  default     = null
+}
+
 variable "postgres_password" {
   description = "Postgres password. Auto-generated if empty."
   type        = string


### PR DESCRIPTION
IP-only (no domain, no TLS) tailnet deployments were stuck in an auth loop because the binary sent Secure cookies but the browser dropped them over HTTP. Add terraform variable and auto-default to false when domain is unset. Matches the documented intent in config/mod.rs (Useful when running behind Tailscale without TLS termination).