### PR TITLE
fix: v0.7.9 production regressions (stage deadlines, retry, inspect, ps, logs, oauth)

### DIFF
--- a/cli/src/commands/inspect.rs
+++ b/cli/src/commands/inspect.rs
@@ -3,25 +3,43 @@ use anyhow::Result;
 use crate::api_types::InspectResponse;
 use crate::client::NemoClient;
 
-pub async fn fetch(client: &NemoClient, branch: &str) -> Result<InspectResponse> {
+pub async fn fetch_by_id(client: &NemoClient, id: uuid::Uuid) -> Result<InspectResponse> {
+    client.get(&format!("/inspect?id={id}")).await
+}
+
+pub async fn fetch_by_branch(client: &NemoClient, branch: &str) -> Result<InspectResponse> {
     client
         .get(&format!("/inspect?branch={}", urlencoding::encode(branch)))
         .await
 }
 
-/// Run the inspect command. The `_json` parameter is accepted for consistency
-/// (so agents can pass `--json` uniformly) but has no effect — output is
-/// always JSON.
-pub async fn run(client: &NemoClient, path: &str, _json: bool) -> Result<()> {
-    // Prepend "agent/" if not already present so users can pass "alice/slug-hash"
-    let branch = if path.starts_with("agent/") {
-        path.to_string()
-    } else {
-        format!("agent/{path}")
-    };
+/// Back-compat alias for `fetch_by_branch`. Callers that already have
+/// a fully-qualified branch name (e.g. the helm TUI) can keep using
+/// this; the UUID-routing logic lives in `run`.
+pub async fn fetch(client: &NemoClient, branch: &str) -> Result<InspectResponse> {
+    fetch_by_branch(client, branch).await
+}
 
-    // Pass branch as query param (not path segment) because branch names contain slashes
-    let resp = fetch(client, &branch).await?;
+/// Run the inspect command. Accepts either a loop UUID or a branch
+/// shorthand (e.g. `alice/slug-hash`, which is auto-prefixed with
+/// `agent/`). UUID inputs used to be silently treated as branch names,
+/// producing 400 "No loop found for branch: agent/<uuid>"; now they
+/// are routed to the id-based lookup instead.
+///
+/// The `_json` parameter is accepted for consistency (so agents can
+/// pass `--json` uniformly) but has no effect — output is always JSON.
+pub async fn run(client: &NemoClient, path: &str, _json: bool) -> Result<()> {
+    let resp = if let Ok(id) = uuid::Uuid::try_parse(path) {
+        fetch_by_id(client, id).await?
+    } else {
+        // Prepend "agent/" if not already present so users can pass "alice/slug-hash"
+        let branch = if path.starts_with("agent/") {
+            path.to_string()
+        } else {
+            format!("agent/{path}")
+        };
+        fetch_by_branch(client, &branch).await?
+    };
 
     // Structured JSON output; formatted human-readable rendering is a future enhancement.
     println!("{}", serde_json::to_string_pretty(&resp)?);

--- a/cli/src/commands/logs.rs
+++ b/cli/src/commands/logs.rs
@@ -25,22 +25,51 @@ pub async fn run_tail(
     loop_id: &str,
     tail_lines: u32,
     container: &str,
+    follow: bool,
 ) -> Result<TailResult> {
-    let path = format!("/pod-logs/{loop_id}?tail={tail_lines}&container={container}");
+    let follow_param = if follow { "&follow=true" } else { "" };
+    let path = format!("/pod-logs/{loop_id}?tail={tail_lines}&container={container}{follow_param}");
     let resp = client.get_stream(&path).await?;
     let status = resp.status();
-    let text = resp.text().await?;
+
     // Server returns 204 No Content for benign "no pod" states.
     // 4xx/5xx are real errors. 200 = real log output.
     if status == reqwest::StatusCode::NO_CONTENT {
         return Ok(TailResult::NoPod);
     }
     if !status.is_success() {
+        let text = resp.text().await?;
         anyhow::bail!("pod-logs returned {status}: {text}");
     }
-    print!("{text}");
-    if !text.ends_with('\n') {
-        println!();
+
+    if follow {
+        // Stream chunks as they arrive so the operator sees output
+        // without waiting for the pod to exit. Critical for
+        // `opencode --format json` audits whose NDJSON lands in the
+        // kubelet log in bursts rather than continuously.
+        use std::io::Write;
+        let mut stream = resp.bytes_stream();
+        let stdout = std::io::stdout();
+        let mut handle = stdout.lock();
+        let mut last_ended_with_newline = true;
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk?;
+            if chunk.is_empty() {
+                continue;
+            }
+            last_ended_with_newline = chunk.last() == Some(&b'\n');
+            handle.write_all(&chunk)?;
+            handle.flush()?;
+        }
+        if !last_ended_with_newline {
+            writeln!(handle)?;
+        }
+    } else {
+        let text = resp.text().await?;
+        print!("{text}");
+        if !text.ends_with('\n') {
+            println!();
+        }
     }
     Ok(TailResult::Ok)
 }

--- a/cli/src/commands/resume.rs
+++ b/cli/src/commands/resume.rs
@@ -7,18 +7,29 @@ struct ResumeResponse {
     loop_id: uuid::Uuid,
     state: String,
     resume_requested: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    stage_timeout_secs: Option<u32>,
 }
 
-pub async fn run(client: &NemoClient, loop_id: &str, json: bool) -> Result<()> {
-    let resp: ResumeResponse = client
-        .post(&format!("/resume/{loop_id}"), &serde_json::json!({}))
-        .await?;
+pub async fn run(
+    client: &NemoClient,
+    loop_id: &str,
+    json: bool,
+    stage_timeout: Option<u32>,
+) -> Result<()> {
+    let body = match stage_timeout {
+        Some(secs) => serde_json::json!({ "stage_timeout_secs": secs }),
+        None => serde_json::json!({}),
+    };
+
+    let resp: ResumeResponse = client.post(&format!("/resume/{loop_id}"), &body).await?;
 
     if json {
         let output = serde_json::json!({
             "loop_id": resp.loop_id,
             "state": resp.state,
             "resume_requested": resp.resume_requested,
+            "stage_timeout_secs": resp.stage_timeout_secs,
             "message": if resp.resume_requested { "Loop resumed." } else { "Resume not applicable for current state." },
         });
         println!("{}", serde_json::to_string_pretty(&output)?);
@@ -28,6 +39,9 @@ pub async fn run(client: &NemoClient, loop_id: &str, json: bool) -> Result<()> {
     if resp.resume_requested {
         println!("Resumed loop {}", resp.loop_id);
         println!("  State: {}", resp.state);
+        if let Some(secs) = resp.stage_timeout_secs {
+            println!("  Stage timeout: {secs}s (per-loop override)");
+        }
         println!("  Loop will resume on next reconciliation tick.");
     } else {
         println!(

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -19,6 +19,9 @@ pub struct StartArgs<'a> {
     pub ship_mode: bool,
     pub model_impl: Option<String>,
     pub model_review: Option<String>,
+    /// Optional per-stage Job `activeDeadlineSeconds` override. Uniform
+    /// across all stages. Server-side floored to 300s.
+    pub stage_timeout_secs: Option<u32>,
 }
 
 pub async fn run(client: &NemoClient, args: StartArgs<'_>) -> Result<()> {
@@ -161,6 +164,10 @@ fn build_start_body(args: &StartArgs<'_>, spec_content: &str) -> serde_json::Val
         });
     }
 
+    if let Some(secs) = args.stage_timeout_secs {
+        body["stage_timeout_secs"] = serde_json::json!(secs);
+    }
+
     body
 }
 
@@ -186,6 +193,7 @@ mod tests {
             ship_mode: false,
             model_impl: None,
             model_review: None,
+            stage_timeout_secs: None,
         };
         let body = build_start_body(&args, &content);
 
@@ -224,6 +232,7 @@ mod tests {
             ship_mode: false,
             model_impl: Some("claude-opus-4-6".to_string()),
             model_review: None,
+            stage_timeout_secs: None,
         };
         let body = build_start_body(&args, "# Spec");
         assert!(body["model_overrides"].is_object());
@@ -241,6 +250,7 @@ mod tests {
             ship_mode: false,
             model_impl: None,
             model_review: None,
+            stage_timeout_secs: None,
         };
         let body = build_start_body(&args, "# Spec");
         assert!(body.get("model_overrides").is_none());
@@ -289,6 +299,7 @@ mod tests {
             ship_mode: false,
             model_impl: None,
             model_review: None,
+            stage_timeout_secs: None,
         };
         let body = build_start_body(&args, "# Spec");
         assert_eq!(
@@ -309,6 +320,7 @@ mod tests {
             ship_mode: false,
             model_impl: None,
             model_review: None,
+            stage_timeout_secs: None,
         };
         let body = build_start_body(&args, "# Spec");
         assert_eq!(body["harden"], false, "--no-harden must send harden: false");
@@ -393,6 +405,7 @@ mod tests {
             ship_mode: false,
             model_impl: None,
             model_review: None,
+            stage_timeout_secs: None,
         };
         assert_eq!(
             phase_plan_label(&args),
@@ -412,6 +425,7 @@ mod tests {
             ship_mode: false,
             model_impl: None,
             model_review: None,
+            stage_timeout_secs: None,
         };
         assert_eq!(phase_plan_label(&args), "IMPLEMENT (harden skipped)");
     }
@@ -428,6 +442,7 @@ mod tests {
             ship_mode: false,
             model_impl: None,
             model_review: None,
+            stage_timeout_secs: None,
         };
         assert_eq!(phase_plan_label(&args), "HARDEN \u{2192} IMPLEMENT");
     }
@@ -444,6 +459,7 @@ mod tests {
             ship_mode: true,
             model_impl: None,
             model_review: None,
+            stage_timeout_secs: None,
         };
         assert_eq!(
             phase_plan_label(&args),
@@ -463,6 +479,7 @@ mod tests {
             ship_mode: false,
             model_impl: None,
             model_review: None,
+            stage_timeout_secs: None,
         };
         assert_eq!(phase_plan_label(&args), "HARDEN");
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -61,6 +61,14 @@ enum Commands {
         /// Override reviewer model
         #[arg(long)]
         model_review: Option<String>,
+
+        /// Per-stage Job `activeDeadlineSeconds` override in seconds.
+        /// Applies uniformly to every stage (audit/revise/implement/test/review).
+        /// Floored to 300s server-side. Default: cluster config (audit/review: 900s,
+        /// implement/test: 1800s). Use when large specs need longer audits than
+        /// the cluster default, e.g. `--stage-timeout 2700` for 45-minute audits.
+        #[arg(long, value_name = "SECONDS")]
+        stage_timeout: Option<u32>,
     },
 
     /// Implement spec, create PR. Terminal: CONVERGED
@@ -105,6 +113,11 @@ enum Commands {
         /// Override reviewer model
         #[arg(long)]
         model_review: Option<String>,
+
+        /// Per-stage Job `activeDeadlineSeconds` override in seconds.
+        /// Applies uniformly to every stage. Floored to 300s server-side.
+        #[arg(long, value_name = "SECONDS")]
+        stage_timeout: Option<u32>,
     },
 
     /// Implement + auto-merge. Terminal: SHIPPED
@@ -135,6 +148,11 @@ enum Commands {
         /// Override reviewer model
         #[arg(long)]
         model_review: Option<String>,
+
+        /// Per-stage Job `activeDeadlineSeconds` override in seconds.
+        /// Applies uniformly to every stage. Floored to 300s server-side.
+        #[arg(long, value_name = "SECONDS")]
+        stage_timeout: Option<u32>,
     },
 
     /// Show your running loops
@@ -181,15 +199,18 @@ enum Commands {
     #[command(long_about = "Stream logs for a loop.\n\n\
         Streams real-time logs from a running loop via SSE, or fetches historical\n\
         logs from completed rounds. Filter by round and stage to narrow output.\n\
-        Use --tail for raw pod container stdout (live only).\n\n\
+        Use --tail for raw pod container stdout (live only). Use --follow with\n\
+        --tail to stream stdout until the pod exits — useful for audit/review\n\
+        stages that run `opencode --format json`, which buffers its NDJSON so a\n\
+        one-shot --tail may return an empty body.\n\n\
         Example:\n  \
           $ nemo logs 8cb88352-5cf4-4dda-9cd0-6a0d6851ba92\n  \
           [implement/r1] Setting up worktree...\n  \
           [implement/r1] Running agent...\n\n  \
           $ nemo logs 8cb88352-... --round 2 --stage review\n  \
           [review/r2] Reviewing implementation...\n\n  \
-          $ nemo logs 8cb88352-... --tail\n  \
-          # Raw pod stdout (live container output)\n\n\
+          $ nemo logs 8cb88352-... --tail --follow\n  \
+          # Streams stdout in real time (use for --format json audits)\n\n\
         See also: nemo status (find loop IDs), nemo ps (pod-level introspection).")]
     Logs {
         /// Loop ID
@@ -207,6 +228,13 @@ enum Commands {
         /// the Postgres log stream. Works mid-run without kubectl.
         #[arg(long)]
         tail: bool,
+
+        /// Stream pod stdout until the pod exits (requires --tail). Use this
+        /// for stages that buffer output (e.g. `opencode --format json`)
+        /// where a one-shot `--tail` returns an empty body because nothing
+        /// has been flushed to the kubelet yet.
+        #[arg(long)]
+        follow: bool,
 
         /// Max lines to return with --tail (default 500, max 10000)
         #[arg(long, default_value_t = 500)]
@@ -324,6 +352,13 @@ enum Commands {
         /// Output as JSON
         #[arg(long)]
         json: bool,
+
+        /// Raise the per-stage Job `activeDeadlineSeconds` before resuming.
+        /// Use this to recover from a `StageDeadlineExceeded` failure on a
+        /// stage whose wall-clock budget was too small — e.g. a large spec
+        /// whose audit exceeded the 900s default. Floored to 300s server-side.
+        #[arg(long, value_name = "SECONDS")]
+        stage_timeout: Option<u32>,
     },
 
     /// Extend a FAILED loop's max_rounds and resume it from the last stage
@@ -1064,6 +1099,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
             spec_path,
             model_impl,
             model_review,
+            stage_timeout,
         } => {
             let (model_impl, model_review) =
                 project_config::resolve_models(model_impl, model_review, &nemo_config.models)?;
@@ -1079,6 +1115,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                     ship_mode: false,
                     model_impl,
                     model_review,
+                    stage_timeout_secs: stage_timeout,
                 },
             )
             .await?;
@@ -1090,6 +1127,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
             auto_approve,
             model_impl,
             model_review,
+            stage_timeout,
         } => {
             if let Some(warning) = commands::start::deprecation_warning(harden) {
                 eprintln!("{warning}");
@@ -1108,6 +1146,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                     ship_mode: false,
                     model_impl,
                     model_review,
+                    stage_timeout_secs: stage_timeout,
                 },
             )
             .await?;
@@ -1117,6 +1156,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
             harden,
             model_impl,
             model_review,
+            stage_timeout,
         } => {
             let (model_impl, model_review) =
                 project_config::resolve_models(model_impl, model_review, &nemo_config.models)?;
@@ -1132,6 +1172,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                     ship_mode: true,
                     model_impl,
                     model_review,
+                    stage_timeout_secs: stage_timeout,
                 },
             )
             .await?;
@@ -1156,9 +1197,15 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
             round,
             stage,
             tail,
+            follow,
             tail_lines,
             container,
         } => {
+            if follow && !tail {
+                anyhow::bail!(
+                    "--follow requires --tail (it streams pod stdout); drop --follow for SSE streaming via the historical log path"
+                );
+            }
             if tail {
                 if round.is_some() || stage.is_some() {
                     anyhow::bail!(
@@ -1166,7 +1213,14 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                          run without --tail for filtered historical logs"
                     );
                 }
-                match commands::logs::run_tail(&http_client, &loop_id, tail_lines, &container).await
+                match commands::logs::run_tail(
+                    &http_client,
+                    &loop_id,
+                    tail_lines,
+                    &container,
+                    follow,
+                )
+                .await
                 {
                     Ok(commands::logs::TailResult::Ok) => {}
                     Ok(commands::logs::TailResult::NoPod) => {
@@ -1205,8 +1259,12 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
         Commands::Inspect { path, json } => {
             commands::inspect::run(&http_client, &path, json).await?;
         }
-        Commands::Resume { loop_id, json } => {
-            commands::resume::run(&http_client, &loop_id, json).await?;
+        Commands::Resume {
+            loop_id,
+            json,
+            stage_timeout,
+        } => {
+            commands::resume::run(&http_client, &loop_id, json, stage_timeout).await?;
         }
         Commands::Extend { loop_id, add, json } => {
             commands::extend::run(&http_client, &loop_id, add, json).await?;

--- a/control-plane/migrations/20260424000001_add_stage_timeout_override.sql
+++ b/control-plane/migrations/20260424000001_add_stage_timeout_override.sql
@@ -1,0 +1,11 @@
+-- Add per-loop stage timeout override. Applies uniformly to every
+-- stage Job's `activeDeadlineSeconds` when set; otherwise the cluster
+-- defaults from Timeouts config apply. NULL = no override.
+--
+-- Motivated by v0.7.9 production bug: a 32 KB spec's opencode audit
+-- exceeded the hardcoded 900s budget and retried deterministically
+-- until max_retries. Operators need a knob to raise this per-loop
+-- without changing cluster config, and to raise it at resume time
+-- after a DeadlineExceeded FAILED transition.
+ALTER TABLE loops
+    ADD COLUMN stage_timeout_secs INTEGER;

--- a/control-plane/src/api/dashboard/handlers.rs
+++ b/control-plane/src/api/dashboard/handlers.rs
@@ -1793,6 +1793,7 @@ mod tests {
             hardened_spec_path: None,
             spec_pr_url: None,
             resolved_default_branch: Some("main".to_string()),
+            stage_timeout_secs: None,
             created_at: now,
             updated_at: now,
         }

--- a/control-plane/src/api/handlers.rs
+++ b/control-plane/src/api/handlers.rs
@@ -9,15 +9,21 @@ use crate::error::NautiloopError;
 use crate::state::LoopFlag;
 use crate::types::api::{
     ApproveResponse, CancelResponse, CredentialRequest, DiffQuery, DiffResponse, ExtendRequest,
-    ExtendResponse, InspectResponse, LogsQuery, LoopSummary, ResumeResponse, RoundSummary,
-    StartRequest, StartResponse, StatusQuery, StatusResponse,
+    ExtendResponse, InspectResponse, LogsQuery, LoopSummary, ResumeRequest, ResumeResponse,
+    RoundSummary, StartRequest, StartResponse, StatusQuery, StatusResponse,
 };
 use crate::types::{LoopKind, LoopRecord, LoopState, generate_branch_name};
 
-/// Query parameters for GET /inspect
+/// Query parameters for GET /inspect. Exactly one of `id` or `branch`
+/// must be supplied. We accept both because the CLI frequently has a
+/// loop ID (UUID) in hand and prepending `agent/` to a UUID produces a
+/// nonsense branch name that bypasses the real lookup.
 #[derive(Debug, serde::Deserialize)]
 pub struct InspectQuery {
-    pub branch: String,
+    #[serde(default)]
+    pub id: Option<Uuid>,
+    #[serde(default)]
+    pub branch: Option<String>,
 }
 
 /// POST /start - Submit a spec for processing.
@@ -231,6 +237,7 @@ pub async fn start(
                 .unwrap_or(&default_ref)
                 .to_string(),
         ),
+        stage_timeout_secs: req.stage_timeout_secs.map(|s| s as i32),
         created_at: now,
         updated_at: now,
     };
@@ -479,6 +486,10 @@ pub async fn logs(
 /// - `tail`: max lines to return (default 500, max 10000)
 /// - `container`: container name to read from (default "agent"; "auth-sidecar"
 ///   is the other interesting one for egress debugging)
+/// - `follow`: if "true", stream the container's stdout until the pod exits
+///   rather than returning a one-shot snapshot. Useful for stages running
+///   `opencode --format json`, which buffers NDJSON and so may produce an
+///   empty body for a one-shot tail right after dispatch.
 pub async fn pod_logs(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
@@ -544,6 +555,7 @@ pub async fn pod_logs(
             "container must be 'agent' or 'auth-sidecar', got {container}"
         )));
     }
+    let follow = query.get("follow").is_some_and(|v| v == "true" || v == "1");
 
     let kube_client = state.kube_client.as_ref().ok_or_else(|| {
         NautiloopError::Internal("K8s client not available — pod logs disabled".to_string())
@@ -590,10 +602,58 @@ pub async fn pod_logs(
     });
 
     let log_params = kube::api::LogParams {
-        container: Some(container),
+        container: Some(container.clone()),
         tail_lines: Some(tail_lines),
+        follow,
         ..Default::default()
     };
+
+    // Streaming (follow) path: wire the kubelet log stream through to
+    // the HTTP client as chunked text so an operator sees NDJSON
+    // bursts in real time. `log_stream` returns an `AsyncBufRead`; we
+    // wrap it in an `async_stream` so Axum can consume it as a byte
+    // stream body without pulling in tokio-util just for this.
+    if follow {
+        use futures::AsyncReadExt;
+
+        let Some(pod_name) = sorted_pods.first().and_then(|p| p.metadata.name.clone()) else {
+            return Ok(info_response(format!(
+                "# no pod yet for job {job_name} (pre-creation race or TTL cleanup)\n"
+            )));
+        };
+
+        let mut reader = pods_api
+            .log_stream(&pod_name, &log_params)
+            .await
+            .map_err(|e| {
+                NautiloopError::Internal(format!(
+                    "Failed to open log stream for pod {pod_name}: {e}"
+                ))
+            })?;
+
+        let body_stream = async_stream::stream! {
+            let mut buf = vec![0u8; 8192];
+            loop {
+                match reader.read(&mut buf).await {
+                    Ok(0) => break,
+                    Ok(n) => yield Ok::<_, std::io::Error>(axum::body::Bytes::copy_from_slice(&buf[..n])),
+                    Err(e) => {
+                        yield Err(std::io::Error::other(format!("kube log stream error: {e}")));
+                        break;
+                    }
+                }
+            }
+        };
+        let body = axum::body::Body::from_stream(body_stream);
+
+        return Ok((
+            axum::http::StatusCode::OK,
+            [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
+            body,
+        )
+            .into_response());
+    }
+
     let mut logs: Option<String> = None;
     for pod in &sorted_pods {
         if let Some(pod_name) = &pod.metadata.name {
@@ -718,7 +778,9 @@ pub async fn approve(
 pub async fn resume(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
+    body: Option<Json<ResumeRequest>>,
 ) -> Result<Json<ResumeResponse>, NautiloopError> {
+    let req = body.map(|Json(r)| r).unwrap_or_default();
     let record = state
         .store
         .get_loop(id)
@@ -767,6 +829,24 @@ pub async fn resume(
         });
     }
 
+    // If the caller supplied a new --stage-timeout, persist it before
+    // raising the resume flag so the next reconciler tick's redispatch
+    // picks up the larger budget. The driver's resolve_stage_timeout
+    // floors this at 300s; we also reject <1 here to keep "unset"
+    // distinct from "explicit zero".
+    let mut updated_timeout = record.stage_timeout_secs;
+    if let Some(secs) = req.stage_timeout_secs {
+        if secs == 0 {
+            return Err(NautiloopError::BadRequest(
+                "stage_timeout_secs must be a positive integer (minimum 300)".to_string(),
+            ));
+        }
+        let mut updated = record.clone();
+        updated.stage_timeout_secs = Some(secs as i32);
+        state.store.update_loop(&updated).await?;
+        updated_timeout = Some(secs as i32);
+    }
+
     state
         .store
         .set_loop_flag(id, LoopFlag::Resume, true)
@@ -776,6 +856,7 @@ pub async fn resume(
         loop_id: id,
         state: record.state,
         resume_requested: true,
+        stage_timeout_secs: updated_timeout.map(|v| v as u32),
     }))
 }
 
@@ -858,20 +939,32 @@ pub async fn extend(
     }))
 }
 
-/// GET /inspect?branch=agent/alice/slug-hash - View detailed loop state.
-/// Branch passed as query param because branch names contain slashes.
+/// GET /inspect?id=<uuid> | ?branch=agent/alice/slug-hash - View detailed loop state.
+/// Exactly one of `id` or `branch` must be supplied; `id` wins if both are
+/// present. Branch passed as query param because branch names contain slashes.
 pub async fn inspect(
     State(state): State<AppState>,
     Query(params): Query<InspectQuery>,
 ) -> Result<Json<InspectResponse>, NautiloopError> {
-    let branch = &params.branch;
-
-    // Use get_loop_by_branch_any to include terminal loops (N5)
-    let record = state
-        .store
-        .get_loop_by_branch_any(branch)
-        .await?
-        .ok_or_else(|| NautiloopError::BadRequest(format!("No loop found for branch: {branch}")))?;
+    let record = match (&params.id, &params.branch) {
+        (Some(id), _) => state
+            .store
+            .get_loop(*id)
+            .await?
+            .ok_or_else(|| NautiloopError::BadRequest(format!("No loop found for id: {id}")))?,
+        (None, Some(branch)) => state
+            .store
+            .get_loop_by_branch_any(branch)
+            .await?
+            .ok_or_else(|| {
+                NautiloopError::BadRequest(format!("No loop found for branch: {branch}"))
+            })?,
+        (None, None) => {
+            return Err(NautiloopError::BadRequest(
+                "inspect requires either ?id=<uuid> or ?branch=<branch>".to_string(),
+            ));
+        }
+    };
 
     let rounds = state.store.get_rounds(record.id).await?;
 
@@ -1443,6 +1536,7 @@ mod tests {
             hardened_spec_path: None,
             spec_pr_url: None,
             resolved_default_branch: Some("main".to_string()),
+            stage_timeout_secs: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
@@ -1505,6 +1599,7 @@ mod tests {
             hardened_spec_path: None,
             spec_pr_url: None,
             resolved_default_branch: Some("main".to_string()),
+            stage_timeout_secs: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
@@ -1561,6 +1656,7 @@ mod tests {
             hardened_spec_path: None,
             spec_pr_url: None,
             resolved_default_branch: Some("main".to_string()),
+            stage_timeout_secs: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
@@ -2425,6 +2521,7 @@ mod tests {
             hardened_spec_path: None,
             spec_pr_url: None,
             resolved_default_branch: Some("main".to_string()),
+            stage_timeout_secs: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };

--- a/control-plane/src/api/introspect.rs
+++ b/control-plane/src/api/introspect.rs
@@ -155,7 +155,7 @@ pub async fn pod_introspect(
 
     // Parse exec output — timeout/failure → partial snapshot with metrics (FR-2c, NFR-4)
     let mut warnings: Vec<String> = Vec::new();
-    let (processes, worktree) = match exec_result {
+    let (processes, worktree, had_processes_key) = match exec_result {
         Ok(output) => parse_introspect_output(&output),
         Err(ExecError::Timeout {
             msg,
@@ -169,15 +169,34 @@ pub async fn pod_introspect(
             // was slow and got cancelled.
             match partial_output {
                 Some(ref partial) if !partial.trim().is_empty() => parse_introspect_output(partial),
-                _ => (Vec::new(), default_worktree()),
+                _ => (Vec::new(), default_worktree(), false),
             }
         }
         Err(ExecError::Other(e)) => {
             tracing::warn!(pod = %pod_name, error = %e, "introspect exec failed, returning partial");
             warnings.push(format!("exec failed ({e}), showing partial data"));
-            (Vec::new(), default_worktree())
+            (Vec::new(), default_worktree(), false)
         }
     };
+
+    // FR-1b fallback detection: if exec succeeded but the output never
+    // contained a `processes` key, the in-pod fallback `echo '{...}'`
+    // ran and the real `nautiloop-introspect` binary is missing or
+    // crashed before emitting its first NDJSON line. Promote this to
+    // a warning so operators see the failure instead of mistaking an
+    // empty list for a quiet pod.
+    if !had_processes_key {
+        tracing::warn!(
+            pod = %pod_name,
+            "introspect script unavailable in container (fallback path produced worktree-only output); \
+             `nemo ps` will report no processes"
+        );
+        warnings.push(
+            "introspect script unavailable in container (fallback ran); \
+             process list is not the real state — use `kubectl exec` or `nemo logs` instead"
+                .to_string(),
+        );
+    }
 
     let response = PodIntrospectResponse {
         loop_id,
@@ -489,10 +508,18 @@ pub fn parse_memory_to_bytes(mem: &str) -> u64 {
 /// worktree collection is killed mid-flight (FR-2c). We also support the legacy
 /// single-object format (one JSON object with both keys) for backward
 /// compatibility with older agent images and the exec fallback.
-pub fn parse_introspect_output(output: &str) -> (Vec<ProcessInfo>, WorktreeInfo) {
+/// Parse the NDJSON/JSON output from the in-pod introspect script.
+/// The third tuple element is `true` when the output contained an
+/// explicit `processes` key (even if the array was empty) — the
+/// absence of the key is the signal that the shell fallback ran and
+/// the real script either timed out, was missing from the image, or
+/// crashed at startup. Callers use that flag to promote the empty
+/// process list from "pod is idle" into a loud warning, so operators
+/// do not mistake a broken introspect path for a quiet pod.
+pub fn parse_introspect_output(output: &str) -> (Vec<ProcessInfo>, WorktreeInfo, bool) {
     let trimmed = output.trim();
     if trimmed.is_empty() {
-        return (Vec::new(), default_worktree());
+        return (Vec::new(), default_worktree(), false);
     }
 
     // Collect all parsed JSON values. Try the whole output as a single object
@@ -518,9 +545,11 @@ pub fn parse_introspect_output(output: &str) -> (Vec<ProcessInfo>, WorktreeInfo)
 
     let mut processes = Vec::new();
     let mut worktree = default_worktree();
+    let mut had_processes_key = false;
 
     for parsed in &values {
         if let Some(arr) = parsed.get("processes").and_then(|p| p.as_array()) {
+            had_processes_key = true;
             processes = arr
                 .iter()
                 .filter_map(|v| {
@@ -554,7 +583,7 @@ pub fn parse_introspect_output(output: &str) -> (Vec<ProcessInfo>, WorktreeInfo)
         }
     }
 
-    (processes, worktree)
+    (processes, worktree, had_processes_key)
 }
 
 fn default_worktree() -> WorktreeInfo {
@@ -633,6 +662,7 @@ mod tests {
             hardened_spec_path: None,
             spec_pr_url: None,
             resolved_default_branch: Some("main".to_string()),
+            stage_timeout_secs: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         }
@@ -847,7 +877,7 @@ mod tests {
             r#"{"worktree":{"path":"/work","target_dir_bytes":3221225472,"target_dir_artifacts":1069,"uncommitted_files":2,"head_sha":"42bffd9"}}"#,
         );
 
-        let (processes, worktree) = parse_introspect_output(output);
+        let (processes, worktree, had_processes_key) = parse_introspect_output(output);
         assert_eq!(processes.len(), 2);
         assert_eq!(processes[0].pid, 12);
         assert_eq!(processes[0].cmd, "claude");
@@ -856,6 +886,7 @@ mod tests {
         assert_eq!(worktree.target_dir_bytes, Some(3221225472));
         assert_eq!(worktree.uncommitted_files, Some(2));
         assert_eq!(worktree.head_sha.as_deref(), Some("42bffd9"));
+        assert!(had_processes_key);
     }
 
     #[test]
@@ -864,7 +895,7 @@ mod tests {
         // but before worktree emission (FR-2c). Processes must be preserved.
         let output = r#"{"processes":[{"pid":12,"ppid":1,"user":"agent","cpu_percent":3.2,"cmd":"claude","age_seconds":1320}]}"#;
 
-        let (processes, worktree) = parse_introspect_output(output);
+        let (processes, worktree, had_processes_key) = parse_introspect_output(output);
         assert_eq!(processes.len(), 1);
         assert_eq!(processes[0].pid, 12);
         assert_eq!(processes[0].cmd, "claude");
@@ -872,6 +903,7 @@ mod tests {
         assert_eq!(worktree.path, "/work");
         assert_eq!(worktree.target_dir_bytes, None);
         assert_eq!(worktree.head_sha, None);
+        assert!(had_processes_key);
     }
 
     #[test]
@@ -890,40 +922,46 @@ mod tests {
             }
         }"#;
 
-        let (processes, worktree) = parse_introspect_output(output);
+        let (processes, worktree, had_processes_key) = parse_introspect_output(output);
         assert_eq!(processes.len(), 1);
         assert_eq!(processes[0].pid, 12);
         assert_eq!(worktree.target_dir_artifacts, Some(1069));
         assert_eq!(worktree.uncommitted_files, Some(2));
+        assert!(had_processes_key);
     }
 
     #[test]
     fn test_parse_introspect_output_empty() {
-        let (processes, worktree) = parse_introspect_output("");
+        let (processes, worktree, had_processes_key) = parse_introspect_output("");
         assert!(processes.is_empty());
         assert_eq!(worktree.path, "/work");
+        assert!(!had_processes_key);
     }
 
     #[test]
     fn test_parse_introspect_output_garbage() {
-        let (processes, worktree) = parse_introspect_output("not json at all");
+        let (processes, worktree, had_processes_key) = parse_introspect_output("not json at all");
         assert!(processes.is_empty());
         assert_eq!(worktree.path, "/work");
+        assert!(!had_processes_key);
     }
 
     #[test]
     fn test_parse_introspect_output_partial_worktree() {
         // Matches the fallback JSON emitted when the script is absent or crashes:
         // only worktree defaults (no processes key), so it cannot overwrite real
-        // process data already emitted before a timeout.
+        // process data already emitted before a timeout. `had_processes_key`
+        // must be false here so the handler promotes this to a loud warning
+        // rather than letting `nemo ps` silently report "(no processes)".
         let output = r#"{"worktree":{"path":"/work","target_dir_bytes":null,"target_dir_artifacts":null,"uncommitted_files":null,"head_sha":null}}"#;
-        let (processes, worktree) = parse_introspect_output(output);
+        let (processes, worktree, had_processes_key) = parse_introspect_output(output);
         assert!(processes.is_empty());
         assert_eq!(worktree.path, "/work");
         assert_eq!(worktree.target_dir_bytes, None);
         assert_eq!(worktree.target_dir_artifacts, None);
         assert_eq!(worktree.uncommitted_files, None); // null → None (unknown)
         assert_eq!(worktree.head_sha, None);
+        assert!(!had_processes_key);
     }
 
     #[test]
@@ -936,7 +974,7 @@ mod tests {
             "\n",
             r#"{"worktree":{"path":"/work","target_dir_bytes":null,"target_dir_artifacts":null,"uncommitted_files":null,"head_sha":null}}"#,
         );
-        let (processes, worktree) = parse_introspect_output(output);
+        let (processes, worktree, had_processes_key) = parse_introspect_output(output);
         assert_eq!(
             processes.len(),
             1,
@@ -946,5 +984,6 @@ mod tests {
         assert_eq!(processes[0].cmd, "claude");
         assert_eq!(worktree.path, "/work");
         assert_eq!(worktree.target_dir_bytes, None);
+        assert!(had_processes_key);
     }
 }

--- a/control-plane/src/k8s/client.rs
+++ b/control-plane/src/k8s/client.rs
@@ -72,7 +72,16 @@ impl JobDispatcher for KubeJobDispatcher {
 
         let mut status = job_to_status(&job);
 
-        // For failed jobs, inspect pod exit codes for auth expiry (exit code 42)
+        // For failed jobs, inspect pods for two terminal signals that the
+        // bare Job.status.conditions list can't always reveal in time:
+        //   - exit code 42 (agent convention) ⇒ AuthExpired
+        //   - pod.status.reason == "DeadlineExceeded" ⇒ DeadlineExceeded
+        //
+        // The deadline check also covers the race where `failed > 0` has
+        // incremented on the Job but the `type=Failed` condition has not
+        // yet been materialised with `reason=DeadlineExceeded`, producing
+        // the misleading "Pod failure" fallback on the first status read
+        // after kill time.
         if matches!(status, JobStatus::Failed { .. }) {
             let pods_api: Api<Pod> = Api::namespaced(self.client.clone(), ns);
             let lp = ListParams::default().labels(&format!("job-name={name}"));
@@ -86,6 +95,14 @@ impl JobDispatcher for KubeJobDispatcher {
                             _ => "Auth expired (exit code 42)".to_string(),
                         };
                         status = JobStatus::AuthExpired { reason };
+                        break;
+                    }
+                    if pod_deadline_exceeded(pod) {
+                        let reason = match &status {
+                            JobStatus::Failed { reason } => reason.clone(),
+                            _ => "DeadlineExceeded".to_string(),
+                        };
+                        status = JobStatus::DeadlineExceeded { reason };
                         break;
                     }
                 }
@@ -193,6 +210,33 @@ fn extract_exit_code(pod: &Pod) -> Option<i32> {
     None
 }
 
+/// Detect whether a pod was terminated because the Job's
+/// `activeDeadlineSeconds` elapsed. Kubelet stamps this as
+/// `pod.status.reason == "DeadlineExceeded"`; the agent container
+/// is also recorded as terminated with `reason: DeadlineExceeded`.
+/// We check both because kubelet ordering is not guaranteed.
+fn pod_deadline_exceeded(pod: &Pod) -> bool {
+    let Some(status) = pod.status.as_ref() else {
+        return false;
+    };
+    if status.reason.as_deref() == Some("DeadlineExceeded") {
+        return true;
+    }
+    if let Some(statuses) = status.container_statuses.as_ref() {
+        for cs in statuses {
+            if cs.name != "agent" {
+                continue;
+            }
+            if let Some(terminated) = cs.state.as_ref().and_then(|s| s.terminated.as_ref())
+                && terminated.reason.as_deref() == Some("DeadlineExceeded")
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 /// Extract job status from K8s Job resource.
 fn job_to_status(job: &Job) -> JobStatus {
     let status = match &job.status {
@@ -214,6 +258,13 @@ fn job_to_status(job: &Job) -> JobStatus {
                     (None, Some(m)) => m.clone(),
                     (None, None) => "Unknown failure".to_string(),
                 };
+                // Distinguish activeDeadlineSeconds termination from
+                // genuine pod failure. K8s stamps `reason: DeadlineExceeded`
+                // on the condition when the Job's deadline trips; an
+                // identical retry will hit the same wall-clock budget.
+                if condition.reason.as_deref() == Some("DeadlineExceeded") {
+                    return JobStatus::DeadlineExceeded { reason };
+                }
                 return JobStatus::Failed { reason };
             }
         }

--- a/control-plane/src/k8s/job_builder.rs
+++ b/control-plane/src/k8s/job_builder.rs
@@ -966,6 +966,33 @@ mod tests {
     }
 
     #[test]
+    fn test_build_job_sidecar_present_on_retry_attempts() {
+        // Regression guard for the v0.7.9 production observation that
+        // retry pods (`-t2`, `-t3`, ...) appeared to lack the
+        // `auth-sidecar` container. The job builder takes `retry_count`
+        // only as an opaque counter that influences the generated job
+        // name — it must NOT gate sidecar inclusion. This test locks
+        // that invariant so a future refactor can't silently drop the
+        // sidecar from retry pods (which would break OAuth and git
+        // push for every recovered attempt).
+        let stage = test_stage();
+        let cfg = test_cfg();
+        for retry_count in [0u32, 1, 2, 5] {
+            let mut ctx = test_ctx();
+            ctx.retry_count = retry_count;
+            let job = build_job(&ctx, &stage, &cfg);
+            let pod_spec = job.spec.as_ref().unwrap().template.spec.as_ref().unwrap();
+            let inits = pod_spec.init_containers.as_ref().unwrap_or_else(|| {
+                panic!("retry_count={retry_count}: init_containers must be Some")
+            });
+            assert!(
+                inits.iter().any(|c| c.name == "auth-sidecar"),
+                "retry_count={retry_count}: auth-sidecar must be present in init_containers"
+            );
+        }
+    }
+
+    #[test]
     fn test_build_job_sidecar_security_context() {
         let ctx = test_ctx();
         let stage = test_stage();

--- a/control-plane/src/k8s/mod.rs
+++ b/control-plane/src/k8s/mod.rs
@@ -19,6 +19,11 @@ pub enum JobStatus {
     Failed { reason: String },
     /// Job failed with exit code 42 (auth/credential expiry convention).
     AuthExpired { reason: String },
+    /// Job was terminated by `activeDeadlineSeconds`. This is deterministic:
+    /// an identical retry will hit the same wall-clock budget. The loop
+    /// engine must NOT auto-retry; surface to the operator so they can
+    /// raise `--stage-timeout` and resume.
+    DeadlineExceeded { reason: String },
     /// Job not found.
     NotFound,
 }

--- a/control-plane/src/loop_engine/driver.rs
+++ b/control-plane/src/loop_engine/driver.rs
@@ -242,6 +242,14 @@ impl ConvergentLoopDriver {
                         // Job failed: check retry logic
                         self.handle_job_failed(record, &reason).await
                     }
+                    JobStatus::DeadlineExceeded { reason } => {
+                        // Stage hit activeDeadlineSeconds. Auto-retry would
+                        // repeat identical work and hit the same wall, so
+                        // transition directly to FAILED. Stay resumable
+                        // (#96 failed_from_state) so an operator can
+                        // `nemo resume --stage-timeout=<larger>`.
+                        self.handle_stage_deadline_exceeded(record, &reason).await
+                    }
                     JobStatus::AuthExpired { reason } => {
                         // Auth expired (exit code 42): go directly to AWAITING_REAUTH
                         self.handle_auth_expired(record, &reason).await
@@ -771,7 +779,7 @@ impl ConvergentLoopDriver {
         record.sub_state = Some(SubState::Dispatched);
         record.retry_count = 0; // Reset per-stage retry budget
 
-        let stage_config = self.test_stage_config();
+        let stage_config = self.test_stage_config(record);
         let mut ctx = self.build_context(record).await?;
         self.inject_test_services(record, &mut ctx).await;
 
@@ -1695,6 +1703,63 @@ impl ConvergentLoopDriver {
         self.handle_job_failed_inner(record, reason, true).await
     }
 
+    /// Handle `activeDeadlineSeconds` expiry on a stage Job. Unlike
+    /// a generic pod failure, this is deterministic: a retry hits the
+    /// same wall-clock budget and produces the same outcome. We
+    /// transition directly to FAILED (resumable via #96 so the
+    /// operator can raise `--stage-timeout` and resume without
+    /// re-submitting the spec) and delete the stale Job so the
+    /// resume path can reuse the `-t{N}` slot.
+    async fn handle_stage_deadline_exceeded(
+        &self,
+        record: &LoopRecord,
+        reason: &str,
+    ) -> Result<LoopState> {
+        self.sync_current_stage_logs(record).await;
+
+        if let Some(ref job_name) = record.active_job_name
+            && let Err(e) = self
+                .dispatcher
+                .delete_job(job_name, &self.config.cluster.jobs_namespace)
+                .await
+        {
+            tracing::warn!(
+                loop_id = %record.id,
+                job = job_name,
+                error = %e,
+                "Failed to delete deadline-exceeded job during transition to FAILED"
+            );
+        }
+
+        let budget_secs = self
+            .stage_timeout_for(record)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let operator_reason = if budget_secs > 0 {
+            format!(
+                "StageDeadlineExceeded: {reason} (budget was {budget_secs}s; raise --stage-timeout and resume)"
+            )
+        } else {
+            format!("StageDeadlineExceeded: {reason} (raise --stage-timeout and resume)")
+        };
+
+        let mut updated = record.clone();
+        updated.failed_from_state = Some(updated.state);
+        updated.state = LoopState::Failed;
+        updated.sub_state = None;
+        updated.failure_reason = Some(operator_reason.clone());
+        updated.active_job_name = None;
+        self.store.update_loop(&updated).await?;
+
+        tracing::error!(
+            loop_id = %record.id,
+            stage = ?record.state,
+            reason = %operator_reason,
+            "Stage hit activeDeadlineSeconds; transitioning to FAILED without retry"
+        );
+        Ok(LoopState::Failed)
+    }
+
     /// Like `handle_job_failed` but does NOT mark the exhausted Failed state
     /// as resumable via #96. Use this for failures where ingest_job_output
     /// has already stamped completed_at on the current round (e.g. a job
@@ -2066,7 +2131,7 @@ impl ConvergentLoopDriver {
                 }
             }
             LoopState::Implementing => (self.implement_stage_config(record), "implement"),
-            LoopState::Testing => (self.test_stage_config(), "test"),
+            LoopState::Testing => (self.test_stage_config(record), "test"),
             LoopState::Reviewing => (self.review_stage_config(record), "review"),
             _ => return Ok(record.state),
         };
@@ -2127,7 +2192,7 @@ impl ConvergentLoopDriver {
                     .unwrap_or_else(|| self.config.models.reviewer.clone()),
             ),
             prompt_template: Some(".nautiloop/prompts/spec-audit.md".to_string()),
-            timeout: self.config.timeouts.audit_duration(),
+            timeout: resolve_stage_timeout(record, self.config.timeouts.audit_duration()),
             max_retries: 2,
         }
     }
@@ -2142,7 +2207,7 @@ impl ConvergentLoopDriver {
                     .unwrap_or_else(|| self.config.models.implementor.clone()),
             ),
             prompt_template: Some(".nautiloop/prompts/spec-revise.md".to_string()),
-            timeout: self.config.timeouts.revise_duration(),
+            timeout: resolve_stage_timeout(record, self.config.timeouts.revise_duration()),
             max_retries: 2,
         }
     }
@@ -2157,17 +2222,17 @@ impl ConvergentLoopDriver {
                     .unwrap_or_else(|| self.config.models.implementor.clone()),
             ),
             prompt_template: Some(".nautiloop/prompts/implement.md".to_string()),
-            timeout: self.config.timeouts.implement_duration(),
+            timeout: resolve_stage_timeout(record, self.config.timeouts.implement_duration()),
             max_retries: 2,
         }
     }
 
-    fn test_stage_config(&self) -> StageConfig {
+    fn test_stage_config(&self, record: &LoopRecord) -> StageConfig {
         StageConfig {
             name: "test".to_string(),
             model: None,
             prompt_template: None,
-            timeout: self.config.timeouts.test_duration(),
+            timeout: resolve_stage_timeout(record, self.config.timeouts.test_duration()),
             max_retries: 2,
         }
     }
@@ -2182,7 +2247,7 @@ impl ConvergentLoopDriver {
                     .unwrap_or_else(|| self.config.models.reviewer.clone()),
             ),
             prompt_template: Some(".nautiloop/prompts/review.md".to_string()),
-            timeout: self.config.timeouts.review_duration(),
+            timeout: resolve_stage_timeout(record, self.config.timeouts.review_duration()),
             max_retries: 2,
         }
     }
@@ -2193,6 +2258,27 @@ impl ConvergentLoopDriver {
             .resolved_default_branch
             .clone()
             .unwrap_or_else(|| self.config.cluster.default_branch.clone())
+    }
+
+    /// Resolve the effective stage timeout for the loop's current state.
+    /// Returns `None` for non-active stages (Pending, Failed, etc.). The
+    /// per-loop `stage_timeout_secs` override, when set, supersedes the
+    /// cluster default; otherwise falls back to the matching
+    /// `Timeouts::*_duration()` value from config.
+    fn stage_timeout_for(&self, record: &LoopRecord) -> Option<std::time::Duration> {
+        let default = match record.state {
+            LoopState::Hardening => {
+                // Hardening can be audit or revise; pick based on the
+                // most recent round's stage (same logic as job name
+                // derivation in delete_stale_failed_attempts).
+                self.config.timeouts.audit_duration()
+            }
+            LoopState::Implementing => self.config.timeouts.implement_duration(),
+            LoopState::Testing => self.config.timeouts.test_duration(),
+            LoopState::Reviewing => self.config.timeouts.review_duration(),
+            _ => return None,
+        };
+        Some(resolve_stage_timeout(record, default))
     }
 
     fn max_retries_for_stage(&self, _state: LoopState) -> u32 {
@@ -2513,6 +2599,19 @@ impl ConvergentLoopDriver {
     }
 }
 
+/// Resolve the effective per-stage timeout for a loop record. If the
+/// record carries an explicit override (from `--stage-timeout` at
+/// submit or resume time), that wins; otherwise the stage's
+/// cluster-default duration is returned. Enforces a 300s floor to
+/// avoid nonsense values from CLI typos.
+fn resolve_stage_timeout(record: &LoopRecord, default: std::time::Duration) -> std::time::Duration {
+    const FLOOR_SECS: u64 = 300;
+    match record.stage_timeout_secs {
+        Some(secs) if secs > 0 => std::time::Duration::from_secs((secs as u64).max(FLOOR_SECS)),
+        _ => default,
+    }
+}
+
 /// Detect if a job failure reason indicates expired credentials.
 /// Agents use exit code 42 or specific error messages when auth fails.
 fn is_auth_error(reason: &str) -> bool {
@@ -2601,6 +2700,7 @@ mod tests {
             hardened_spec_path: None,
             spec_pr_url: None,
             resolved_default_branch: Some("main".to_string()),
+            stage_timeout_secs: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         }
@@ -2915,6 +3015,71 @@ mod tests {
 
         let new_state = driver.tick(record.id).await.unwrap();
         assert_eq!(new_state, LoopState::Implementing);
+    }
+
+    #[tokio::test]
+    async fn test_stage_deadline_exceeded_does_not_retry() {
+        // v0.7.9 regression guard: a stage Job terminated by
+        // `activeDeadlineSeconds` must NOT be auto-retried. The budget
+        // is deterministic — a retry would hit the same wall and
+        // produce the same outcome (wasting 15+ minutes per attempt
+        // and burning LLM tokens). Instead we transition directly to
+        // FAILED with `failed_from_state` preserved so the operator
+        // can raise `--stage-timeout` and resume.
+        let store = Arc::new(MemoryStateStore::new());
+        let dispatcher = Arc::new(MockJobDispatcher::new());
+        let driver = make_driver(store.clone(), dispatcher.clone());
+        install_fresh_claude_creds(&dispatcher).await;
+
+        let mut record = make_pending_loop(true);
+        record.state = LoopState::Hardening;
+        record.sub_state = Some(SubState::Dispatched);
+        record.round = 1;
+        record.retry_count = 0;
+        record.active_job_name = Some("audit-job".to_string());
+        store.create_loop(&record).await.unwrap();
+
+        let job = k8s_openapi::api::batch::v1::Job {
+            metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta {
+                name: Some("audit-job".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        dispatcher.create_job(&job).await.unwrap();
+        dispatcher
+            .set_job_status(
+                "audit-job",
+                JobStatus::DeadlineExceeded {
+                    reason: "DeadlineExceeded: Job was active longer than specified deadline"
+                        .to_string(),
+                },
+            )
+            .await;
+
+        let new_state = driver.tick(record.id).await.unwrap();
+        assert_eq!(
+            new_state,
+            LoopState::Failed,
+            "deadline-exceeded must transition straight to FAILED"
+        );
+
+        let updated = store.get_loop(record.id).await.unwrap().unwrap();
+        assert_eq!(updated.retry_count, 0, "deadline must NOT bump retry_count");
+        assert_eq!(
+            updated.failed_from_state,
+            Some(LoopState::Hardening),
+            "failed_from_state must be preserved so `nemo resume --stage-timeout` can restart"
+        );
+        let reason = updated.failure_reason.as_deref().unwrap_or("");
+        assert!(
+            reason.contains("StageDeadlineExceeded"),
+            "failure_reason must surface the deadline distinctly from generic pod failures; got: {reason}"
+        );
+        assert!(
+            reason.contains("stage-timeout"),
+            "failure_reason must tell the operator how to recover; got: {reason}"
+        );
     }
 
     #[tokio::test]

--- a/control-plane/src/loop_engine/reconciler.rs
+++ b/control-plane/src/loop_engine/reconciler.rs
@@ -254,6 +254,7 @@ mod tests {
             hardened_spec_path: None,
             spec_pr_url: None,
             resolved_default_branch: Some("main".to_string()),
+            stage_timeout_secs: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };

--- a/control-plane/src/state/postgres.rs
+++ b/control-plane/src/state/postgres.rs
@@ -146,6 +146,10 @@ fn row_to_loop_record(row: &PgRow) -> Result<LoopRecord> {
         hardened_spec_path: row.get("hardened_spec_path"),
         spec_pr_url: row.get("spec_pr_url"),
         resolved_default_branch: row.try_get("resolved_default_branch").ok().flatten(),
+        stage_timeout_secs: row
+            .try_get::<Option<i32>, _>("stage_timeout_secs")
+            .ok()
+            .flatten(),
         created_at: row.get("created_at"),
         updated_at: row.get("updated_at"),
     })
@@ -321,6 +325,7 @@ impl StateStore for PgStateStore {
                 opencode_session_id, claude_session_id, active_job_name, retry_count, model_implementor,
                 model_reviewer, merge_sha, merged_at, hardened_spec_path, spec_pr_url,
                 resolved_default_branch,
+                stage_timeout_secs,
                 created_at, updated_at
             ) VALUES (
                 $1, $2, $3, $4, $5, $6::loop_kind,
@@ -330,7 +335,8 @@ impl StateStore for PgStateStore {
                 $22, $23, $24, $25, $26,
                 $27, $28, $29, $30, $31,
                 $32,
-                $33, $34
+                $33,
+                $34, $35
             )
             RETURNING *
             "#,
@@ -367,6 +373,7 @@ impl StateStore for PgStateStore {
         .bind(&record.hardened_spec_path)
         .bind(&record.spec_pr_url)
         .bind(&record.resolved_default_branch)
+        .bind(record.stage_timeout_secs)
         .bind(record.created_at)
         .bind(record.updated_at)
         .fetch_one(&self.pool)
@@ -607,6 +614,7 @@ impl StateStore for PgStateStore {
                 hardened_spec_path = $17, spec_pr_url = $18,
                 failed_from_state = $19::loop_state,
                 max_rounds = $20,
+                stage_timeout_secs = $21,
                 updated_at = NOW()
             WHERE id = $1
             "#,
@@ -631,6 +639,7 @@ impl StateStore for PgStateStore {
         .bind(&record.spec_pr_url)
         .bind(record.failed_from_state.map(loop_state_str))
         .bind(record.max_rounds)
+        .bind(record.stage_timeout_secs)
         .execute(&self.pool)
         .await?;
         Ok(())
@@ -1100,6 +1109,7 @@ mod tests {
             hardened_spec_path: None,
             spec_pr_url: None,
             resolved_default_branch: Some("main".to_string()),
+            stage_timeout_secs: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         }

--- a/control-plane/src/types/api.rs
+++ b/control-plane/src/types/api.rs
@@ -23,6 +23,12 @@ pub struct StartRequest {
     pub ship_mode: bool,
     #[serde(default)]
     pub model_overrides: Option<ModelOverrides>,
+    /// Optional per-loop override for the per-stage K8s Job
+    /// `activeDeadlineSeconds` budget. CLI `--stage-timeout=<secs>`.
+    /// Applies uniformly to every stage (audit/revise/implement/test/review).
+    /// Floored to 300s server-side to avoid nonsense values.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stage_timeout_secs: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -123,12 +129,28 @@ pub struct ApproveResponse {
     pub approve_requested: bool,
 }
 
+/// POST /resume/:id request body. Optional — an empty body is valid
+/// and preserves prior behaviour. Present mostly so operators can raise
+/// the per-stage timeout before resuming a loop that hit
+/// `StageDeadlineExceeded`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ResumeRequest {
+    /// Optional per-loop override for per-stage Job `activeDeadlineSeconds`.
+    /// Applies from the next redispatch onward. Floored to 300s server-side.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stage_timeout_secs: Option<u32>,
+}
+
 /// POST /resume/:id response body.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResumeResponse {
     pub loop_id: Uuid,
     pub state: LoopState,
     pub resume_requested: bool,
+    /// Echo of the per-loop stage timeout after any update made by the
+    /// resume call. Useful so the CLI can confirm the override took.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stage_timeout_secs: Option<u32>,
 }
 
 /// POST /extend/:id request body.

--- a/control-plane/src/types/mod.rs
+++ b/control-plane/src/types/mod.rs
@@ -290,6 +290,12 @@ pub struct LoopRecord {
     /// Resolved default branch name (e.g., "main"), frozen at loop creation.
     /// Used for PR --base and merge SHA resolution.
     pub resolved_default_branch: Option<String>,
+    /// Optional per-loop override for the `activeDeadlineSeconds`
+    /// budget on every stage's K8s Job (CLI `--stage-timeout=<secs>`).
+    /// When `None`, the cluster-default timeouts from config apply.
+    /// Persisted so `nemo resume --stage-timeout=<larger>` can raise
+    /// the budget without re-submitting the spec.
+    pub stage_timeout_secs: Option<i32>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }

--- a/control-plane/tests/dashboard_integration.rs
+++ b/control-plane/tests/dashboard_integration.rs
@@ -76,6 +76,7 @@ fn make_loop(engineer: &str, state: LoopState) -> LoopRecord {
         hardened_spec_path: None,
         spec_pr_url: None,
         resolved_default_branch: Some("main".to_string()),
+        stage_timeout_secs: None,
         created_at: now,
         updated_at: now,
     }

--- a/control-plane/tests/judge_integration.rs
+++ b/control-plane/tests/judge_integration.rs
@@ -130,6 +130,7 @@ fn make_reviewing_loop(round: i32) -> LoopRecord {
         hardened_spec_path: None,
         spec_pr_url: None,
         resolved_default_branch: Some("main".to_string()),
+        stage_timeout_secs: None,
         created_at: Utc::now(),
         updated_at: Utc::now(),
     }
@@ -170,6 +171,7 @@ fn make_hardening_loop(round: i32) -> LoopRecord {
         hardened_spec_path: None,
         spec_pr_url: None,
         resolved_default_branch: Some("main".to_string()),
+        stage_timeout_secs: None,
         created_at: Utc::now(),
         updated_at: Utc::now(),
     }

--- a/sidecar/src/model_proxy.rs
+++ b/sidecar/src/model_proxy.rs
@@ -62,10 +62,37 @@ const CHATGPT_CODEX_RESPONSES_ENDPOINT: &str = "https://chatgpt.com/backend-api/
 const OPENAI_CRED_PATH: &str = "/secrets/model-credentials/openai";
 const ANTHROPIC_CRED_PATH: &str = "/secrets/model-credentials/anthropic";
 const OPENAI_OAUTH_REFRESH_MARGIN_MS: i64 = 60_000;
+/// Minimum wall-clock gap between OAuth refresh attempts after a
+/// failure. The upstream rejects re-use of an already-consumed
+/// `refresh_token` with `refresh_token_reused`; retrying immediately
+/// burns log volume and, worse, invalidates any refresh token another
+/// consumer (e.g. the engineer's local Codex CLI) may be holding. 60s
+/// is long enough to let the client back off and short enough that a
+/// genuinely recoverable error is not left unchecked for minutes.
+const OPENAI_OAUTH_REFRESH_COOLDOWN_MS: i64 = 60_000;
 const FORBIDDEN_BODY: &[u8] =
     br#"{"error":"only /openai/* and /anthropic/* routes are supported"}"#;
 
-type SharedOpenAiOauthCache = Arc<Mutex<Option<CodexOauthCredential>>>;
+/// Shared state for the OpenAI Codex OAuth refresh path.
+///
+/// Holds both the last successful credential (so freshly-refreshed
+/// tokens propagate across concurrent requests without re-reading the
+/// on-disk file) AND the last failed-refresh timestamp (so repeated
+/// failures inside the cooldown window short-circuit immediately
+/// instead of hammering the upstream with identical requests).
+#[derive(Default)]
+pub(crate) struct OauthCacheState {
+    credential: Option<CodexOauthCredential>,
+    last_failure: Option<OauthRefreshFailure>,
+}
+
+#[derive(Debug, Clone)]
+struct OauthRefreshFailure {
+    at_ms: i64,
+    message: String,
+}
+
+type SharedOpenAiOauthCache = Arc<Mutex<OauthCacheState>>;
 
 /// Errors produced by the server. These are surfaced to the caller in
 /// `main.rs`; per-request errors are turned into HTTP responses.
@@ -268,7 +295,8 @@ pub async fn serve(
     let connector = SsrfConnector::new(tls_config);
     let client: UpstreamClient = Client::builder(TokioExecutor::new()).build(connector);
     let client = Arc::new(client);
-    let openai_oauth_cache: SharedOpenAiOauthCache = Arc::new(Mutex::new(None));
+    let openai_oauth_cache: SharedOpenAiOauthCache =
+        Arc::new(Mutex::new(OauthCacheState::default()));
 
     let graceful = GracefulShutdown::new();
 
@@ -319,7 +347,7 @@ pub async fn serve(
 async fn handle(
     req: Request<Incoming>,
     client: &UpstreamClient,
-    openai_oauth_cache: &Mutex<Option<CodexOauthCredential>>,
+    openai_oauth_cache: &Mutex<OauthCacheState>,
 ) -> Response<BoxBody<Bytes, hyper::Error>> {
     handle_inner(req, client, openai_oauth_cache, None).await
 }
@@ -333,7 +361,7 @@ async fn handle(
 async fn handle_inner<C>(
     req: Request<Incoming>,
     client: &Client<C, UpstreamBody>,
-    openai_oauth_cache: &Mutex<Option<CodexOauthCredential>>,
+    openai_oauth_cache: &Mutex<OauthCacheState>,
     test_config: Option<&TestProxyConfigInner>,
 ) -> Response<BoxBody<Bytes, hyper::Error>>
 where
@@ -367,7 +395,16 @@ where
         match ensure_fresh_oauth_credential(client, credential, openai_oauth_cache).await {
             Ok(credential) => Some(credential),
             Err(e) => {
-                logging::error(&format!("failed to refresh OpenAI OAuth credentials: {e}"));
+                // `ensure_fresh_oauth_credential` already logs a single
+                // `warn` on the FIRST failure; subsequent failures within
+                // the cooldown window reach here and would otherwise
+                // produce one error line per request for up to 15 min
+                // (the audit stage deadline). Emit at `info` level
+                // instead to preserve per-request traceability without
+                // spamming operators.
+                logging::info(&format!(
+                    "openai oauth refresh unavailable (cooled down): {e}"
+                ));
                 return error_response(502, "openai oauth refresh failed");
             }
         }
@@ -619,7 +656,8 @@ pub async fn serve_for_test(
     let client: Client<HttpConnector, UpstreamBody> =
         Client::builder(TokioExecutor::new()).build(connector);
     let client = Arc::new(client);
-    let openai_oauth_cache: SharedOpenAiOauthCache = Arc::new(Mutex::new(None));
+    let openai_oauth_cache: SharedOpenAiOauthCache =
+        Arc::new(Mutex::new(OauthCacheState::default()));
 
     let graceful = GracefulShutdown::new();
 
@@ -753,13 +791,13 @@ fn oauth_needs_refresh(credential: &CodexOauthCredential) -> bool {
 
 async fn maybe_resolve_cached_oauth_credential(
     credential: OpenAiCredential,
-    openai_oauth_cache: &Mutex<Option<CodexOauthCredential>>,
+    openai_oauth_cache: &Mutex<OauthCacheState>,
 ) -> OpenAiCredential {
     let OpenAiCredential::CodexOauth(file_credential) = credential else {
         return credential;
     };
 
-    let cached = openai_oauth_cache.lock().await.clone();
+    let cached = openai_oauth_cache.lock().await.credential.clone();
     let effective = match cached {
         Some(cached_credential)
             if cached_credential.account_id == file_credential.account_id
@@ -776,7 +814,7 @@ async fn maybe_resolve_cached_oauth_credential(
 async fn ensure_fresh_oauth_credential<C>(
     client: &Client<C, UpstreamBody>,
     credential: OpenAiCredential,
-    openai_oauth_cache: &Mutex<Option<CodexOauthCredential>>,
+    openai_oauth_cache: &Mutex<OauthCacheState>,
 ) -> Result<OpenAiCredential, String>
 where
     C: hyper_util::client::legacy::connect::Connect + Clone + Send + Sync + 'static,
@@ -789,9 +827,53 @@ where
         return Ok(OpenAiCredential::CodexOauth(oauth));
     }
 
-    let refreshed = refresh_codex_oauth_credential(client, &oauth).await?;
-    *openai_oauth_cache.lock().await = Some(refreshed.clone());
-    Ok(OpenAiCredential::CodexOauth(refreshed))
+    // Back off on repeated refresh failures. The upstream returns
+    // `refresh_token_reused` if the same refresh_token is consumed
+    // twice; without a cooldown, every request during the ~15 min
+    // audit window re-attempts the refresh every ~30s, spamming logs
+    // and invalidating tokens held by other consumers (e.g. the
+    // engineer's local Codex CLI). Short-circuit to the cached error
+    // while we wait.
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    {
+        let guard = openai_oauth_cache.lock().await;
+        if let Some(ref failure) = guard.last_failure
+            && now_ms.saturating_sub(failure.at_ms) < OPENAI_OAUTH_REFRESH_COOLDOWN_MS
+        {
+            let remaining_ms = OPENAI_OAUTH_REFRESH_COOLDOWN_MS - (now_ms - failure.at_ms);
+            let remaining_secs = (remaining_ms / 1000).max(1);
+            return Err(format!(
+                "oauth refresh in cooldown ({remaining_secs}s remaining); last error: {}",
+                failure.message
+            ));
+        }
+    }
+
+    match refresh_codex_oauth_credential(client, &oauth).await {
+        Ok(refreshed) => {
+            let mut guard = openai_oauth_cache.lock().await;
+            guard.credential = Some(refreshed.clone());
+            // Clear the backoff window on success so the next legitimate
+            // failure gets a fresh timer rather than an already-aged one.
+            guard.last_failure = None;
+            Ok(OpenAiCredential::CodexOauth(refreshed))
+        }
+        Err(e) => {
+            let mut guard = openai_oauth_cache.lock().await;
+            let first_failure = guard.last_failure.is_none();
+            guard.last_failure = Some(OauthRefreshFailure {
+                at_ms: now_ms,
+                message: e.clone(),
+            });
+            if first_failure {
+                logging::warn(&format!(
+                    "OpenAI OAuth refresh failed; backing off for {}s before retrying: {e}",
+                    OPENAI_OAUTH_REFRESH_COOLDOWN_MS / 1000,
+                ));
+            }
+            Err(e)
+        }
+    }
 }
 
 async fn refresh_codex_oauth_credential<C>(
@@ -1037,6 +1119,73 @@ fn patch_responses_body(bytes: Bytes, is_codex_oauth: bool) -> Bytes {
 mod tests {
     use super::*;
     use http::HeaderMap;
+
+    #[tokio::test]
+    async fn oauth_cache_backoff_short_circuits_within_window() {
+        // v0.7.9 regression guard: when the upstream rejects the
+        // refresh token (e.g. `refresh_token_reused`), subsequent
+        // refresh attempts within the cooldown window must NOT
+        // re-hit the upstream. This used to cause one refresh per
+        // request for ~15 min per audit stage, burning log volume
+        // and invalidating tokens held by other consumers.
+        let cache: SharedOpenAiOauthCache = Arc::new(Mutex::new(OauthCacheState::default()));
+        let now_ms = chrono::Utc::now().timestamp_millis();
+
+        // Seed a fresh failure.
+        cache.lock().await.last_failure = Some(OauthRefreshFailure {
+            at_ms: now_ms,
+            message: "refresh_token_reused".to_string(),
+        });
+
+        // Build a credential that would trigger refresh if not for the cooldown.
+        // (expires in the past → needs refresh).
+        let stale = CodexOauthCredential {
+            access: "stale-access".to_string(),
+            refresh: "stale-refresh".to_string(),
+            expires_ms: now_ms - 1,
+            account_id: Some("acct_1".to_string()),
+        };
+
+        // Use a real client but any resolver is fine — the cooldown
+        // path returns before any network call is made.
+        let connector = hyper_util::client::legacy::connect::HttpConnector::new();
+        let client: Client<_, UpstreamBody> =
+            Client::builder(TokioExecutor::new()).build(connector);
+        let result =
+            ensure_fresh_oauth_credential(&client, OpenAiCredential::CodexOauth(stale), &cache)
+                .await;
+        let err = result.expect_err("cooldown must short-circuit with Err");
+        assert!(
+            err.contains("cooldown"),
+            "error must mention cooldown so callers can distinguish from real refresh failures; got: {err}"
+        );
+        assert!(
+            err.contains("refresh_token_reused"),
+            "error must echo the original upstream message; got: {err}"
+        );
+
+        // Expire the backoff; now the function attempts a real refresh (which
+        // will fail against the no-op client, but that's fine — the test only
+        // proves that the short-circuit is scoped to the cooldown window).
+        cache.lock().await.last_failure = Some(OauthRefreshFailure {
+            at_ms: now_ms - OPENAI_OAUTH_REFRESH_COOLDOWN_MS - 1,
+            message: "stale".to_string(),
+        });
+        let stale = CodexOauthCredential {
+            access: "stale-access".to_string(),
+            refresh: "stale-refresh".to_string(),
+            expires_ms: now_ms - 1,
+            account_id: Some("acct_1".to_string()),
+        };
+        let result =
+            ensure_fresh_oauth_credential(&client, OpenAiCredential::CodexOauth(stale), &cache)
+                .await;
+        let err = result.expect_err("post-cooldown refresh hits upstream and fails");
+        assert!(
+            !err.contains("cooldown"),
+            "post-cooldown error must not be the cooldown short-circuit; got: {err}"
+        );
+    }
 
     // --- route_target ---
 


### PR DESCRIPTION
## Summary

Bundle of fixes for the v0.7.9 real-world failure where a 32 KB spec's harden audit exceeded the hardcoded 900s Job `activeDeadlineSeconds` and retried deterministically until max_retries, plus related CLI bugs surfaced by the same run.

Root cause on the headline bug: the control plane could not distinguish `DeadlineExceeded` from a generic pod failure, there was no CLI knob to raise the timeout, and retries of a deterministic deadline kill will always hit the same wall.

## Fixes

- **`JobStatus::DeadlineExceeded`** surfaced distinctly (server-side k8s `condition.reason` + pod-level fallback for the race). Driver transitions straight to FAILED, no auto-retry, with operator-facing `failure_reason` that says exactly how to recover. `failed_from_state` preserved for resume.
- **`--stage-timeout=<secs>`** on `nemo harden`, `nemo start`, `nemo ship` (initial submit) and `nemo resume` (raise before next redispatch). Persisted on `LoopRecord` via new migration; floored to 300s server-side. Applies uniformly to every stage.
- **`nemo inspect <uuid>`** no longer misroutes as branch — handler accepts `?id=<uuid>` and CLI detects UUID input.
- **`nemo ps`** emits a loud warning when the in-pod introspect script is unavailable (the shell fallback path) instead of silently reporting "(no processes)".
- **`nemo logs --tail --follow`** streams the kubelet log through `async_stream`, fixing the empty-body behavior for stages that run `opencode --format json` (buffered NDJSON).
- **Sidecar OAuth refresh backoff**: 60s cooldown after a failed refresh, short-circuited cached error instead of hammering `/oauth/token` every ~30s for the full stage window and invalidating tokens held by other consumers. Per-request log downgraded to `info`; single `warn` on first failure.
- **Retry-pod sidecar invariant** locked by a table-driven test over `retry_count in [0, 1, 2, 5]` (regression guard for the v0.7.9 operational observation of retry pods without `auth-sidecar`).

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib --bins` (469 unit tests, including three new regression guards: `test_stage_deadline_exceeded_does_not_retry`, `test_build_job_sidecar_present_on_retry_attempts`, `oauth_cache_backoff_short_circuits_within_window`)
- [ ] End-to-end smoke: `nemo harden specs/<big-spec>.md --stage-timeout 2700` on nautiloop-dev, confirm single-retry deadline transitions cleanly to FAILED with the new `StageDeadlineExceeded` reason and `nemo resume --stage-timeout 3600` restarts.
- [ ] Dashboard + `nemo inspect <uuid>` reachable after DB migration applied.
- [ ] Sidecar OAuth log volume drops during a forced refresh-failure window.

Ref: v0.7.9 repro on loop `bfbd82a1-b15f-4305-b789-863c2874934e` (harden audit of `refactor-315-frontend-v2-migration-spec.md`).