### PR TITLE
fix(terraform): api-server RBAC for pods/log/exec in nautiloop-jobs

### DIFF
--- a/terraform/modules/nautiloop/k8s.tf
+++ b/terraform/modules/nautiloop/k8s.tf
@@ -305,6 +305,20 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["create", "update", "get"]
+  # Matches dev/k8s/02-rbac.yaml. The dashboard log-stream endpoints
+  # (/logs, /pod-logs, /ps) and /cache disk-usage endpoint all need to
+  # list pods, read their logs, and exec into running agent pods in
+  # this namespace. Without these rules every tail returns 403. See
+  # control-plane/src/api/handlers.rs:538 and api/cache.rs:142.
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list", "get"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["get", "create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
## Summary
Dashboard log-stream endpoints (`/logs`, `/pod-logs`, `/ps`) and the `/cache` disk-usage panel list pods and read logs/exec inside agent pods in `nautiloop-jobs`. The api-server's Role in that namespace has been secrets-only since the initial commit — every tail returned 403. Latent bug, not a regression; just surfaced now that the pilot is using the dashboard.

- Mirrors the rules that `dev/k8s/02-rbac.yaml` has always had.
- Loop progression is unaffected (loop-engine uses a separate SA with its own full Role).

## Test plan
- [x] Reviewed code paths: `control-plane/src/api/handlers.rs:538` (list + log), `control-plane/src/api/cache.rs:142` (exec).
- [ ] Pilot smoke: after `terraform apply`, dashboard log tail succeeds without 403.