### PR TITLE
chore: release 0.7.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-control-plane"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-sidecar"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "bytes",
  "chrono",
@@ -2692,7 +2692,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-cli"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["control-plane", "cli", "sidecar"]
 
 [workspace.package]
-version = "0.7.10"
+version = "0.7.11"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -65,9 +65,9 @@ module "nautiloop" {
   acme_email = "me@mydomain.com"     # required if domain is set
 
   # Optional: images (defaults to latest public GHCR)
-  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.10"
-  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.10"
-  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.10"
+  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.11"
+  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.11"
+  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.11"
 }
 ```
 
@@ -83,9 +83,9 @@ module "nautiloop" {
 | `repo_ssh_private_key` | no | auto-generated | SSH deploy key. If null, generates ED25519 |
 | `domain` | no | `null` | Domain for TLS. null = HTTP on raw IP:8080 |
 | `acme_email` | no | `null` | Let's Encrypt email. Required if domain is set |
-| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.10` | Control plane image |
-| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.10` | Agent base image |
-| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.10` | Auth sidecar image |
+| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.11` | Control plane image |
+| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.11` | Agent base image |
+| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.11` | Auth sidecar image |
 | `k3s_version` | no | `v1.32.13+k3s1` | k3s version (v1.32+ required) |
 | `postgres_password` | no | auto-generated | Postgres password |
 | `postgres_volume_size` | no | `20` | Postgres volume size (Gi) |
@@ -233,9 +233,9 @@ nemo auth                    # pushes credentials (Claude, OpenAI, SSH) to clust
 ```bash
 ./build-images.sh --tag 0.2.0
 terraform apply \
-  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.10" \
-  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.10" \
-  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.10"
+  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.11" \
+  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.11" \
+  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.11"
 ```
 
 All three images must be updated together to avoid version skew.

--- a/terraform/examples/existing-server/variables.tf
+++ b/terraform/examples/existing-server/variables.tf
@@ -50,17 +50,17 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.10"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.11"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.10"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.11"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.10"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.11"
 }

--- a/terraform/examples/hetzner/variables.tf
+++ b/terraform/examples/hetzner/variables.tf
@@ -77,19 +77,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.10"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.11"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.10"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.11"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.10"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.11"
 }
 
 variable "k3s_version" {

--- a/terraform/modules/nautiloop/variables.tf
+++ b/terraform/modules/nautiloop/variables.tf
@@ -79,19 +79,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.10"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.11"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.10"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.11"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.10"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.11"
 }
 
 # --- Optional: tuning ---

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -71,19 +71,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.10"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.11"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.10"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.11"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.10"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.11"
 }
 
 variable "k3s_version" {


### PR DESCRIPTION
## Summary
Re-cut the v0.7.10 content after fixing the release workflow. v0.7.10's tag was pushed but no artifacts were published because both control-plane image builds failed on a stale `sidecar/tests/parity/` reference (#204).

Carries forward:
- fix(k8s): surface `DeadlineExceeded` as a distinct `JobStatus` and transition straight to FAILED with `failed_from_state` preserved so `nemo resume --stage-timeout=<larger>` can restart (#202).
- feat(cli,api): `--stage-timeout=<secs>` on `nemo harden`, `nemo start`, `nemo ship`, and `nemo resume` with a 300s floor (#202).
- fix(api,cli): `nemo inspect <uuid>` routes to `?id=<uuid>` instead of misinterpreting the UUID as a branch name (#202).
- fix(api): `nemo ps` emits a loud warning when the in-pod introspect script's shell fallback ran, instead of silently reporting "(no processes)" (#202).
- feat(api,cli): `nemo logs --tail --follow` streams the kubelet log so bursty `opencode --format json` output is visible in real time (#202).
- fix(sidecar): 60s cooldown on OAuth refresh failures, short-circuited cached error instead of re-hitting the upstream per request (#202).
- fix(ci): drop stale `sidecar/tests/parity` reference from control-plane Dockerfile (#204).

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib --bins` (469 unit tests).
- [x] Local `docker buildx build --platform linux/arm64` and `--platform linux/amd64` against `images/control-plane/Dockerfile`.
- [ ] Operator smoke test on real-world harden after release images ship.