### PR TITLE
fix(terraform): control-plane auth-sidecar was unstartable since 0.7.4

### DIFF
--- a/dev/k8s/05-control-plane.yaml
+++ b/dev/k8s/05-control-plane.yaml
@@ -31,6 +31,14 @@ spec:
           restartPolicy: Always
           ports:
             - containerPort: 9090
+          env:
+            # Sidecar fatals without GIT_REPO_URL (FR-24). Control-plane
+            # doesn't use the git SSH proxy but the binary binds all
+            # four listeners unconditionally. In dev this points at the
+            # nautiloop repo itself; setup.sh patches the value via
+            # kubectl set env if NAUTILOOP_GIT_REPO_URL differs.
+            - name: GIT_REPO_URL
+              value: "git@github.com:tinkrtailor/nautiloop.git"
           volumeMounts:
             - name: judge-creds
               mountPath: /secrets/model-credentials
@@ -43,8 +51,11 @@ spec:
               cpu: 100m
               memory: 64Mi
           startupProbe:
-            tcpSocket:
-              port: 9090
+            # 9090 is loopback-only; kubelet must probe the health port
+            # (9093, bound on all interfaces).
+            httpGet:
+              path: /healthz
+              port: 9093
             periodSeconds: 2
             failureThreshold: 30
       containers:
@@ -176,6 +187,14 @@ spec:
           restartPolicy: Always
           ports:
             - containerPort: 9090
+          env:
+            # Sidecar fatals without GIT_REPO_URL (FR-24). Control-plane
+            # doesn't use the git SSH proxy but the binary binds all
+            # four listeners unconditionally. In dev this points at the
+            # nautiloop repo itself; setup.sh patches the value via
+            # kubectl set env if NAUTILOOP_GIT_REPO_URL differs.
+            - name: GIT_REPO_URL
+              value: "git@github.com:tinkrtailor/nautiloop.git"
           volumeMounts:
             - name: judge-creds
               mountPath: /secrets/model-credentials
@@ -188,8 +207,11 @@ spec:
               cpu: 100m
               memory: 64Mi
           startupProbe:
-            tcpSocket:
-              port: 9090
+            # 9090 is loopback-only; kubelet must probe the health port
+            # (9093, bound on all interfaces).
+            httpGet:
+              path: /healthz
+              port: 9093
             periodSeconds: 2
             failureThreshold: 30
       containers:

--- a/terraform/modules/nautiloop/control-plane.tf
+++ b/terraform/modules/nautiloop/control-plane.tf
@@ -127,6 +127,13 @@ spec:
           restartPolicy: Always
           ports:
             - containerPort: 9090
+          env:
+            # FR-24: sidecar main.rs parses GIT_REPO_URL at startup and
+            # fatals if missing. The control-plane doesn't use the sidecar's
+            # git SSH proxy (judge only uses the model proxy), but the binary
+            # binds all four listeners unconditionally.
+            - name: GIT_REPO_URL
+              value: "${var.git_repo_url}"
           volumeMounts:
             - name: judge-creds
               mountPath: /secrets/model-credentials
@@ -274,6 +281,13 @@ spec:
           restartPolicy: Always
           ports:
             - containerPort: 9090
+          env:
+            # FR-24: sidecar main.rs parses GIT_REPO_URL at startup and
+            # fatals if missing. The control-plane doesn't use the sidecar's
+            # git SSH proxy (judge only uses the model proxy), but the binary
+            # binds all four listeners unconditionally.
+            - name: GIT_REPO_URL
+              value: "${var.git_repo_url}"
           volumeMounts:
             - name: judge-creds
               mountPath: /secrets/model-credentials

--- a/terraform/modules/nautiloop/control-plane.tf
+++ b/terraform/modules/nautiloop/control-plane.tf
@@ -146,8 +146,15 @@ spec:
               cpu: 100m
               memory: 64Mi
           startupProbe:
-            tcpSocket:
-              port: 9090
+            # Port 9090 (model proxy) binds on loopback only, so kubelet
+            # probes get connection-refused. Port 9093 (health endpoint)
+            # binds on all interfaces and its /healthz returns 200 once
+            # all four sidecar listeners are up (see sidecar/src/main.rs
+            # FR-20, FR-22). Matches the agent-pod pattern in
+            # control-plane/src/k8s/job_builder.rs.
+            httpGet:
+              path: /healthz
+              port: 9093
             periodSeconds: 2
             failureThreshold: 30
       containers:
@@ -300,8 +307,15 @@ spec:
               cpu: 100m
               memory: 64Mi
           startupProbe:
-            tcpSocket:
-              port: 9090
+            # Port 9090 (model proxy) binds on loopback only, so kubelet
+            # probes get connection-refused. Port 9093 (health endpoint)
+            # binds on all interfaces and its /healthz returns 200 once
+            # all four sidecar listeners are up (see sidecar/src/main.rs
+            # FR-20, FR-22). Matches the agent-pod pattern in
+            # control-plane/src/k8s/job_builder.rs.
+            httpGet:
+              path: /healthz
+              port: 9093
             periodSeconds: 2
             failureThreshold: 30
       containers:


### PR DESCRIPTION
## Summary
PR #188 (merged into v0.7.4) added the auth-sidecar native sidecar initContainer to both control-plane Deployments so the judge could route through the same proxy agent pods use. Two bugs landed with that change and only surfaced on v0.7.5 when the Hetzner pilot did a full terraform apply (v0.7.4 deploys were image-tag-only and never re-rendered the manifests):

1. **GIT_REPO_URL missing.** Sidecar main.rs fatals immediately without it (FR-24). Both control-plane pods crashlooped.
2. **startupProbe wrong port.** Used `tcpSocket: 9090` but 9090 is the model proxy which binds only on loopback. Kubelet probes got `connection refused`, the init container restarted, and the main container never started. Switched to `httpGet /healthz :9093` which is the all-interfaces health listener (matches the agent-pod pattern in `control-plane/src/k8s/job_builder.rs:171-181`).

Both fixes applied to the terraform module and to `dev/k8s/05-control-plane.yaml` (same bugs, different manifests).

## Test plan
- [x] Smoke test on local k3d: `kubectl apply -f dev/k8s/05-control-plane.yaml` after rebuilding the sidecar image. Both `nautiloop-api-server` and `nautiloop-loop-engine` reach `2/2 Running` in ~25s.
- [x] Sidecar `curl localhost:9093/healthz` → `{"status":"ok"}`.
- [x] Api-server `curl localhost:8080/health` → 200.
- [ ] Post-release smoke by pilot: `terraform apply` with new image tags, both pods reach 2/2 Ready.