### PR TITLE
fix(terraform): repopulate ssh known hosts on upgrade

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -90,6 +90,7 @@ module "nautiloop" {
 | `postgres_password` | no | auto-generated | Postgres password |
 | `postgres_volume_size` | no | `20` | Postgres volume size (Gi) |
 | `cache_volume_size` | no | `50` | Size of the shared `/cache` compiler cache PVC in GiB; used by sccache, ccache, npm, pnpm, yarn, bun, pip, turbo, go, and any tool configured via `[cache.env]` in nemo.toml. Deprecated alias: `cargo_cache_volume_size` (exists for one release cycle, then removed). |
+| `ssh_known_hosts` | no | `""` | SSH known_hosts entries for the git remote. If unset, the module runs `ssh-keyscan` and manages the `nautiloop-ssh-known-hosts` ConfigMaps automatically. |
 
 ## Module outputs
 
@@ -238,6 +239,18 @@ terraform apply \
 ```
 
 All three images must be updated together to avoid version skew.
+
+If you leave `ssh_known_hosts` unset, the module populates `nautiloop-ssh-known-hosts` from `ssh-keyscan` during apply. Older module versions could leave those ConfigMaps empty on upgrade. If you are recovering a cluster that was upgraded from an older release, patch both namespaces once, replacing `<git-host>` with your Git server host:
+
+```bash
+kubectl -n nautiloop-system create configmap nautiloop-ssh-known-hosts \
+  --from-literal="known_hosts=$(ssh-keyscan <git-host>)" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl -n nautiloop-jobs create configmap nautiloop-ssh-known-hosts \
+  --from-literal="known_hosts=$(ssh-keyscan <git-host>)" \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
 
 ## Legacy: root terraform
 

--- a/terraform/modules/nautiloop/k8s.tf
+++ b/terraform/modules/nautiloop/k8s.tf
@@ -188,7 +188,7 @@ metadata:
 data:
 ${local._judge_creds_data}
 YAML
-  judge_creds_yaml = (local._judge_has_claude || local._judge_has_anthropic) ? local._judge_creds_yaml_template : ""
+  judge_creds_yaml           = (local._judge_has_claude || local._judge_has_anthropic) ? local._judge_creds_yaml_template : ""
 
   # Registry creds (only rendered when image_pull_secret provided)
   _dockerconfigjson_b64 = var.image_pull_secret_dockerconfigjson != null ? base64encode(var.image_pull_secret_dockerconfigjson) : ""
@@ -223,6 +223,7 @@ metadata:
 data:
   git_repo_url: "${var.git_repo_url}"
   domain: "${local.has_domain ? var.domain : var.server_ip}"
+${var.ssh_known_hosts != "" ? <<-YAML
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -242,9 +243,11 @@ data:
   known_hosts: |
     ${indent(4, var.ssh_known_hosts)}
 YAML
+: ""}
+YAML
 
-  # RBAC: service accounts, roles, role bindings
-  rbac_yaml = <<-YAML
+# RBAC: service accounts, roles, role bindings
+rbac_yaml = <<-YAML
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -335,11 +338,11 @@ subjects:
     namespace: nautiloop-system
 YAML
 
-  # Networking: TLS mode (domain set) — cert-manager resources + IngressRoutes
-  # Always rendered; only applied when has_domain is true (via count on null_resource)
-  _acme_email         = var.acme_email != null ? var.acme_email : ""
-  _domain             = var.domain != null ? var.domain : ""
-  networking_tls_yaml = <<-YAML
+# Networking: TLS mode (domain set) — cert-manager resources + IngressRoutes
+# Always rendered; only applied when has_domain is true (via count on null_resource)
+_acme_email         = var.acme_email != null ? var.acme_email : ""
+_domain             = var.domain != null ? var.domain : ""
+networking_tls_yaml = <<-YAML
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
@@ -418,8 +421,8 @@ spec:
     - ${local._domain}
 YAML
 
-  # Networking: IP-only mode (no domain) — LoadBalancer service
-  networking_ip_yaml = <<-YAML
+# Networking: IP-only mode (no domain) — LoadBalancer service
+networking_ip_yaml = <<-YAML
 apiVersion: v1
 kind: Service
 metadata:
@@ -577,6 +580,7 @@ resource "null_resource" "ssh_keyscan" {
 
   triggers = {
     git_repo_url = var.git_repo_url
+    config_hash  = sha256(local.config_yaml)
   }
 
   provisioner "local-exec" {


### PR DESCRIPTION
## Summary
- stop `k8s_config` from pre-creating empty `nautiloop-ssh-known-hosts` ConfigMaps when `ssh_known_hosts` is unset
- make the fallback `null_resource.ssh_keyscan` re-run when the rendered config changes so upgrades repair old empty ConfigMaps
- document the `ssh_known_hosts` fallback and a manual recovery path for clusters upgraded from older module versions

## Validation
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- `terraform validate` in `terraform/examples/existing-server`