### PR TITLE
chore: release 0.7.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-control-plane"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-sidecar"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "bytes",
  "chrono",
@@ -2692,7 +2692,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-cli"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["control-plane", "cli", "sidecar"]
 
 [workspace.package]
-version = "0.7.11"
+version = "0.7.12"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -65,9 +65,9 @@ module "nautiloop" {
   acme_email = "me@mydomain.com"     # required if domain is set
 
   # Optional: images (defaults to latest public GHCR)
-  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.11"
-  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.11"
-  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.11"
+  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.12"
+  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.12"
+  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.12"
 }
 ```
 
@@ -83,9 +83,9 @@ module "nautiloop" {
 | `repo_ssh_private_key` | no | auto-generated | SSH deploy key. If null, generates ED25519 |
 | `domain` | no | `null` | Domain for TLS. null = HTTP on raw IP:8080 |
 | `acme_email` | no | `null` | Let's Encrypt email. Required if domain is set |
-| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.11` | Control plane image |
-| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.11` | Agent base image |
-| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.11` | Auth sidecar image |
+| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.12` | Control plane image |
+| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.12` | Agent base image |
+| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.12` | Auth sidecar image |
 | `k3s_version` | no | `v1.32.13+k3s1` | k3s version (v1.32+ required) |
 | `postgres_password` | no | auto-generated | Postgres password |
 | `postgres_volume_size` | no | `20` | Postgres volume size (Gi) |
@@ -233,9 +233,9 @@ nemo auth                    # pushes credentials (Claude, OpenAI, SSH) to clust
 ```bash
 ./build-images.sh --tag 0.2.0
 terraform apply \
-  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.11" \
-  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.11" \
-  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.11"
+  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.12" \
+  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.12" \
+  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.12"
 ```
 
 All three images must be updated together to avoid version skew.

--- a/terraform/examples/existing-server/variables.tf
+++ b/terraform/examples/existing-server/variables.tf
@@ -50,17 +50,17 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.11"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.12"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.11"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.12"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.11"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.12"
 }

--- a/terraform/examples/hetzner/variables.tf
+++ b/terraform/examples/hetzner/variables.tf
@@ -77,19 +77,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.11"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.12"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.11"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.12"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.11"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.12"
 }
 
 variable "k3s_version" {

--- a/terraform/modules/nautiloop/variables.tf
+++ b/terraform/modules/nautiloop/variables.tf
@@ -79,19 +79,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.11"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.12"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.11"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.12"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.11"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.12"
 }
 
 # --- Optional: tuning ---

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -71,19 +71,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.11"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.12"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.11"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.12"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.11"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.12"
 }
 
 variable "k3s_version" {


### PR DESCRIPTION
## Summary
Patch release: ship the nemo.toml `[timeouts]` plumbing from #206 so operators can raise per-stage Job `activeDeadlineSeconds` budgets without editing the control-plane image. Compile-time defaults bumped — the prior 900s / 1800s budgets were too aggressive for real-world specs (a 32 KB spec audited by opencode against a real monorepo consistently blew past 15 min).

- fix(cli): parse `[timeouts]` from repo-level `nemo.toml` and attach per-stage overrides to `/start` and `/resume` submit bodies (#206).
- feat(api): `StartRequest` / `ResumeRequest` accept a `timeouts` block; server persists per-stage overrides on five new columns (migration 20260424000002) (#206).
- feat(loop_engine): `resolve_stage_timeout` precedence — per-stage override > uniform `--stage-timeout` > cluster default. 300s floor on explicit overrides (#206).
- feat(terraform): new `timeouts` variable on root + module; emits `[timeouts]` in the `nautiloop-config` ConfigMap when set (#206).
- feat(cli): `nemo init` template updated to match new defaults and explain the plumbing (#206).
- fix: pre-existing `tmpdir_lite` flake in CLI tests fixed with process-wide atomic counter (#206).

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib --bins` (472 unit tests).
- [x] `terraform validate` on `terraform/examples/existing-server`.
- [x] k3d end-to-end smoke: per-stage, uniform, and default paths each produce a Job with the expected `activeDeadlineSeconds`.
- [ ] Operator smoke test after release images ship.