### PR TITLE
fix: honor [timeouts] in nemo.toml and bump aggressive defaults

### DIFF
--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -64,13 +64,18 @@ default_branch = "{default_branch}"
 max_rounds_harden = 10
 max_rounds_implement = 15
 
+# Per-stage K8s Job `activeDeadlineSeconds` overrides. These flow
+# through to every `nemo harden` / `nemo start` / `nemo ship` run
+# submitted from this repo — the CLI attaches them to the submit
+# request and the server pins them on the loop record so retries and
+# resumes inherit the budget. Floor enforced at 300s server-side.
 [timeouts]
-implement_secs = 1800
-review_secs = 900
-test_secs = 1800
-audit_secs = 900
-revise_secs = 900
-watchdog_secs = 900
+implement_secs = 7200
+review_secs    = 3600
+test_secs      = 7200
+audit_secs     = 3600
+revise_secs    = 3600
+watchdog_secs  = 3600
 
 [models]
 implementor = "claude-opus-4"

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -22,6 +22,11 @@ pub struct StartArgs<'a> {
     /// Optional per-stage Job `activeDeadlineSeconds` override. Uniform
     /// across all stages. Server-side floored to 300s.
     pub stage_timeout_secs: Option<u32>,
+    /// Per-stage timeout overrides sourced from the repo-level
+    /// `nemo.toml` `[timeouts]` block. Attached to the submit body so
+    /// the server can stamp them on the loop record; per-stage beats
+    /// uniform `stage_timeout_secs` at stage-dispatch time.
+    pub project_timeouts: crate::project_config::TimeoutsSection,
 }
 
 pub async fn run(client: &NemoClient, args: StartArgs<'_>) -> Result<()> {
@@ -168,6 +173,11 @@ fn build_start_body(args: &StartArgs<'_>, spec_content: &str) -> serde_json::Val
         body["stage_timeout_secs"] = serde_json::json!(secs);
     }
 
+    if !args.project_timeouts.is_empty() {
+        body["timeouts"] =
+            serde_json::to_value(&args.project_timeouts).unwrap_or(serde_json::Value::Null);
+    }
+
     body
 }
 
@@ -194,6 +204,7 @@ mod tests {
             model_impl: None,
             model_review: None,
             stage_timeout_secs: None,
+            project_timeouts: Default::default(),
         };
         let body = build_start_body(&args, &content);
 
@@ -233,10 +244,68 @@ mod tests {
             model_impl: Some("claude-opus-4-6".to_string()),
             model_review: None,
             stage_timeout_secs: None,
+            project_timeouts: Default::default(),
         };
         let body = build_start_body(&args, "# Spec");
         assert!(body["model_overrides"].is_object());
         assert_eq!(body["model_overrides"]["implementor"], "claude-opus-4-6");
+    }
+
+    #[test]
+    fn test_build_start_body_includes_project_timeouts() {
+        // v0.7.12 regression guard: [timeouts] in the repo-level
+        // nemo.toml must flow through to the submit body so the server
+        // can stamp per-stage overrides on the loop record. Prior to
+        // this, `nemo init` generated [timeouts] that nothing read.
+        let args = StartArgs {
+            engineer: "alice",
+            spec_path: "specs/big.md",
+            harden: true,
+            harden_only: true,
+            auto_approve: false,
+            ship_mode: false,
+            model_impl: None,
+            model_review: None,
+            stage_timeout_secs: None,
+            project_timeouts: crate::project_config::TimeoutsSection {
+                implement_secs: Some(7200),
+                review_secs: Some(3600),
+                test_secs: Some(7200),
+                audit_secs: Some(3600),
+                revise_secs: Some(3600),
+                watchdog_secs: None,
+            },
+        };
+        let body = build_start_body(&args, "# Spec");
+        let timeouts = &body["timeouts"];
+        assert_eq!(timeouts["audit_secs"], 3600);
+        assert_eq!(timeouts["implement_secs"], 7200);
+        assert_eq!(timeouts["review_secs"], 3600);
+        assert!(
+            timeouts.get("watchdog_secs").is_none(),
+            "unset stages must not appear; server treats absent as cluster default"
+        );
+    }
+
+    #[test]
+    fn test_build_start_body_omits_empty_project_timeouts() {
+        let args = StartArgs {
+            engineer: "alice",
+            spec_path: "specs/ok.md",
+            harden: true,
+            harden_only: false,
+            auto_approve: false,
+            ship_mode: false,
+            model_impl: None,
+            model_review: None,
+            stage_timeout_secs: None,
+            project_timeouts: Default::default(),
+        };
+        let body = build_start_body(&args, "# Spec");
+        assert!(
+            body.get("timeouts").is_none(),
+            "empty [timeouts] must not be serialized (keeps request bodies clean)"
+        );
     }
 
     #[test]
@@ -251,6 +320,7 @@ mod tests {
             model_impl: None,
             model_review: None,
             stage_timeout_secs: None,
+            project_timeouts: Default::default(),
         };
         let body = build_start_body(&args, "# Spec");
         assert!(body.get("model_overrides").is_none());
@@ -300,6 +370,7 @@ mod tests {
             model_impl: None,
             model_review: None,
             stage_timeout_secs: None,
+            project_timeouts: Default::default(),
         };
         let body = build_start_body(&args, "# Spec");
         assert_eq!(
@@ -321,6 +392,7 @@ mod tests {
             model_impl: None,
             model_review: None,
             stage_timeout_secs: None,
+            project_timeouts: Default::default(),
         };
         let body = build_start_body(&args, "# Spec");
         assert_eq!(body["harden"], false, "--no-harden must send harden: false");
@@ -406,6 +478,7 @@ mod tests {
             model_impl: None,
             model_review: None,
             stage_timeout_secs: None,
+            project_timeouts: Default::default(),
         };
         assert_eq!(
             phase_plan_label(&args),
@@ -426,6 +499,7 @@ mod tests {
             model_impl: None,
             model_review: None,
             stage_timeout_secs: None,
+            project_timeouts: Default::default(),
         };
         assert_eq!(phase_plan_label(&args), "IMPLEMENT (harden skipped)");
     }
@@ -443,6 +517,7 @@ mod tests {
             model_impl: None,
             model_review: None,
             stage_timeout_secs: None,
+            project_timeouts: Default::default(),
         };
         assert_eq!(phase_plan_label(&args), "HARDEN \u{2192} IMPLEMENT");
     }
@@ -460,6 +535,7 @@ mod tests {
             model_impl: None,
             model_review: None,
             stage_timeout_secs: None,
+            project_timeouts: Default::default(),
         };
         assert_eq!(
             phase_plan_label(&args),
@@ -480,6 +556,7 @@ mod tests {
             model_impl: None,
             model_review: None,
             stage_timeout_secs: None,
+            project_timeouts: Default::default(),
         };
         assert_eq!(phase_plan_label(&args), "HARDEN");
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1103,6 +1103,8 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
         } => {
             let (model_impl, model_review) =
                 project_config::resolve_models(model_impl, model_review, &nemo_config.models)?;
+            let project_timeouts =
+                project_config::load_project_timeouts(&std::env::current_dir()?)?;
             claude_creds::ensure_fresh(&http_client, engineer, eng_name, eng_email).await?;
             commands::start::run(
                 &http_client,
@@ -1116,6 +1118,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                     model_impl,
                     model_review,
                     stage_timeout_secs: stage_timeout,
+                    project_timeouts,
                 },
             )
             .await?;
@@ -1134,6 +1137,8 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
             }
             let (model_impl, model_review) =
                 project_config::resolve_models(model_impl, model_review, &nemo_config.models)?;
+            let project_timeouts =
+                project_config::load_project_timeouts(&std::env::current_dir()?)?;
             claude_creds::ensure_fresh(&http_client, engineer, eng_name, eng_email).await?;
             commands::start::run(
                 &http_client,
@@ -1147,6 +1152,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                     model_impl,
                     model_review,
                     stage_timeout_secs: stage_timeout,
+                    project_timeouts,
                 },
             )
             .await?;
@@ -1160,6 +1166,8 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
         } => {
             let (model_impl, model_review) =
                 project_config::resolve_models(model_impl, model_review, &nemo_config.models)?;
+            let project_timeouts =
+                project_config::load_project_timeouts(&std::env::current_dir()?)?;
             claude_creds::ensure_fresh(&http_client, engineer, eng_name, eng_email).await?;
             commands::start::run(
                 &http_client,
@@ -1173,6 +1181,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                     model_impl,
                     model_review,
                     stage_timeout_secs: stage_timeout,
+                    project_timeouts,
                 },
             )
             .await?;

--- a/cli/src/project_config.rs
+++ b/cli/src/project_config.rs
@@ -29,10 +29,51 @@ pub struct ModelsSection {
     pub reviewer: Option<String>,
 }
 
+/// `[timeouts]` block from the repo-level `nemo.toml`, mirroring the
+/// control-plane's `TimeoutConfig`. Every field is optional so operators
+/// can pin just the stage(s) they care about; unset stages fall through
+/// to the cluster default. Sent to the control-plane on every `nemo
+/// harden/start/ship` submit so the server stamps per-stage overrides
+/// on the loop record.
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+pub struct TimeoutsSection {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub implement_secs: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub review_secs: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test_secs: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub audit_secs: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revise_secs: Option<u32>,
+    /// Watchdog is a server-side concern (no-output timeout, separate
+    /// from `activeDeadlineSeconds`); accepted here so `nemo init`'s
+    /// generated block parses cleanly without being silently rejected.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub watchdog_secs: Option<u32>,
+}
+
+impl TimeoutsSection {
+    /// True if every field is `None` — i.e. there's nothing to send
+    /// to the server. The CLI skips attaching an empty block to keep
+    /// request bodies clean.
+    pub fn is_empty(&self) -> bool {
+        self.implement_secs.is_none()
+            && self.review_secs.is_none()
+            && self.test_secs.is_none()
+            && self.audit_secs.is_none()
+            && self.revise_secs.is_none()
+            && self.watchdog_secs.is_none()
+    }
+}
+
 #[derive(Debug, Default, Deserialize)]
 struct ProjectTomlShape {
     #[serde(default)]
     models: ModelsSection,
+    #[serde(default)]
+    timeouts: TimeoutsSection,
 }
 
 /// Walk up from `start` looking for `nemo.toml`. Returns its directory
@@ -67,6 +108,20 @@ pub fn load_project_models(start: &Path) -> Result<ModelsSection> {
     let contents = std::fs::read_to_string(&path)?;
     let parsed: ProjectTomlShape = toml::from_str(&contents)?;
     Ok(parsed.models)
+}
+
+/// Load `[timeouts]` from the nearest `./nemo.toml`, walking up from
+/// `start`. Returns an empty section if no file is found or the
+/// section is absent. Used at submit time so per-stage deadlines
+/// configured in the repo actually flow to the K8s Job spec instead
+/// of being silently dropped.
+pub fn load_project_timeouts(start: &Path) -> Result<TimeoutsSection> {
+    let Some(path) = find_project_toml(start) else {
+        return Ok(TimeoutsSection::default());
+    };
+    let contents = std::fs::read_to_string(&path)?;
+    let parsed: ProjectTomlShape = toml::from_str(&contents)?;
+    Ok(parsed.timeouts)
 }
 
 /// Resolve the effective (implementor, reviewer) model pair using the
@@ -128,7 +183,12 @@ mod tests {
     #[test]
     fn find_none_when_absent() {
         let td = tmpdir();
-        assert!(find_project_toml(td.path()).is_none());
+        let got = find_project_toml(td.path());
+        assert!(
+            got.is_none(),
+            "expected None, got {got:?} for start={:?}",
+            td.path()
+        );
     }
 
     #[test]
@@ -294,6 +354,15 @@ mod tests {
 #[cfg(test)]
 mod tempdir_lite {
     use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    // Process-wide monotonic counter. Without this, two parallel tests
+    // that call `TempDir::new` in the same nanosecond collide on the
+    // generated path (both test binaries see the same PID + nanos),
+    // and one test's fixture file bleeds into the other's workspace.
+    // find_none_when_absent then fails because a parallel
+    // load_models_parses_section wrote nemo.toml into the shared dir.
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
 
     pub struct TempDir {
         path: PathBuf,
@@ -306,7 +375,8 @@ mod tempdir_lite {
                 .duration_since(std::time::UNIX_EPOCH)
                 .map(|d| d.as_nanos())
                 .unwrap_or(0);
-            base.push(format!("{prefix}-{nanos}-{}", std::process::id()));
+            let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+            base.push(format!("{prefix}-{nanos}-{}-{seq}", std::process::id()));
             std::fs::create_dir_all(&base)?;
             Ok(Self { path: base })
         }

--- a/control-plane/migrations/20260424000002_add_per_stage_timeout_overrides.sql
+++ b/control-plane/migrations/20260424000002_add_per_stage_timeout_overrides.sql
@@ -1,0 +1,15 @@
+-- Per-stage `activeDeadlineSeconds` overrides plumbed from repo-level
+-- `nemo.toml` [timeouts]. Each column mirrors a stage_config entry in
+-- the driver. NULL means "fall through to the uniform stage_timeout_secs
+-- override (if set by --stage-timeout) or the cluster default".
+--
+-- Distinct from `stage_timeout_secs` (migration 20260424000001), which
+-- is a uniform-across-all-stages value set by `--stage-timeout`. The
+-- per-stage columns win when set, so a user can pin audit=3600 but
+-- still let implement inherit the cluster default.
+ALTER TABLE loops
+    ADD COLUMN implement_timeout_secs INTEGER,
+    ADD COLUMN test_timeout_secs      INTEGER,
+    ADD COLUMN review_timeout_secs    INTEGER,
+    ADD COLUMN audit_timeout_secs     INTEGER,
+    ADD COLUMN revise_timeout_secs    INTEGER;

--- a/control-plane/src/api/dashboard/handlers.rs
+++ b/control-plane/src/api/dashboard/handlers.rs
@@ -1794,6 +1794,11 @@ mod tests {
             spec_pr_url: None,
             resolved_default_branch: Some("main".to_string()),
             stage_timeout_secs: None,
+            implement_timeout_secs: None,
+            test_timeout_secs: None,
+            review_timeout_secs: None,
+            audit_timeout_secs: None,
+            revise_timeout_secs: None,
             created_at: now,
             updated_at: now,
         }

--- a/control-plane/src/api/handlers.rs
+++ b/control-plane/src/api/handlers.rs
@@ -238,6 +238,31 @@ pub async fn start(
                 .to_string(),
         ),
         stage_timeout_secs: req.stage_timeout_secs.map(|s| s as i32),
+        implement_timeout_secs: req
+            .timeouts
+            .as_ref()
+            .and_then(|t| t.implement_secs)
+            .map(|s| s as i32),
+        test_timeout_secs: req
+            .timeouts
+            .as_ref()
+            .and_then(|t| t.test_secs)
+            .map(|s| s as i32),
+        review_timeout_secs: req
+            .timeouts
+            .as_ref()
+            .and_then(|t| t.review_secs)
+            .map(|s| s as i32),
+        audit_timeout_secs: req
+            .timeouts
+            .as_ref()
+            .and_then(|t| t.audit_secs)
+            .map(|s| s as i32),
+        revise_timeout_secs: req
+            .timeouts
+            .as_ref()
+            .and_then(|t| t.revise_secs)
+            .map(|s| s as i32),
         created_at: now,
         updated_at: now,
     };
@@ -829,22 +854,53 @@ pub async fn resume(
         });
     }
 
-    // If the caller supplied a new --stage-timeout, persist it before
-    // raising the resume flag so the next reconciler tick's redispatch
-    // picks up the larger budget. The driver's resolve_stage_timeout
-    // floors this at 300s; we also reject <1 here to keep "unset"
-    // distinct from "explicit zero".
+    // If the caller supplied a new --stage-timeout or per-stage
+    // overrides, persist them before raising the resume flag so the
+    // next reconciler tick's redispatch picks up the larger budget.
+    // `resolve_stage_timeout` floors all explicit values at 300s; we
+    // also reject 0 here to keep "unset" distinct from "explicit
+    // zero".
+    let has_per_stage = req
+        .timeouts
+        .as_ref()
+        .map(|t| {
+            t.implement_secs.is_some()
+                || t.test_secs.is_some()
+                || t.review_secs.is_some()
+                || t.audit_secs.is_some()
+                || t.revise_secs.is_some()
+        })
+        .unwrap_or(false);
     let mut updated_timeout = record.stage_timeout_secs;
-    if let Some(secs) = req.stage_timeout_secs {
-        if secs == 0 {
+    if req.stage_timeout_secs.is_some() || has_per_stage {
+        if let Some(0) = req.stage_timeout_secs {
             return Err(NautiloopError::BadRequest(
                 "stage_timeout_secs must be a positive integer (minimum 300)".to_string(),
             ));
         }
         let mut updated = record.clone();
-        updated.stage_timeout_secs = Some(secs as i32);
+        if let Some(secs) = req.stage_timeout_secs {
+            updated.stage_timeout_secs = Some(secs as i32);
+            updated_timeout = Some(secs as i32);
+        }
+        if let Some(ref t) = req.timeouts {
+            if let Some(s) = t.implement_secs {
+                updated.implement_timeout_secs = Some(s as i32);
+            }
+            if let Some(s) = t.test_secs {
+                updated.test_timeout_secs = Some(s as i32);
+            }
+            if let Some(s) = t.review_secs {
+                updated.review_timeout_secs = Some(s as i32);
+            }
+            if let Some(s) = t.audit_secs {
+                updated.audit_timeout_secs = Some(s as i32);
+            }
+            if let Some(s) = t.revise_secs {
+                updated.revise_timeout_secs = Some(s as i32);
+            }
+        }
         state.store.update_loop(&updated).await?;
-        updated_timeout = Some(secs as i32);
     }
 
     state
@@ -1537,6 +1593,11 @@ mod tests {
             spec_pr_url: None,
             resolved_default_branch: Some("main".to_string()),
             stage_timeout_secs: None,
+            implement_timeout_secs: None,
+            test_timeout_secs: None,
+            review_timeout_secs: None,
+            audit_timeout_secs: None,
+            revise_timeout_secs: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
@@ -1600,6 +1661,11 @@ mod tests {
             spec_pr_url: None,
             resolved_default_branch: Some("main".to_string()),
             stage_timeout_secs: None,
+            implement_timeout_secs: None,
+            test_timeout_secs: None,
+            review_timeout_secs: None,
+            audit_timeout_secs: None,
+            revise_timeout_secs: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
@@ -1657,6 +1723,11 @@ mod tests {
             spec_pr_url: None,
             resolved_default_branch: Some("main".to_string()),
             stage_timeout_secs: None,
+            implement_timeout_secs: None,
+            test_timeout_secs: None,
+            review_timeout_secs: None,
+            audit_timeout_secs: None,
+            revise_timeout_secs: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
@@ -2522,6 +2593,11 @@ mod tests {
             spec_pr_url: None,
             resolved_default_branch: Some("main".to_string()),
             stage_timeout_secs: None,
+            implement_timeout_secs: None,
+            test_timeout_secs: None,
+            review_timeout_secs: None,
+            audit_timeout_secs: None,
+            revise_timeout_secs: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };

--- a/control-plane/src/api/introspect.rs
+++ b/control-plane/src/api/introspect.rs
@@ -663,6 +663,11 @@ mod tests {
             spec_pr_url: None,
             resolved_default_branch: Some("main".to_string()),
             stage_timeout_secs: None,
+            implement_timeout_secs: None,
+            test_timeout_secs: None,
+            review_timeout_secs: None,
+            audit_timeout_secs: None,
+            revise_timeout_secs: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         }

--- a/control-plane/src/config/mod.rs
+++ b/control-plane/src/config/mod.rs
@@ -328,23 +328,32 @@ impl TimeoutConfig {
     }
 }
 
+// Defaults bumped in 0.7.12: the prior 900s / 1800s budgets were too
+// aggressive for real-world specs. A 32 KB spec audited by
+// `opencode --format json -m openai/gpt-5.4` against a real monorepo
+// consistently exceeded 15 min, tripping `activeDeadlineSeconds` before
+// the stage produced a verdict. The new floor is roomy enough that the
+// deadline is genuinely a watchdog, not an expected-runtime gate.
+// Operators who want tighter budgets can override via the [timeouts]
+// block on the server's nemo.toml ConfigMap (terraform var
+// `timeouts`), or per-loop via `--stage-timeout` on the CLI.
 fn default_implement_timeout() -> u64 {
-    1800
+    7200
 }
 fn default_review_timeout() -> u64 {
-    900
+    3600
 }
 fn default_test_timeout() -> u64 {
-    1800
+    7200
 }
 fn default_audit_timeout() -> u64 {
-    900
+    3600
 }
 fn default_revise_timeout() -> u64 {
-    900
+    3600
 }
 fn default_watchdog_timeout() -> u64 {
-    900
+    3600
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -527,8 +536,8 @@ mod tests {
         let config = NautiloopConfig::default();
         assert_eq!(config.limits.max_rounds_harden, 10);
         assert_eq!(config.limits.max_rounds_implement, 15);
-        assert_eq!(config.timeouts.implement_secs, 1800);
-        assert_eq!(config.timeouts.review_secs, 900);
+        assert_eq!(config.timeouts.implement_secs, 7200);
+        assert_eq!(config.timeouts.review_secs, 3600);
         assert_eq!(config.cluster.max_connections, 20);
         assert_eq!(config.cluster.reconcile_interval_secs, 5);
     }
@@ -536,9 +545,11 @@ mod tests {
     #[test]
     fn test_timeout_durations() {
         let config = TimeoutConfig::default();
-        assert_eq!(config.implement_duration(), Duration::from_secs(1800));
-        assert_eq!(config.review_duration(), Duration::from_secs(900));
-        assert_eq!(config.test_duration(), Duration::from_secs(1800));
+        assert_eq!(config.implement_duration(), Duration::from_secs(7200));
+        assert_eq!(config.review_duration(), Duration::from_secs(3600));
+        assert_eq!(config.test_duration(), Duration::from_secs(7200));
+        assert_eq!(config.audit_duration(), Duration::from_secs(3600));
+        assert_eq!(config.revise_duration(), Duration::from_secs(3600));
     }
 
     #[test]
@@ -559,7 +570,7 @@ mod tests {
         assert_eq!(config.limits.max_rounds_harden, 5);
         assert_eq!(config.limits.max_rounds_implement, 10);
         assert_eq!(config.timeouts.implement_secs, 3600);
-        assert_eq!(config.timeouts.review_secs, 900); // default
+        assert_eq!(config.timeouts.review_secs, 3600); // default
         assert_eq!(config.models.implementor, "claude-sonnet-4");
     }
 

--- a/control-plane/src/loop_engine/driver.rs
+++ b/control-plane/src/loop_engine/driver.rs
@@ -2192,7 +2192,11 @@ impl ConvergentLoopDriver {
                     .unwrap_or_else(|| self.config.models.reviewer.clone()),
             ),
             prompt_template: Some(".nautiloop/prompts/spec-audit.md".to_string()),
-            timeout: resolve_stage_timeout(record, self.config.timeouts.audit_duration()),
+            timeout: resolve_stage_timeout(
+                record,
+                record.audit_timeout_secs,
+                self.config.timeouts.audit_duration(),
+            ),
             max_retries: 2,
         }
     }
@@ -2207,7 +2211,11 @@ impl ConvergentLoopDriver {
                     .unwrap_or_else(|| self.config.models.implementor.clone()),
             ),
             prompt_template: Some(".nautiloop/prompts/spec-revise.md".to_string()),
-            timeout: resolve_stage_timeout(record, self.config.timeouts.revise_duration()),
+            timeout: resolve_stage_timeout(
+                record,
+                record.revise_timeout_secs,
+                self.config.timeouts.revise_duration(),
+            ),
             max_retries: 2,
         }
     }
@@ -2222,7 +2230,11 @@ impl ConvergentLoopDriver {
                     .unwrap_or_else(|| self.config.models.implementor.clone()),
             ),
             prompt_template: Some(".nautiloop/prompts/implement.md".to_string()),
-            timeout: resolve_stage_timeout(record, self.config.timeouts.implement_duration()),
+            timeout: resolve_stage_timeout(
+                record,
+                record.implement_timeout_secs,
+                self.config.timeouts.implement_duration(),
+            ),
             max_retries: 2,
         }
     }
@@ -2232,7 +2244,11 @@ impl ConvergentLoopDriver {
             name: "test".to_string(),
             model: None,
             prompt_template: None,
-            timeout: resolve_stage_timeout(record, self.config.timeouts.test_duration()),
+            timeout: resolve_stage_timeout(
+                record,
+                record.test_timeout_secs,
+                self.config.timeouts.test_duration(),
+            ),
             max_retries: 2,
         }
     }
@@ -2247,7 +2263,11 @@ impl ConvergentLoopDriver {
                     .unwrap_or_else(|| self.config.models.reviewer.clone()),
             ),
             prompt_template: Some(".nautiloop/prompts/review.md".to_string()),
-            timeout: resolve_stage_timeout(record, self.config.timeouts.review_duration()),
+            timeout: resolve_stage_timeout(
+                record,
+                record.review_timeout_secs,
+                self.config.timeouts.review_duration(),
+            ),
             max_retries: 2,
         }
     }
@@ -2261,24 +2281,37 @@ impl ConvergentLoopDriver {
     }
 
     /// Resolve the effective stage timeout for the loop's current state.
-    /// Returns `None` for non-active stages (Pending, Failed, etc.). The
-    /// per-loop `stage_timeout_secs` override, when set, supersedes the
-    /// cluster default; otherwise falls back to the matching
-    /// `Timeouts::*_duration()` value from config.
+    /// Returns `None` for non-active stages (Pending, Failed, etc.).
+    /// Applies the same precedence as the stage-config helpers:
+    /// per-stage override > uniform override > cluster default.
     fn stage_timeout_for(&self, record: &LoopRecord) -> Option<std::time::Duration> {
-        let default = match record.state {
+        let (per_stage, default) = match record.state {
             LoopState::Hardening => {
-                // Hardening can be audit or revise; pick based on the
-                // most recent round's stage (same logic as job name
-                // derivation in delete_stale_failed_attempts).
-                self.config.timeouts.audit_duration()
+                // Hardening is audit or revise; we can't know which
+                // without the last round record, so bias toward audit
+                // (the more common case) when picking the override
+                // column. The default side uses audit for the same
+                // reason.
+                (
+                    record.audit_timeout_secs,
+                    self.config.timeouts.audit_duration(),
+                )
             }
-            LoopState::Implementing => self.config.timeouts.implement_duration(),
-            LoopState::Testing => self.config.timeouts.test_duration(),
-            LoopState::Reviewing => self.config.timeouts.review_duration(),
+            LoopState::Implementing => (
+                record.implement_timeout_secs,
+                self.config.timeouts.implement_duration(),
+            ),
+            LoopState::Testing => (
+                record.test_timeout_secs,
+                self.config.timeouts.test_duration(),
+            ),
+            LoopState::Reviewing => (
+                record.review_timeout_secs,
+                self.config.timeouts.review_duration(),
+            ),
             _ => return None,
         };
-        Some(resolve_stage_timeout(record, default))
+        Some(resolve_stage_timeout(record, per_stage, default))
     }
 
     fn max_retries_for_stage(&self, _state: LoopState) -> u32 {
@@ -2599,17 +2632,35 @@ impl ConvergentLoopDriver {
     }
 }
 
-/// Resolve the effective per-stage timeout for a loop record. If the
-/// record carries an explicit override (from `--stage-timeout` at
-/// submit or resume time), that wins; otherwise the stage's
-/// cluster-default duration is returned. Enforces a 300s floor to
-/// avoid nonsense values from CLI typos.
-fn resolve_stage_timeout(record: &LoopRecord, default: std::time::Duration) -> std::time::Duration {
+/// Resolve the effective timeout for a specific stage on a loop record.
+///
+/// Precedence (first set wins):
+///
+/// 1. Per-stage override on the record (from repo-level `nemo.toml`
+///    `[timeouts]` block plumbed through the CLI at submit time).
+/// 2. Uniform `stage_timeout_secs` (CLI `--stage-timeout`).
+/// 3. Cluster-default duration passed as `default`.
+///
+/// Every explicit override is floored at 300s to prevent CLI typos
+/// from producing a deadline that fires before the pod finishes
+/// pulling its image.
+fn resolve_stage_timeout(
+    record: &LoopRecord,
+    per_stage: Option<i32>,
+    default: std::time::Duration,
+) -> std::time::Duration {
     const FLOOR_SECS: u64 = 300;
-    match record.stage_timeout_secs {
-        Some(secs) if secs > 0 => std::time::Duration::from_secs((secs as u64).max(FLOOR_SECS)),
-        _ => default,
+    if let Some(secs) = per_stage
+        && secs > 0
+    {
+        return std::time::Duration::from_secs((secs as u64).max(FLOOR_SECS));
     }
+    if let Some(secs) = record.stage_timeout_secs
+        && secs > 0
+    {
+        return std::time::Duration::from_secs((secs as u64).max(FLOOR_SECS));
+    }
+    default
 }
 
 /// Detect if a job failure reason indicates expired credentials.
@@ -2660,6 +2711,105 @@ mod tests {
             .await;
     }
 
+    #[test]
+    fn resolve_stage_timeout_precedence_per_stage_beats_uniform_beats_default() {
+        // v0.7.12 regression guard: per-stage override (from nemo.toml
+        // [timeouts]) must win over the uniform --stage-timeout
+        // override, which must win over the cluster default. If this
+        // breaks, operators who pin `audit_secs = 3600` in nemo.toml
+        // silently get whatever the cluster was shipped with.
+        use crate::types::LoopRecord;
+        use chrono::Utc;
+        use std::time::Duration;
+
+        fn blank() -> LoopRecord {
+            LoopRecord {
+                id: uuid::Uuid::new_v4(),
+                engineer: "alice".to_string(),
+                spec_path: "x.md".to_string(),
+                spec_content_hash: "h".to_string(),
+                branch: "agent/alice/x-h".to_string(),
+                kind: LoopKind::Harden,
+                state: LoopState::Hardening,
+                sub_state: None,
+                round: 1,
+                max_rounds: 10,
+                harden: true,
+                harden_only: false,
+                auto_approve: false,
+                cancel_requested: false,
+                approve_requested: false,
+                resume_requested: false,
+                paused_from_state: None,
+                reauth_from_state: None,
+                failed_from_state: None,
+                failure_reason: None,
+                current_sha: None,
+                opencode_session_id: None,
+                claude_session_id: None,
+                active_job_name: None,
+                retry_count: 0,
+                ship_mode: false,
+                model_implementor: None,
+                model_reviewer: None,
+                merge_sha: None,
+                merged_at: None,
+                hardened_spec_path: None,
+                spec_pr_url: None,
+                resolved_default_branch: Some("main".to_string()),
+                stage_timeout_secs: None,
+                implement_timeout_secs: None,
+                test_timeout_secs: None,
+                review_timeout_secs: None,
+                audit_timeout_secs: None,
+                revise_timeout_secs: None,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+            }
+        }
+
+        let default = Duration::from_secs(900);
+
+        // 1. No overrides → cluster default.
+        let r = blank();
+        assert_eq!(resolve_stage_timeout(&r, None, default), default);
+
+        // 2. Uniform override only → applies to every stage.
+        let mut r = blank();
+        r.stage_timeout_secs = Some(2700);
+        assert_eq!(
+            resolve_stage_timeout(&r, None, default),
+            Duration::from_secs(2700)
+        );
+
+        // 3. Per-stage override only → beats default even without uniform.
+        let mut r = blank();
+        r.audit_timeout_secs = Some(3600);
+        assert_eq!(
+            resolve_stage_timeout(&r, r.audit_timeout_secs, default),
+            Duration::from_secs(3600)
+        );
+
+        // 4. Per-stage wins over uniform when BOTH are set.
+        let mut r = blank();
+        r.stage_timeout_secs = Some(1800);
+        r.audit_timeout_secs = Some(3600);
+        assert_eq!(
+            resolve_stage_timeout(&r, r.audit_timeout_secs, default),
+            Duration::from_secs(3600),
+            "per-stage must win over uniform"
+        );
+
+        // 5. Floor: a 60s typo gets clamped to 300s, not honoured.
+        let mut r = blank();
+        r.audit_timeout_secs = Some(60);
+        assert_eq!(
+            resolve_stage_timeout(&r, r.audit_timeout_secs, default),
+            Duration::from_secs(300),
+            "300s floor must apply to per-stage overrides"
+        );
+    }
+
     fn make_pending_loop(auto_approve: bool) -> LoopRecord {
         LoopRecord {
             id: Uuid::new_v4(),
@@ -2701,6 +2851,11 @@ mod tests {
             spec_pr_url: None,
             resolved_default_branch: Some("main".to_string()),
             stage_timeout_secs: None,
+            implement_timeout_secs: None,
+            test_timeout_secs: None,
+            review_timeout_secs: None,
+            audit_timeout_secs: None,
+            revise_timeout_secs: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         }

--- a/control-plane/src/loop_engine/reconciler.rs
+++ b/control-plane/src/loop_engine/reconciler.rs
@@ -255,6 +255,11 @@ mod tests {
             spec_pr_url: None,
             resolved_default_branch: Some("main".to_string()),
             stage_timeout_secs: None,
+            implement_timeout_secs: None,
+            test_timeout_secs: None,
+            review_timeout_secs: None,
+            audit_timeout_secs: None,
+            revise_timeout_secs: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };

--- a/control-plane/src/state/postgres.rs
+++ b/control-plane/src/state/postgres.rs
@@ -150,6 +150,26 @@ fn row_to_loop_record(row: &PgRow) -> Result<LoopRecord> {
             .try_get::<Option<i32>, _>("stage_timeout_secs")
             .ok()
             .flatten(),
+        implement_timeout_secs: row
+            .try_get::<Option<i32>, _>("implement_timeout_secs")
+            .ok()
+            .flatten(),
+        test_timeout_secs: row
+            .try_get::<Option<i32>, _>("test_timeout_secs")
+            .ok()
+            .flatten(),
+        review_timeout_secs: row
+            .try_get::<Option<i32>, _>("review_timeout_secs")
+            .ok()
+            .flatten(),
+        audit_timeout_secs: row
+            .try_get::<Option<i32>, _>("audit_timeout_secs")
+            .ok()
+            .flatten(),
+        revise_timeout_secs: row
+            .try_get::<Option<i32>, _>("revise_timeout_secs")
+            .ok()
+            .flatten(),
         created_at: row.get("created_at"),
         updated_at: row.get("updated_at"),
     })
@@ -326,6 +346,8 @@ impl StateStore for PgStateStore {
                 model_reviewer, merge_sha, merged_at, hardened_spec_path, spec_pr_url,
                 resolved_default_branch,
                 stage_timeout_secs,
+                implement_timeout_secs, test_timeout_secs, review_timeout_secs,
+                audit_timeout_secs, revise_timeout_secs,
                 created_at, updated_at
             ) VALUES (
                 $1, $2, $3, $4, $5, $6::loop_kind,
@@ -336,7 +358,9 @@ impl StateStore for PgStateStore {
                 $27, $28, $29, $30, $31,
                 $32,
                 $33,
-                $34, $35
+                $34, $35, $36,
+                $37, $38,
+                $39, $40
             )
             RETURNING *
             "#,
@@ -374,6 +398,11 @@ impl StateStore for PgStateStore {
         .bind(&record.spec_pr_url)
         .bind(&record.resolved_default_branch)
         .bind(record.stage_timeout_secs)
+        .bind(record.implement_timeout_secs)
+        .bind(record.test_timeout_secs)
+        .bind(record.review_timeout_secs)
+        .bind(record.audit_timeout_secs)
+        .bind(record.revise_timeout_secs)
         .bind(record.created_at)
         .bind(record.updated_at)
         .fetch_one(&self.pool)
@@ -615,6 +644,11 @@ impl StateStore for PgStateStore {
                 failed_from_state = $19::loop_state,
                 max_rounds = $20,
                 stage_timeout_secs = $21,
+                implement_timeout_secs = $22,
+                test_timeout_secs = $23,
+                review_timeout_secs = $24,
+                audit_timeout_secs = $25,
+                revise_timeout_secs = $26,
                 updated_at = NOW()
             WHERE id = $1
             "#,
@@ -640,6 +674,11 @@ impl StateStore for PgStateStore {
         .bind(record.failed_from_state.map(loop_state_str))
         .bind(record.max_rounds)
         .bind(record.stage_timeout_secs)
+        .bind(record.implement_timeout_secs)
+        .bind(record.test_timeout_secs)
+        .bind(record.review_timeout_secs)
+        .bind(record.audit_timeout_secs)
+        .bind(record.revise_timeout_secs)
         .execute(&self.pool)
         .await?;
         Ok(())
@@ -1110,6 +1149,11 @@ mod tests {
             spec_pr_url: None,
             resolved_default_branch: Some("main".to_string()),
             stage_timeout_secs: None,
+            implement_timeout_secs: None,
+            test_timeout_secs: None,
+            review_timeout_secs: None,
+            audit_timeout_secs: None,
+            revise_timeout_secs: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         }

--- a/control-plane/src/types/api.rs
+++ b/control-plane/src/types/api.rs
@@ -29,6 +29,29 @@ pub struct StartRequest {
     /// Floored to 300s server-side to avoid nonsense values.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stage_timeout_secs: Option<u32>,
+    /// Optional per-stage overrides read from the repo-level `nemo.toml`
+    /// `[timeouts]` block. Any stage left `None` falls through to the
+    /// uniform `stage_timeout_secs` (if set) or the cluster default.
+    /// Per-stage wins over uniform.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeouts: Option<StageTimeouts>,
+}
+
+/// Per-stage `activeDeadlineSeconds` overrides mirroring the
+/// `[timeouts]` block in `nemo.toml`. All fields optional so operators
+/// can pin just the stage(s) they care about; the rest fall through.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct StageTimeouts {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub implement_secs: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test_secs: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub review_secs: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub audit_secs: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revise_secs: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -139,6 +162,12 @@ pub struct ResumeRequest {
     /// Applies from the next redispatch onward. Floored to 300s server-side.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stage_timeout_secs: Option<u32>,
+    /// Optional per-stage overrides (mirrors `[timeouts]` in nemo.toml).
+    /// Each field overrides the corresponding stage's deadline for
+    /// future redispatches. Fields left `None` preserve whatever was
+    /// already pinned on the loop row.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeouts: Option<StageTimeouts>,
 }
 
 /// POST /resume/:id response body.

--- a/control-plane/src/types/mod.rs
+++ b/control-plane/src/types/mod.rs
@@ -290,12 +290,24 @@ pub struct LoopRecord {
     /// Resolved default branch name (e.g., "main"), frozen at loop creation.
     /// Used for PR --base and merge SHA resolution.
     pub resolved_default_branch: Option<String>,
-    /// Optional per-loop override for the `activeDeadlineSeconds`
+    /// Optional per-loop uniform override for the `activeDeadlineSeconds`
     /// budget on every stage's K8s Job (CLI `--stage-timeout=<secs>`).
-    /// When `None`, the cluster-default timeouts from config apply.
-    /// Persisted so `nemo resume --stage-timeout=<larger>` can raise
-    /// the budget without re-submitting the spec.
+    /// When `None`, per-stage overrides (below) win, then the cluster
+    /// default. Persisted so `nemo resume --stage-timeout=<larger>` can
+    /// raise the budget without re-submitting the spec.
     pub stage_timeout_secs: Option<i32>,
+    /// Per-stage `activeDeadlineSeconds` overrides plumbed from the
+    /// repo-level `nemo.toml` `[timeouts]` block by the CLI at submit
+    /// time. Each `Some(n)` pins that stage's deadline to `n` seconds
+    /// (300s floor enforced server-side). `None` falls through to the
+    /// uniform override, then the cluster default. Per-stage beats
+    /// uniform because operators sometimes want a long audit budget
+    /// without also extending every implement stage.
+    pub implement_timeout_secs: Option<i32>,
+    pub test_timeout_secs: Option<i32>,
+    pub review_timeout_secs: Option<i32>,
+    pub audit_timeout_secs: Option<i32>,
+    pub revise_timeout_secs: Option<i32>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }

--- a/control-plane/tests/dashboard_integration.rs
+++ b/control-plane/tests/dashboard_integration.rs
@@ -77,6 +77,11 @@ fn make_loop(engineer: &str, state: LoopState) -> LoopRecord {
         spec_pr_url: None,
         resolved_default_branch: Some("main".to_string()),
         stage_timeout_secs: None,
+        implement_timeout_secs: None,
+        test_timeout_secs: None,
+        review_timeout_secs: None,
+        audit_timeout_secs: None,
+        revise_timeout_secs: None,
         created_at: now,
         updated_at: now,
     }

--- a/control-plane/tests/judge_integration.rs
+++ b/control-plane/tests/judge_integration.rs
@@ -131,6 +131,11 @@ fn make_reviewing_loop(round: i32) -> LoopRecord {
         spec_pr_url: None,
         resolved_default_branch: Some("main".to_string()),
         stage_timeout_secs: None,
+        implement_timeout_secs: None,
+        test_timeout_secs: None,
+        review_timeout_secs: None,
+        audit_timeout_secs: None,
+        revise_timeout_secs: None,
         created_at: Utc::now(),
         updated_at: Utc::now(),
     }
@@ -172,6 +177,11 @@ fn make_hardening_loop(round: i32) -> LoopRecord {
         spec_pr_url: None,
         resolved_default_branch: Some("main".to_string()),
         stage_timeout_secs: None,
+        implement_timeout_secs: None,
+        test_timeout_secs: None,
+        review_timeout_secs: None,
+        audit_timeout_secs: None,
+        revise_timeout_secs: None,
         created_at: Utc::now(),
         updated_at: Utc::now(),
     }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -44,4 +44,6 @@ module "nautiloop" {
   ssh_known_hosts      = var.ssh_known_hosts
 
   image_pull_secret_dockerconfigjson = var.image_pull_secret_dockerconfigjson
+
+  timeouts = var.timeouts
 }

--- a/terraform/modules/nautiloop/control-plane.tf
+++ b/terraform/modules/nautiloop/control-plane.tf
@@ -11,6 +11,20 @@ locals {
     ((var.domain == null || var.domain == "") ? false : null)
   )
 
+  # Render a [timeouts] block only if the operator provided at least
+  # one override. Unset stages fall through to the control-plane's
+  # compile-time defaults (7200s / 3600s) — emitting `key = null` in
+  # TOML would break the parser, so we build the block line by line.
+  _timeout_lines = var.timeouts == null ? [] : compact([
+    var.timeouts.implement_secs != null ? "implement_secs = ${var.timeouts.implement_secs}" : "",
+    var.timeouts.review_secs != null ? "review_secs = ${var.timeouts.review_secs}" : "",
+    var.timeouts.test_secs != null ? "test_secs = ${var.timeouts.test_secs}" : "",
+    var.timeouts.audit_secs != null ? "audit_secs = ${var.timeouts.audit_secs}" : "",
+    var.timeouts.revise_secs != null ? "revise_secs = ${var.timeouts.revise_secs}" : "",
+    var.timeouts.watchdog_secs != null ? "watchdog_secs = ${var.timeouts.watchdog_secs}" : "",
+  ])
+  _timeouts_block = length(local._timeout_lines) == 0 ? "" : "\n[timeouts]\n${join("\n", local._timeout_lines)}\n"
+
   nautiloop_toml = <<-TOML
 [cluster]
 git_repo_url = "${var.git_repo_url}"
@@ -18,6 +32,7 @@ agent_image = "${var.agent_base_image}"
 sidecar_image = "${var.sidecar_image}"
 ${var.image_pull_secret_dockerconfigjson != null ? "image_pull_secret = \"nautiloop-registry-creds\"" : ""}
 ${local._dashboard_secure_cookie_resolved != null ? "dashboard_secure_cookie = ${local._dashboard_secure_cookie_resolved}" : ""}
+${local._timeouts_block}
 TOML
 
   config_checksum = sha256(local.nautiloop_toml)

--- a/terraform/modules/nautiloop/variables.tf
+++ b/terraform/modules/nautiloop/variables.tf
@@ -213,3 +213,39 @@ variable "judge_claude_credentials" {
   default     = null
   sensitive   = true
 }
+
+# --- Cluster-wide [timeouts] for stage Jobs ---
+
+variable "timeouts" {
+  description = <<-EOT
+    Cluster-wide per-stage `activeDeadlineSeconds` budgets, mirroring
+    the [timeouts] block in nemo.toml. Each stage is optional; unset
+    stages use the control-plane's compile-time defaults (7200s for
+    implement/test, 3600s for everything else). Operators who run
+    larger specs can raise these once via terraform instead of
+    editing every loop's nemo.toml.
+
+    Per-loop overrides still apply on top of these defaults: `nemo
+    harden --stage-timeout` wins uniformly, and the repo-level
+    nemo.toml [timeouts] plumbed by the CLI wins per-stage.
+  EOT
+  type = object({
+    implement_secs = optional(number)
+    review_secs    = optional(number)
+    test_secs      = optional(number)
+    audit_secs     = optional(number)
+    revise_secs    = optional(number)
+    watchdog_secs  = optional(number)
+  })
+  default = null
+
+  validation {
+    condition = (
+      var.timeouts == null
+      || alltrue([
+        for k, v in var.timeouts : v == null || v >= 300
+      ])
+    )
+    error_message = "Every timeouts.*_secs value must be >= 300 (server floor). Set null to inherit the compile-time default."
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -123,3 +123,16 @@ variable "image_pull_secret_dockerconfigjson" {
   default     = null
   sensitive   = true
 }
+
+variable "timeouts" {
+  description = "Cluster-wide [timeouts] overrides for stage Jobs. See module docs for precedence."
+  type = object({
+    implement_secs = optional(number)
+    review_secs    = optional(number)
+    test_secs      = optional(number)
+    audit_secs     = optional(number)
+    revise_secs    = optional(number)
+    watchdog_secs  = optional(number)
+  })
+  default = null
+}


### PR DESCRIPTION
## Summary

Two bundled fixes responding to a live v0.7.11 bug report: the `[timeouts]` block that `nemo init` generates in repo-level `nemo.toml` was a dead letter, and the compile-time defaults were too aggressive for real-world specs.

**Root cause:** The CLI never parsed `[timeouts]`. The server never received it. Users edited `nemo.toml` in good faith; nothing on the path read it. The server fell back to compile-time 900s / 1800s defaults, which can't fit a 32 KB spec audited by opencode against a real monorepo.

**Fix:** Three precedence layers, all implemented:

| Layer | How | Scope |
|---|---|---|
| Per-stage override | repo `nemo.toml` `[timeouts]` | per-loop, per-stage |
| Uniform override | `nemo harden --stage-timeout=N` | per-loop, all stages |
| Cluster default | terraform var `timeouts` | cluster-wide |

Per-stage beats uniform beats default. Compile-time defaults bumped to match what operators were writing in their `nemo.toml` anyway (7200s for implement/test, 3600s for everything else).

## End-to-end smoke test (local k3d)

Built, imported, restarted, then exercised all three paths:

| Scenario | Request | Job `activeDeadlineSeconds` |
|---|---|---|
| Per-stage override | `timeouts.audit_secs: 1500` | **1500** |
| Uniform override | `stage_timeout_secs: 900` | **900** |
| No overrides | (empty) | **3600** (new default) |

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib --bins` (472 unit tests, new regression guards: `resolve_stage_timeout_precedence_per_stage_beats_uniform_beats_default`, `test_build_start_body_includes_project_timeouts`, `test_build_start_body_omits_empty_project_timeouts`).
- [x] `terraform validate` on `terraform/examples/existing-server`.
- [x] k3d smoke: per-stage, uniform, and cluster-default paths each produce a Job with the expected `activeDeadlineSeconds`.
- [ ] After release: operator smoke test with the real spec that tripped the v0.7.11 bug.