### PR TITLE
fix: mount /cache on every stage, ship bun in agent-base, plumb [cache.env]

### DIFF
--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -27,6 +27,10 @@ pub struct StartArgs<'a> {
     /// the server can stamp them on the loop record; per-stage beats
     /// uniform `stage_timeout_secs` at stage-dispatch time.
     pub project_timeouts: crate::project_config::TimeoutsSection,
+    /// `[cache.env]` overrides from the repo-level `nemo.toml`.
+    /// Merged with the cluster-default cache env at dispatch time;
+    /// per-loop keys win on collisions. Empty map = no override.
+    pub project_cache_env: crate::project_config::CacheSection,
 }
 
 pub async fn run(client: &NemoClient, args: StartArgs<'_>) -> Result<()> {
@@ -178,6 +182,11 @@ fn build_start_body(args: &StartArgs<'_>, spec_content: &str) -> serde_json::Val
             serde_json::to_value(&args.project_timeouts).unwrap_or(serde_json::Value::Null);
     }
 
+    if !args.project_cache_env.is_empty() {
+        body["cache_env"] =
+            serde_json::to_value(&args.project_cache_env.env).unwrap_or(serde_json::Value::Null);
+    }
+
     body
 }
 
@@ -205,6 +214,7 @@ mod tests {
             model_review: None,
             stage_timeout_secs: None,
             project_timeouts: Default::default(),
+            project_cache_env: Default::default(),
         };
         let body = build_start_body(&args, &content);
 
@@ -245,6 +255,7 @@ mod tests {
             model_review: None,
             stage_timeout_secs: None,
             project_timeouts: Default::default(),
+            project_cache_env: Default::default(),
         };
         let body = build_start_body(&args, "# Spec");
         assert!(body["model_overrides"].is_object());
@@ -275,6 +286,7 @@ mod tests {
                 revise_secs: Some(3600),
                 watchdog_secs: None,
             },
+            project_cache_env: Default::default(),
         };
         let body = build_start_body(&args, "# Spec");
         let timeouts = &body["timeouts"];
@@ -284,6 +296,60 @@ mod tests {
         assert!(
             timeouts.get("watchdog_secs").is_none(),
             "unset stages must not appear; server treats absent as cluster default"
+        );
+    }
+
+    #[test]
+    fn test_build_start_body_includes_project_cache_env() {
+        // v0.7.13 regression guard: [cache.env] in repo-level nemo.toml
+        // must flow through to the submit body so the server can stamp
+        // per-loop overrides on the loop record and merge them at
+        // stage dispatch. Same dead-letter shape the [timeouts] fix
+        // addressed in v0.7.12.
+        let mut env = std::collections::HashMap::new();
+        env.insert(
+            "BUN_INSTALL_CACHE_DIR".to_string(),
+            "/cache/bun".to_string(),
+        );
+        env.insert("TURBO_CACHE_DIR".to_string(), "/cache/turbo".to_string());
+        let args = StartArgs {
+            engineer: "alice",
+            spec_path: "specs/js-monorepo.md",
+            harden: true,
+            harden_only: true,
+            auto_approve: false,
+            ship_mode: false,
+            model_impl: None,
+            model_review: None,
+            stage_timeout_secs: None,
+            project_timeouts: Default::default(),
+            project_cache_env: crate::project_config::CacheSection { env },
+        };
+        let body = build_start_body(&args, "# Spec");
+        let cache_env = &body["cache_env"];
+        assert_eq!(cache_env["BUN_INSTALL_CACHE_DIR"], "/cache/bun");
+        assert_eq!(cache_env["TURBO_CACHE_DIR"], "/cache/turbo");
+    }
+
+    #[test]
+    fn test_build_start_body_omits_empty_project_cache_env() {
+        let args = StartArgs {
+            engineer: "alice",
+            spec_path: "specs/ok.md",
+            harden: true,
+            harden_only: false,
+            auto_approve: false,
+            ship_mode: false,
+            model_impl: None,
+            model_review: None,
+            stage_timeout_secs: None,
+            project_timeouts: Default::default(),
+            project_cache_env: Default::default(),
+        };
+        let body = build_start_body(&args, "# Spec");
+        assert!(
+            body.get("cache_env").is_none(),
+            "empty [cache.env] must not be serialized"
         );
     }
 
@@ -300,6 +366,7 @@ mod tests {
             model_review: None,
             stage_timeout_secs: None,
             project_timeouts: Default::default(),
+            project_cache_env: Default::default(),
         };
         let body = build_start_body(&args, "# Spec");
         assert!(
@@ -321,6 +388,7 @@ mod tests {
             model_review: None,
             stage_timeout_secs: None,
             project_timeouts: Default::default(),
+            project_cache_env: Default::default(),
         };
         let body = build_start_body(&args, "# Spec");
         assert!(body.get("model_overrides").is_none());
@@ -371,6 +439,7 @@ mod tests {
             model_review: None,
             stage_timeout_secs: None,
             project_timeouts: Default::default(),
+            project_cache_env: Default::default(),
         };
         let body = build_start_body(&args, "# Spec");
         assert_eq!(
@@ -393,6 +462,7 @@ mod tests {
             model_review: None,
             stage_timeout_secs: None,
             project_timeouts: Default::default(),
+            project_cache_env: Default::default(),
         };
         let body = build_start_body(&args, "# Spec");
         assert_eq!(body["harden"], false, "--no-harden must send harden: false");
@@ -479,6 +549,7 @@ mod tests {
             model_review: None,
             stage_timeout_secs: None,
             project_timeouts: Default::default(),
+            project_cache_env: Default::default(),
         };
         assert_eq!(
             phase_plan_label(&args),
@@ -500,6 +571,7 @@ mod tests {
             model_review: None,
             stage_timeout_secs: None,
             project_timeouts: Default::default(),
+            project_cache_env: Default::default(),
         };
         assert_eq!(phase_plan_label(&args), "IMPLEMENT (harden skipped)");
     }
@@ -518,6 +590,7 @@ mod tests {
             model_review: None,
             stage_timeout_secs: None,
             project_timeouts: Default::default(),
+            project_cache_env: Default::default(),
         };
         assert_eq!(phase_plan_label(&args), "HARDEN \u{2192} IMPLEMENT");
     }
@@ -536,6 +609,7 @@ mod tests {
             model_review: None,
             stage_timeout_secs: None,
             project_timeouts: Default::default(),
+            project_cache_env: Default::default(),
         };
         assert_eq!(
             phase_plan_label(&args),
@@ -557,6 +631,7 @@ mod tests {
             model_review: None,
             stage_timeout_secs: None,
             project_timeouts: Default::default(),
+            project_cache_env: Default::default(),
         };
         assert_eq!(phase_plan_label(&args), "HARDEN");
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1105,6 +1105,8 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                 project_config::resolve_models(model_impl, model_review, &nemo_config.models)?;
             let project_timeouts =
                 project_config::load_project_timeouts(&std::env::current_dir()?)?;
+            let project_cache_env =
+                project_config::load_project_cache_env(&std::env::current_dir()?)?;
             claude_creds::ensure_fresh(&http_client, engineer, eng_name, eng_email).await?;
             commands::start::run(
                 &http_client,
@@ -1119,6 +1121,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                     model_review,
                     stage_timeout_secs: stage_timeout,
                     project_timeouts,
+                    project_cache_env,
                 },
             )
             .await?;
@@ -1139,6 +1142,8 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                 project_config::resolve_models(model_impl, model_review, &nemo_config.models)?;
             let project_timeouts =
                 project_config::load_project_timeouts(&std::env::current_dir()?)?;
+            let project_cache_env =
+                project_config::load_project_cache_env(&std::env::current_dir()?)?;
             claude_creds::ensure_fresh(&http_client, engineer, eng_name, eng_email).await?;
             commands::start::run(
                 &http_client,
@@ -1153,6 +1158,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                     model_review,
                     stage_timeout_secs: stage_timeout,
                     project_timeouts,
+                    project_cache_env,
                 },
             )
             .await?;
@@ -1168,6 +1174,8 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                 project_config::resolve_models(model_impl, model_review, &nemo_config.models)?;
             let project_timeouts =
                 project_config::load_project_timeouts(&std::env::current_dir()?)?;
+            let project_cache_env =
+                project_config::load_project_cache_env(&std::env::current_dir()?)?;
             claude_creds::ensure_fresh(&http_client, engineer, eng_name, eng_email).await?;
             commands::start::run(
                 &http_client,
@@ -1182,6 +1190,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                     model_review,
                     stage_timeout_secs: stage_timeout,
                     project_timeouts,
+                    project_cache_env,
                 },
             )
             .await?;

--- a/cli/src/project_config.rs
+++ b/cli/src/project_config.rs
@@ -68,12 +68,32 @@ impl TimeoutsSection {
     }
 }
 
+/// `[cache]` + `[cache.env]` block from repo-level `nemo.toml`.
+/// Mirrors the server-side `CacheConfig` just enough to read env
+/// overrides; the `disabled` flag stays server-side only since a
+/// per-loop "disable cache" doesn't really make sense (operators
+/// would set `[cache] disabled = true` on the cluster config, not
+/// per-loop).
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+pub struct CacheSection {
+    #[serde(default)]
+    pub env: std::collections::HashMap<String, String>,
+}
+
+impl CacheSection {
+    pub fn is_empty(&self) -> bool {
+        self.env.is_empty()
+    }
+}
+
 #[derive(Debug, Default, Deserialize)]
 struct ProjectTomlShape {
     #[serde(default)]
     models: ModelsSection,
     #[serde(default)]
     timeouts: TimeoutsSection,
+    #[serde(default)]
+    cache: CacheSection,
 }
 
 /// Walk up from `start` looking for `nemo.toml`. Returns its directory
@@ -122,6 +142,21 @@ pub fn load_project_timeouts(start: &Path) -> Result<TimeoutsSection> {
     let contents = std::fs::read_to_string(&path)?;
     let parsed: ProjectTomlShape = toml::from_str(&contents)?;
     Ok(parsed.timeouts)
+}
+
+/// Load `[cache.env]` from the nearest `./nemo.toml`, walking up from
+/// `start`. Returns an empty section when no file is found or the
+/// section is absent. Used at submit time so repo-level cache env
+/// overrides flow through to the K8s Job spec instead of being
+/// silently dropped by the server (same bug shape as [timeouts] was
+/// before v0.7.12).
+pub fn load_project_cache_env(start: &Path) -> Result<CacheSection> {
+    let Some(path) = find_project_toml(start) else {
+        return Ok(CacheSection::default());
+    };
+    let contents = std::fs::read_to_string(&path)?;
+    let parsed: ProjectTomlShape = toml::from_str(&contents)?;
+    Ok(parsed.cache)
 }
 
 /// Resolve the effective (implementor, reviewer) model pair using the

--- a/control-plane/migrations/20260424000003_add_cache_env_overrides.sql
+++ b/control-plane/migrations/20260424000003_add_cache_env_overrides.sql
@@ -1,0 +1,11 @@
+-- Per-loop `[cache.env]` overrides plumbed from repo-level nemo.toml
+-- by the CLI at submit time. Merged with the cluster default at
+-- stage-dispatch time; per-loop keys win on collisions. NULL = no
+-- override (cluster default stands as-is).
+--
+-- Stored as JSONB rather than split columns because the shape is an
+-- arbitrary env-var map (tool names, version-specific vars, repo
+-- conventions). Enforcing a fixed column list would defeat the
+-- purpose of operator-supplied overrides.
+ALTER TABLE loops
+    ADD COLUMN cache_env_overrides JSONB;

--- a/control-plane/src/api/dashboard/handlers.rs
+++ b/control-plane/src/api/dashboard/handlers.rs
@@ -1799,6 +1799,7 @@ mod tests {
             review_timeout_secs: None,
             audit_timeout_secs: None,
             revise_timeout_secs: None,
+            cache_env_overrides: None,
             created_at: now,
             updated_at: now,
         }

--- a/control-plane/src/api/handlers.rs
+++ b/control-plane/src/api/handlers.rs
@@ -263,6 +263,11 @@ pub async fn start(
             .as_ref()
             .and_then(|t| t.revise_secs)
             .map(|s| s as i32),
+        cache_env_overrides: req
+            .cache_env
+            .as_ref()
+            .filter(|m| !m.is_empty())
+            .and_then(|m| serde_json::to_value(m).ok()),
         created_at: now,
         updated_at: now,
     };
@@ -872,7 +877,8 @@ pub async fn resume(
         })
         .unwrap_or(false);
     let mut updated_timeout = record.stage_timeout_secs;
-    if req.stage_timeout_secs.is_some() || has_per_stage {
+    let has_cache_env = req.cache_env.is_some();
+    if req.stage_timeout_secs.is_some() || has_per_stage || has_cache_env {
         if let Some(0) = req.stage_timeout_secs {
             return Err(NautiloopError::BadRequest(
                 "stage_timeout_secs must be a positive integer (minimum 300)".to_string(),
@@ -899,6 +905,15 @@ pub async fn resume(
             if let Some(s) = t.revise_secs {
                 updated.revise_timeout_secs = Some(s as i32);
             }
+        }
+        // Cache env replacement semantics: present → replace wholesale;
+        // absent → leave existing overrides untouched. Empty map clears.
+        if let Some(ref m) = req.cache_env {
+            updated.cache_env_overrides = if m.is_empty() {
+                None
+            } else {
+                serde_json::to_value(m).ok()
+            };
         }
         state.store.update_loop(&updated).await?;
     }
@@ -1598,6 +1613,7 @@ mod tests {
             review_timeout_secs: None,
             audit_timeout_secs: None,
             revise_timeout_secs: None,
+            cache_env_overrides: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
@@ -1666,6 +1682,7 @@ mod tests {
             review_timeout_secs: None,
             audit_timeout_secs: None,
             revise_timeout_secs: None,
+            cache_env_overrides: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
@@ -1728,6 +1745,7 @@ mod tests {
             review_timeout_secs: None,
             audit_timeout_secs: None,
             revise_timeout_secs: None,
+            cache_env_overrides: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
@@ -2598,6 +2616,7 @@ mod tests {
             review_timeout_secs: None,
             audit_timeout_secs: None,
             revise_timeout_secs: None,
+            cache_env_overrides: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };

--- a/control-plane/src/api/introspect.rs
+++ b/control-plane/src/api/introspect.rs
@@ -668,6 +668,7 @@ mod tests {
             review_timeout_secs: None,
             audit_timeout_secs: None,
             revise_timeout_secs: None,
+            cache_env_overrides: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         }

--- a/control-plane/src/config/mod.rs
+++ b/control-plane/src/config/mod.rs
@@ -123,12 +123,13 @@ impl NautiloopConfig {
     /// Resolve the cache configuration for the job builder.
     ///
     /// Three cases (FR-3b):
-    /// - `None` (absent `[cache]` section) → inject sccache defaults
+    /// - `None` (absent `[cache]` section) → inject common defaults
+    ///   (Rust + JS toolchain paths under `/cache/<tool>`).
     /// - `Some(CacheConfig { disabled: true, .. })` → no mount, no env vars
     /// - `Some(CacheConfig { disabled: false, env })` → use env as-is (may be empty)
     pub fn resolved_cache_config(&self) -> CacheConfig {
         match &self.cache {
-            None => CacheConfig::sccache_defaults(),
+            None => CacheConfig::common_defaults(),
             Some(c) => c.clone(),
         }
     }
@@ -619,19 +620,21 @@ mod tests {
     // =========================================================================
 
     #[test]
-    fn test_resolved_cache_absent_injects_sccache_defaults() {
-        // NFR-3: absent [cache] section (None) → sccache defaults injected.
+    fn test_resolved_cache_absent_injects_common_defaults() {
+        // v0.7.13: absent [cache] section (None) → common defaults
+        // (Rust + JS toolchain) injected. Older releases only injected
+        // sccache env vars here, which meant JS monorepos got zero
+        // cache paths even with /cache mounted.
         let config = NautiloopConfig {
             cache: None,
             ..Default::default()
         };
         let resolved = config.resolved_cache_config();
         assert!(!resolved.disabled);
-        assert_eq!(resolved.env.len(), 4);
         assert_eq!(resolved.env["RUSTC_WRAPPER"], "sccache");
-        assert_eq!(resolved.env["SCCACHE_DIR"], "/cache/sccache");
-        assert_eq!(resolved.env["SCCACHE_CACHE_SIZE"], "15G");
-        assert_eq!(resolved.env["SCCACHE_IDLE_TIMEOUT"], "0");
+        assert_eq!(resolved.env["BUN_INSTALL_CACHE_DIR"], "/cache/bun");
+        assert_eq!(resolved.env["PNPM_STORE_PATH"], "/cache/pnpm");
+        assert_eq!(resolved.env["TURBO_CACHE_DIR"], "/cache/turbo");
     }
 
     #[test]

--- a/control-plane/src/config/repo.rs
+++ b/control-plane/src/config/repo.rs
@@ -27,18 +27,58 @@ pub struct CacheConfig {
 }
 
 impl CacheConfig {
-    /// Sccache defaults injected when `[cache]` is absent from nemo.toml.
-    /// Byte-identical to #130 behavior.
-    pub fn sccache_defaults() -> Self {
+    /// Default cache env vars injected when `[cache]` is absent from
+    /// nemo.toml. Covers the common Rust + JS toolchain so operators
+    /// whose monorepo fits the 80th-percentile shape (Cargo, Bun,
+    /// pnpm, Turborepo, Vitest, Playwright) get a warm cache across
+    /// retries out of the box. Setting a single env var to a
+    /// `/cache/<tool>` path is cheap — if the tool is absent the env
+    /// var is ignored; if present it hits the shared PVC on every
+    /// stage.
+    ///
+    /// Operators who want to prune the list or add repo-specific
+    /// entries can still do so via `[cache.env]` in `nemo.toml`; any
+    /// keys set there override the corresponding defaults, and any
+    /// new keys are layered on top.
+    pub fn common_defaults() -> Self {
         let mut env = HashMap::new();
+        // Rust: sccache compilation cache.
         env.insert("RUSTC_WRAPPER".to_string(), "sccache".to_string());
         env.insert("SCCACHE_DIR".to_string(), "/cache/sccache".to_string());
         env.insert("SCCACHE_CACHE_SIZE".to_string(), "15G".to_string());
         env.insert("SCCACHE_IDLE_TIMEOUT".to_string(), "0".to_string());
+        // JS package-manager + build caches. These all key on
+        // `/cache/<tool>` to match the PVC layout that implement/
+        // audit/review pods mount. No-op when the tool is not on the
+        // PATH — setting e.g. `BUN_INSTALL_CACHE_DIR` in a non-Bun
+        // repo is harmless.
+        env.insert(
+            "BUN_INSTALL_CACHE_DIR".to_string(),
+            "/cache/bun".to_string(),
+        );
+        env.insert("NPM_CONFIG_CACHE".to_string(), "/cache/npm".to_string());
+        env.insert("PNPM_STORE_PATH".to_string(), "/cache/pnpm".to_string());
+        env.insert("YARN_GLOBAL_FOLDER".to_string(), "/cache/yarn".to_string());
+        env.insert("TURBO_CACHE_DIR".to_string(), "/cache/turbo".to_string());
+        // Test-runner caches.
+        env.insert("VITEST_CACHE_DIR".to_string(), "/cache/vitest".to_string());
+        env.insert(
+            "PLAYWRIGHT_BROWSERS_PATH".to_string(),
+            "/cache/playwright".to_string(),
+        );
         Self {
             disabled: false,
             env,
         }
+    }
+
+    /// Back-compat alias. Earlier releases exposed the defaults via
+    /// `sccache_defaults`; renamed to reflect that the list now spans
+    /// the JS toolchain too. Kept for callers outside this crate
+    /// during the deprecation window.
+    #[deprecated(note = "use `common_defaults()` — the list is no longer sccache-only")]
+    pub fn sccache_defaults() -> Self {
+        Self::common_defaults()
     }
 }
 
@@ -426,14 +466,26 @@ mod tests {
     }
 
     #[test]
-    fn test_sccache_defaults() {
-        let defaults = CacheConfig::sccache_defaults();
+    fn test_common_defaults() {
+        let defaults = CacheConfig::common_defaults();
         assert!(!defaults.disabled);
-        assert_eq!(defaults.env.len(), 4);
+        // Rust sccache group.
         assert_eq!(defaults.env["RUSTC_WRAPPER"], "sccache");
         assert_eq!(defaults.env["SCCACHE_DIR"], "/cache/sccache");
         assert_eq!(defaults.env["SCCACHE_CACHE_SIZE"], "15G");
         assert_eq!(defaults.env["SCCACHE_IDLE_TIMEOUT"], "0");
+        // JS package-manager caches.
+        assert_eq!(defaults.env["BUN_INSTALL_CACHE_DIR"], "/cache/bun");
+        assert_eq!(defaults.env["NPM_CONFIG_CACHE"], "/cache/npm");
+        assert_eq!(defaults.env["PNPM_STORE_PATH"], "/cache/pnpm");
+        assert_eq!(defaults.env["YARN_GLOBAL_FOLDER"], "/cache/yarn");
+        assert_eq!(defaults.env["TURBO_CACHE_DIR"], "/cache/turbo");
+        // Test-runner caches.
+        assert_eq!(defaults.env["VITEST_CACHE_DIR"], "/cache/vitest");
+        assert_eq!(
+            defaults.env["PLAYWRIGHT_BROWSERS_PATH"],
+            "/cache/playwright"
+        );
     }
 
     #[test]

--- a/control-plane/src/k8s/job_builder.rs
+++ b/control-plane/src/k8s/job_builder.rs
@@ -76,7 +76,7 @@ pub fn build_job(ctx: &LoopContext, stage: &StageConfig, cfg: &JobBuildConfig) -
     let is_test = matches!(parsed_stage, Some(Stage::Test));
 
     // FR-27: Environment variables on the agent container
-    let agent_env = build_agent_env_vars(ctx, stage, is_test, is_implement_or_revise, &cfg.cache);
+    let agent_env = build_agent_env_vars(ctx, stage, is_test, &cfg.cache);
 
     // Build volumes (FR-25, FR-26, FR-30)
     let mut volumes = build_volumes(
@@ -287,7 +287,6 @@ fn build_agent_env_vars(
     ctx: &LoopContext,
     stage: &StageConfig,
     is_test: bool,
-    is_implement_or_revise: bool,
     cache: &CacheConfig,
 ) -> Vec<EnvVar> {
     let mut env = vec![
@@ -404,11 +403,20 @@ fn build_agent_env_vars(
         }
     }
 
-    // Cache env vars for implement/revise stages. Driven by [cache.env] in
-    // nemo.toml (FR-3a). When [cache] is absent, sccache defaults are injected
-    // by NautiloopConfig::resolved_cache_config(). When disabled=true, no env
-    // vars are set. Sorted by key for deterministic pod specs.
-    if is_implement_or_revise && !cache.disabled {
+    // Cache env vars on every stage. Driven by [cache.env] in nemo.toml
+    // (FR-3a). When [cache] is absent, the common defaults are injected
+    // by NautiloopConfig::resolved_cache_config(). When disabled=true,
+    // no env vars are set. Sorted by key for deterministic pod specs.
+    //
+    // Previously gated on IMPLEMENT/REVISE. That meant audit/review pods
+    // (which routinely run `bun install`, `npm test`, etc. against the
+    // live repo to verify a spec) had no path-aware env vars and cold-
+    // started every filesystem cache on every retry. The /cache mount
+    // is now present on every stage (read-only on review/audit), so
+    // the env vars need to reach those stages too — a `BUN_INSTALL_CACHE_DIR`
+    // pointing at `/cache/bun` is a pure loss when `/cache` isn't there,
+    // and a pure win the moment it is.
+    if !cache.disabled {
         let mut keys: Vec<&String> = cache.env.keys().collect();
         keys.sort();
         for key in keys {
@@ -589,13 +597,23 @@ fn build_agent_mounts(
         },
     ];
 
-    // FR-2a: Mount shared cache PVC at /cache for IMPLEMENT/REVISE only.
-    // Review/audit are read-only stages. Test is per-service.
-    // FR-3d: Skip mount when cache is disabled.
-    if is_implement_or_revise && !cache.disabled {
+    // Mount the shared cache PVC at /cache on every stage.
+    //
+    // Earlier versions gated this on IMPLEMENT/REVISE on the theory
+    // that review/audit are "read-only" stages and shouldn't pollute
+    // the cache. In practice audit and review drive `bun install`,
+    // `npm test`, and similar real commands against the live repo, so
+    // cold-starting every filesystem cache per retry is a pure loss
+    // for operators — and the `[cache.env]` block on nemo.toml then
+    // silently dropped because the env vars referenced `/cache/...`
+    // paths that didn't exist. Mount read-only on review/audit so
+    // they can read existing cache entries without mutating them.
+    // Implement/revise and test remain read-write.
+    if !cache.disabled {
         mounts.push(VolumeMount {
             name: "cache".to_string(),
             mount_path: "/cache".to_string(),
+            read_only: Some(is_review_or_audit),
             ..Default::default()
         });
     }
@@ -784,7 +802,7 @@ mod tests {
             git_repo_url: "git@github.com:test-org/test-repo.git".to_string(),
             ssh_known_hosts_configmap: "nautiloop-ssh-known-hosts".to_string(),
             skip_iptables: false,
-            cache: CacheConfig::sccache_defaults(),
+            cache: CacheConfig::common_defaults(),
         }
     }
 
@@ -1371,31 +1389,84 @@ mod tests {
     }
 
     #[test]
-    fn test_cache_env_vars_not_on_review() {
-        // NFR-3: Zero cache env vars on review/audit/test stages.
-        let ctx = test_ctx();
-        let stage = StageConfig {
-            name: "review".to_string(),
-            timeout: Duration::from_secs(900),
-            ..Default::default()
-        };
-        let mut cfg = test_cfg();
-        let mut env = std::collections::HashMap::new();
-        env.insert("FOO".to_string(), "/cache/foo".to_string());
-        cfg.cache = CacheConfig {
-            disabled: false,
-            env,
-        };
+    fn test_cache_env_vars_on_review_and_audit() {
+        // v0.7.13 regression guard (inverts earlier NFR-3): audit /
+        // review pods routinely run `bun install`, `npm test`,
+        // etc. against the live repo to verify a spec. Dropping their
+        // cache env vars silently broke [cache.env] for the two
+        // stages that need it most. Now they receive the same env
+        // vars as implement/revise (with a read-only /cache mount
+        // so they can't clobber the cache).
+        for stage_name in ["review", "audit"] {
+            let ctx = test_ctx();
+            let stage = StageConfig {
+                name: stage_name.to_string(),
+                timeout: Duration::from_secs(900),
+                ..Default::default()
+            };
+            let mut cfg = test_cfg();
+            let mut env = std::collections::HashMap::new();
+            env.insert("FOO".to_string(), "/cache/foo".to_string());
+            cfg.cache = CacheConfig {
+                disabled: false,
+                env,
+            };
 
+            let job = build_job(&ctx, &stage, &cfg);
+            let agent = &job.spec.unwrap().template.spec.unwrap().containers[0];
+            let env_vars = agent.env.as_ref().unwrap();
+            let foo = env_vars.iter().find(|e| e.name == "FOO");
+            assert!(
+                foo.is_some(),
+                "cache env vars must reach the {stage_name} stage"
+            );
+            assert_eq!(foo.unwrap().value.as_deref(), Some("/cache/foo"));
+        }
+    }
+
+    #[test]
+    fn test_cache_mount_read_only_on_review_and_audit() {
+        // Complement to the env-var test: the `/cache` volume mount
+        // is present on review/audit but read-only so those stages
+        // can read existing cache entries without mutating them.
+        for stage_name in ["review", "audit"] {
+            let ctx = test_ctx();
+            let stage = StageConfig {
+                name: stage_name.to_string(),
+                timeout: Duration::from_secs(900),
+                ..Default::default()
+            };
+            let cfg = test_cfg();
+
+            let job = build_job(&ctx, &stage, &cfg);
+            let agent = &job.spec.unwrap().template.spec.unwrap().containers[0];
+            let mounts = agent.volume_mounts.as_ref().unwrap();
+            let cache_mount = mounts
+                .iter()
+                .find(|m| m.mount_path == "/cache")
+                .unwrap_or_else(|| panic!("{stage_name} pod missing /cache mount"));
+            assert_eq!(
+                cache_mount.read_only,
+                Some(true),
+                "/cache on {stage_name} must be read-only"
+            );
+        }
+    }
+
+    #[test]
+    fn test_cache_mount_read_write_on_implement() {
+        let ctx = test_ctx();
+        let stage = test_stage(); // implement
+        let cfg = test_cfg();
         let job = build_job(&ctx, &stage, &cfg);
         let agent = &job.spec.unwrap().template.spec.unwrap().containers[0];
-        let env_vars = agent.env.as_ref().unwrap();
-
-        // FOO should not be in env for review stage
-        assert!(
-            !env_vars.iter().any(|e| e.name == "FOO"),
-            "cache env vars must not appear on review stage"
-        );
+        let mounts = agent.volume_mounts.as_ref().unwrap();
+        let cache_mount = mounts
+            .iter()
+            .find(|m| m.mount_path == "/cache")
+            .expect("implement pod missing /cache mount");
+        // read_only: None or Some(false) both mean writable.
+        assert_ne!(cache_mount.read_only, Some(true));
     }
 
     #[test]
@@ -1502,28 +1573,47 @@ mod tests {
     }
 
     #[test]
-    fn test_sccache_defaults_on_implement() {
-        // NFR-3: Default sccache env vars appear on implement when using defaults.
-        let ctx = test_ctx();
-        let stage = test_stage(); // implement
-        let cfg = test_cfg(); // Uses CacheConfig::sccache_defaults()
+    fn test_common_cache_defaults_on_every_stage() {
+        // v0.7.13: the default cache env block now spans Rust + JS
+        // toolchains and ships on every stage, not just implement.
+        // This test locks the "default env reaches audit/review"
+        // invariant that motivated the v0.7.13 fix.
+        for stage_name in ["implement", "revise", "test", "review", "audit"] {
+            let ctx = test_ctx();
+            let stage = StageConfig {
+                name: stage_name.to_string(),
+                timeout: Duration::from_secs(900),
+                ..Default::default()
+            };
+            let cfg = test_cfg();
 
-        let job = build_job(&ctx, &stage, &cfg);
-        let agent = &job.spec.unwrap().template.spec.unwrap().containers[0];
-        let env_vars = agent.env.as_ref().unwrap();
+            let job = build_job(&ctx, &stage, &cfg);
+            let agent = &job.spec.unwrap().template.spec.unwrap().containers[0];
+            let env_vars = agent.env.as_ref().unwrap();
 
-        let find_env = |name: &str| -> Option<String> {
-            env_vars
-                .iter()
-                .find(|e| e.name == name)
-                .and_then(|e| e.value.clone())
-        };
+            let find_env = |name: &str| -> Option<String> {
+                env_vars
+                    .iter()
+                    .find(|e| e.name == name)
+                    .and_then(|e| e.value.clone())
+            };
 
-        // Sccache defaults
-        assert_eq!(find_env("RUSTC_WRAPPER").unwrap(), "sccache");
-        assert_eq!(find_env("SCCACHE_DIR").unwrap(), "/cache/sccache");
-        assert_eq!(find_env("SCCACHE_CACHE_SIZE").unwrap(), "15G");
-        assert_eq!(find_env("SCCACHE_IDLE_TIMEOUT").unwrap(), "0");
+            assert_eq!(
+                find_env("RUSTC_WRAPPER").unwrap(),
+                "sccache",
+                "sccache default missing on {stage_name}"
+            );
+            assert_eq!(
+                find_env("BUN_INSTALL_CACHE_DIR").unwrap(),
+                "/cache/bun",
+                "bun default missing on {stage_name}"
+            );
+            assert_eq!(
+                find_env("PLAYWRIGHT_BROWSERS_PATH").unwrap(),
+                "/cache/playwright",
+                "playwright default missing on {stage_name}"
+            );
+        }
     }
 
     #[test]
@@ -1555,8 +1645,12 @@ mod tests {
     }
 
     #[test]
-    fn test_cache_not_mounted_on_test_stage() {
-        // FR-2a: Test stages do NOT get the /cache mount.
+    fn test_cache_mounted_read_write_on_test_stage() {
+        // v0.7.13 (inverts prior FR-2a): test stages DO get the /cache
+        // mount read-write. Filesystem caches are the whole point of
+        // the test stage — sccache, Vitest cache, Playwright browser
+        // download cache — and the prior "read-only pods only" gate
+        // meant every test retry cold-started every cache.
         let ctx = test_ctx();
         let stage = StageConfig {
             name: "test".to_string(),
@@ -1568,9 +1662,14 @@ mod tests {
         let job = build_job(&ctx, &stage, &cfg);
         let agent = &job.spec.unwrap().template.spec.unwrap().containers[0];
         let mounts = agent.volume_mounts.as_ref().unwrap();
-        assert!(
-            !mounts.iter().any(|m| m.mount_path == "/cache"),
-            "/cache mount must not appear on test stage"
+        let cache_mount = mounts
+            .iter()
+            .find(|m| m.mount_path == "/cache")
+            .expect("test pod missing /cache mount");
+        assert_ne!(
+            cache_mount.read_only,
+            Some(true),
+            "test stage writes to cache (sccache, vitest); must be read-write"
         );
     }
 }

--- a/control-plane/src/loop_engine/driver.rs
+++ b/control-plane/src/loop_engine/driver.rs
@@ -62,8 +62,23 @@ impl ConvergentLoopDriver {
         }
     }
 
-    /// Build the K8s job configuration from cluster config.
-    fn job_build_config(&self) -> job_builder::JobBuildConfig {
+    /// Build the K8s job configuration from cluster config. Accepts
+    /// an optional per-loop cache-env override (from the repo-level
+    /// `nemo.toml` `[cache.env]` block plumbed through the CLI at
+    /// submit time); those keys overlay the cluster default, with
+    /// per-loop winning on collisions. Empty/missing override leaves
+    /// the cluster default untouched.
+    fn job_build_config_for(&self, record: &LoopRecord) -> job_builder::JobBuildConfig {
+        let mut cache = self.config.resolved_cache_config();
+        if let Some(ref overrides) = record.cache_env_overrides
+            && let Some(map) = overrides.as_object()
+        {
+            for (k, v) in map {
+                if let Some(s) = v.as_str() {
+                    cache.env.insert(k.clone(), s.to_string());
+                }
+            }
+        }
         job_builder::JobBuildConfig {
             namespace: self.config.cluster.jobs_namespace.clone(),
             agent_image: self.config.cluster.agent_image.clone(),
@@ -74,7 +89,7 @@ impl ConvergentLoopDriver {
             git_repo_url: self.config.cluster.git_repo_url.clone(),
             ssh_known_hosts_configmap: self.config.cluster.ssh_known_hosts_configmap.clone(),
             skip_iptables: self.config.cluster.skip_iptables,
-            cache: self.config.resolved_cache_config(),
+            cache,
         }
     }
 
@@ -161,7 +176,8 @@ impl ConvergentLoopDriver {
             let stage_config = self.audit_stage_config(record);
             let mut ctx = self.build_context(&updated).await?;
             ctx.session_id = Self::session_id_for_stage(record, "audit");
-            let job = job_builder::build_job(&ctx, &stage_config, &self.job_build_config());
+            let job =
+                job_builder::build_job(&ctx, &stage_config, &self.job_build_config_for(&updated));
             self.persist_then_dispatch(&mut updated, "audit", &job)
                 .await?;
 
@@ -783,7 +799,7 @@ impl ConvergentLoopDriver {
         let mut ctx = self.build_context(record).await?;
         self.inject_test_services(record, &mut ctx).await;
 
-        let job = job_builder::build_job(&ctx, &stage_config, &self.job_build_config());
+        let job = job_builder::build_job(&ctx, &stage_config, &self.job_build_config_for(record));
         self.persist_then_dispatch(record, "test", &job).await?;
 
         tracing::info!(loop_id = %record.id, round = record.round, "IMPLEMENTING -> TESTING/DISPATCHED");
@@ -1909,7 +1925,7 @@ impl ConvergentLoopDriver {
         let stage_config = self.implement_stage_config(record);
         let mut ctx = self.build_context(&updated).await?;
         ctx.session_id = Self::session_id_for_stage(&updated, "implement");
-        let job = job_builder::build_job(&ctx, &stage_config, &self.job_build_config());
+        let job = job_builder::build_job(&ctx, &stage_config, &self.job_build_config_for(&updated));
         self.persist_then_dispatch(&mut updated, "implement", &job)
             .await?;
 
@@ -1926,7 +1942,7 @@ impl ConvergentLoopDriver {
         let stage_config = self.audit_stage_config(record);
         let mut ctx = self.build_context(record).await?;
         ctx.session_id = Self::session_id_for_stage(record, "audit");
-        let job = job_builder::build_job(&ctx, &stage_config, &self.job_build_config());
+        let job = job_builder::build_job(&ctx, &stage_config, &self.job_build_config_for(record));
         self.persist_then_dispatch(record, "audit", &job).await?;
 
         Ok(LoopState::Hardening)
@@ -1987,7 +2003,7 @@ impl ConvergentLoopDriver {
         let mut ctx = self.build_context(record).await?;
         ctx.session_id = Self::session_id_for_stage(record, "revise");
         ctx.feedback_path = Some(feedback_path.clone());
-        let job = job_builder::build_job(&ctx, &stage_config, &self.job_build_config());
+        let job = job_builder::build_job(&ctx, &stage_config, &self.job_build_config_for(record));
         self.persist_then_dispatch(record, "revise", &job).await?;
 
         tracing::info!(
@@ -2009,7 +2025,7 @@ impl ConvergentLoopDriver {
         let stage_config = self.review_stage_config(record);
         let mut ctx = self.build_context(record).await?;
         ctx.session_id = Self::session_id_for_stage(record, "review");
-        let job = job_builder::build_job(&ctx, &stage_config, &self.job_build_config());
+        let job = job_builder::build_job(&ctx, &stage_config, &self.job_build_config_for(record));
         self.persist_then_dispatch(record, "review", &job).await?;
 
         tracing::info!(loop_id = %record.id, round = record.round, "TESTING -> REVIEWING/DISPATCHED");
@@ -2058,7 +2074,7 @@ impl ConvergentLoopDriver {
         ctx.session_id = Self::session_id_for_stage(record, "implement");
         ctx.feedback_path = Some(feedback_path.to_string());
 
-        let job = job_builder::build_job(&ctx, &stage_config, &self.job_build_config());
+        let job = job_builder::build_job(&ctx, &stage_config, &self.job_build_config_for(record));
         self.persist_then_dispatch(record, "implement", &job)
             .await?;
 
@@ -2160,7 +2176,7 @@ impl ConvergentLoopDriver {
             });
         }
 
-        let job = job_builder::build_job(&ctx, &stage_config, &self.job_build_config());
+        let job = job_builder::build_job(&ctx, &stage_config, &self.job_build_config_for(&updated));
 
         // Persist state FIRST, then create K8s Job
         let job_name = job
@@ -2711,6 +2727,48 @@ mod tests {
             .await;
     }
 
+    #[tokio::test]
+    async fn job_build_config_for_merges_per_loop_cache_env() {
+        // v0.7.13 regression guard: [cache.env] in a repo-level
+        // nemo.toml, plumbed through the CLI as a per-loop override,
+        // must land in the K8s Job's env vars. Per-loop keys win over
+        // cluster defaults on collisions; unrelated cluster-default
+        // keys stay intact.
+        use crate::types::LoopRecord;
+        use serde_json::json;
+
+        let store = Arc::new(MemoryStateStore::new());
+        let dispatcher = Arc::new(MockJobDispatcher::new());
+        let driver = make_driver(store, dispatcher);
+
+        let mut record: LoopRecord = make_pending_loop(true);
+        record.cache_env_overrides = Some(json!({
+            "BUN_INSTALL_CACHE_DIR": "/cache/bun-loop-override",
+            "NPM_CONFIG_CACHE": "/cache/npm-loop-override",
+        }));
+
+        let cfg = driver.job_build_config_for(&record);
+
+        // Per-loop keys win.
+        assert_eq!(
+            cfg.cache
+                .env
+                .get("BUN_INSTALL_CACHE_DIR")
+                .map(String::as_str),
+            Some("/cache/bun-loop-override"),
+        );
+        assert_eq!(
+            cfg.cache.env.get("NPM_CONFIG_CACHE").map(String::as_str),
+            Some("/cache/npm-loop-override"),
+        );
+        // Unrelated cluster-default keys survive the merge.
+        assert_eq!(
+            cfg.cache.env.get("RUSTC_WRAPPER").map(String::as_str),
+            Some("sccache"),
+            "cluster-default sccache env must survive per-loop merge"
+        );
+    }
+
     #[test]
     fn resolve_stage_timeout_precedence_per_stage_beats_uniform_beats_default() {
         // v0.7.12 regression guard: per-stage override (from nemo.toml
@@ -2763,6 +2821,7 @@ mod tests {
                 review_timeout_secs: None,
                 audit_timeout_secs: None,
                 revise_timeout_secs: None,
+                cache_env_overrides: None,
                 created_at: Utc::now(),
                 updated_at: Utc::now(),
             }
@@ -2856,6 +2915,7 @@ mod tests {
             review_timeout_secs: None,
             audit_timeout_secs: None,
             revise_timeout_secs: None,
+            cache_env_overrides: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         }

--- a/control-plane/src/loop_engine/reconciler.rs
+++ b/control-plane/src/loop_engine/reconciler.rs
@@ -260,6 +260,7 @@ mod tests {
             review_timeout_secs: None,
             audit_timeout_secs: None,
             revise_timeout_secs: None,
+            cache_env_overrides: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };

--- a/control-plane/src/state/postgres.rs
+++ b/control-plane/src/state/postgres.rs
@@ -170,6 +170,10 @@ fn row_to_loop_record(row: &PgRow) -> Result<LoopRecord> {
             .try_get::<Option<i32>, _>("revise_timeout_secs")
             .ok()
             .flatten(),
+        cache_env_overrides: row
+            .try_get::<Option<serde_json::Value>, _>("cache_env_overrides")
+            .ok()
+            .flatten(),
         created_at: row.get("created_at"),
         updated_at: row.get("updated_at"),
     })
@@ -348,6 +352,7 @@ impl StateStore for PgStateStore {
                 stage_timeout_secs,
                 implement_timeout_secs, test_timeout_secs, review_timeout_secs,
                 audit_timeout_secs, revise_timeout_secs,
+                cache_env_overrides,
                 created_at, updated_at
             ) VALUES (
                 $1, $2, $3, $4, $5, $6::loop_kind,
@@ -360,7 +365,8 @@ impl StateStore for PgStateStore {
                 $33,
                 $34, $35, $36,
                 $37, $38,
-                $39, $40
+                $39,
+                $40, $41
             )
             RETURNING *
             "#,
@@ -403,6 +409,7 @@ impl StateStore for PgStateStore {
         .bind(record.review_timeout_secs)
         .bind(record.audit_timeout_secs)
         .bind(record.revise_timeout_secs)
+        .bind(&record.cache_env_overrides)
         .bind(record.created_at)
         .bind(record.updated_at)
         .fetch_one(&self.pool)
@@ -649,6 +656,7 @@ impl StateStore for PgStateStore {
                 review_timeout_secs = $24,
                 audit_timeout_secs = $25,
                 revise_timeout_secs = $26,
+                cache_env_overrides = $27,
                 updated_at = NOW()
             WHERE id = $1
             "#,
@@ -679,6 +687,7 @@ impl StateStore for PgStateStore {
         .bind(record.review_timeout_secs)
         .bind(record.audit_timeout_secs)
         .bind(record.revise_timeout_secs)
+        .bind(&record.cache_env_overrides)
         .execute(&self.pool)
         .await?;
         Ok(())
@@ -1154,6 +1163,7 @@ mod tests {
             review_timeout_secs: None,
             audit_timeout_secs: None,
             revise_timeout_secs: None,
+            cache_env_overrides: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         }

--- a/control-plane/src/types/api.rs
+++ b/control-plane/src/types/api.rs
@@ -35,6 +35,12 @@ pub struct StartRequest {
     /// Per-stage wins over uniform.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timeouts: Option<StageTimeouts>,
+    /// Optional `[cache.env]` overrides from the repo-level `nemo.toml`.
+    /// Shape: `{"BUN_INSTALL_CACHE_DIR": "/cache/bun", ...}`. Merged
+    /// with the cluster-default cache env when the driver builds each
+    /// stage Job; per-loop keys win on collisions.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_env: Option<std::collections::HashMap<String, String>>,
 }
 
 /// Per-stage `activeDeadlineSeconds` overrides mirroring the
@@ -168,6 +174,12 @@ pub struct ResumeRequest {
     /// already pinned on the loop row.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timeouts: Option<StageTimeouts>,
+    /// Optional `[cache.env]` override replacement. When present,
+    /// replaces the loop's existing cache_env_overrides wholesale
+    /// (not merged). Pass an empty object to clear. Absent field
+    /// leaves the stored overrides unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_env: Option<std::collections::HashMap<String, String>>,
 }
 
 /// POST /resume/:id response body.

--- a/control-plane/src/types/mod.rs
+++ b/control-plane/src/types/mod.rs
@@ -308,6 +308,12 @@ pub struct LoopRecord {
     pub review_timeout_secs: Option<i32>,
     pub audit_timeout_secs: Option<i32>,
     pub revise_timeout_secs: Option<i32>,
+    /// Per-loop `[cache.env]` overrides plumbed from the repo-level
+    /// `nemo.toml` by the CLI at submit time. Merged with the
+    /// cluster-default cache env at stage-dispatch; per-loop keys win
+    /// on collisions. `None` means no override (use cluster default
+    /// verbatim). Shape: `{"BUN_INSTALL_CACHE_DIR": "/cache/bun", ...}`.
+    pub cache_env_overrides: Option<serde_json::Value>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }

--- a/control-plane/tests/dashboard_integration.rs
+++ b/control-plane/tests/dashboard_integration.rs
@@ -82,6 +82,7 @@ fn make_loop(engineer: &str, state: LoopState) -> LoopRecord {
         review_timeout_secs: None,
         audit_timeout_secs: None,
         revise_timeout_secs: None,
+        cache_env_overrides: None,
         created_at: now,
         updated_at: now,
     }

--- a/control-plane/tests/judge_integration.rs
+++ b/control-plane/tests/judge_integration.rs
@@ -136,6 +136,7 @@ fn make_reviewing_loop(round: i32) -> LoopRecord {
         review_timeout_secs: None,
         audit_timeout_secs: None,
         revise_timeout_secs: None,
+        cache_env_overrides: None,
         created_at: Utc::now(),
         updated_at: Utc::now(),
     }
@@ -182,6 +183,7 @@ fn make_hardening_loop(round: i32) -> LoopRecord {
         review_timeout_secs: None,
         audit_timeout_secs: None,
         revise_timeout_secs: None,
+        cache_env_overrides: None,
         created_at: Utc::now(),
         updated_at: Utc::now(),
     }

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -82,6 +82,44 @@ RUN npm install -g @anthropic-ai/claude-code@2.1.87
 COPY --from=opencode-src /opt/opencode/opencode /usr/local/bin/opencode
 RUN chmod +x /usr/local/bin/opencode && /usr/local/bin/opencode --version
 
+# FR-3b: Install Bun + pnpm system-wide so audit/implement/test stages
+# can run JS monorepos that have migrated off npm. Node + npm come from
+# the base image; Bun ships a standalone binary with its own runtime,
+# so pinning by version + verifying via the release's SHASUMS256.txt
+# gives the same supply-chain guarantee as the opencode/sccache fetches
+# above without us having to hardcode per-arch digests that drift with
+# every bump.
+#
+# pnpm is installed via corepack (ships with node:22) so the version
+# pinned in each repo's `packageManager` field is honored at runtime
+# without us having to track per-monorepo pnpm releases here.
+ARG BUN_VERSION=1.1.43
+RUN set -eux; \
+    case "$(uname -m)" in \
+      x86_64)  asset=bun-linux-x64.zip ;; \
+      aarch64) asset=bun-linux-aarch64.zip ;; \
+      *)       echo "Unsupported arch for bun: $(uname -m)" >&2; exit 1 ;; \
+    esac; \
+    apt-get update && apt-get install -y --no-install-recommends unzip && rm -rf /var/lib/apt/lists/*; \
+    base_url="https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}"; \
+    # Download with the original asset filename so `sha256sum -c` can
+    # find it: SHASUMS256.txt references `bun-linux-<arch>.zip`, and
+    # `sha256sum -c` resolves the filename in that line against cwd.
+    cd /tmp; \
+    curl -fsSL -O "${base_url}/${asset}"; \
+    curl -fsSL -o /tmp/SHASUMS256.txt "${base_url}/SHASUMS256.txt"; \
+    grep -E "  ${asset}\$" SHASUMS256.txt | sha256sum -c -; \
+    unzip -q "/tmp/${asset}" -d /tmp; \
+    dir="$(find /tmp -maxdepth 1 -type d -name 'bun-linux-*' | head -n1)"; \
+    mv "${dir}/bun" /usr/local/bin/bun; \
+    chmod +x /usr/local/bin/bun; \
+    ln -sf /usr/local/bin/bun /usr/local/bin/bunx; \
+    rm -rf "/tmp/${asset}" /tmp/SHASUMS256.txt /tmp/bun-linux-*; \
+    /usr/local/bin/bun --version
+# Enable corepack (ships with node:22) so `pnpm` / `yarn` invocations
+# resolve to the version pinned in each repo's package.json.
+RUN corepack enable && corepack prepare pnpm@latest --activate && pnpm --version
+
 # Optional: Rust toolchain for Rust-targeted repos (e.g. nautiloop itself).
 # Off by default to keep the base image lean (~200MB saved). Enable per-build
 # with `--build-arg INCLUDE_RUST=true`. Production release workflow leaves it off


### PR DESCRIPTION
## Summary

Third bundle from the same v0.7.11/v0.7.12 bug-report cycle. Audit pods showed up empty: `/cache` wasn't mounted, `[cache.env]` in repo-level `nemo.toml` was silently dropped (same dead-letter shape as `[timeouts]` was pre-v0.7.12), and the `nautiloop-agent-base` image didn't ship Bun so JS monorepos on Bun couldn't run `bun install` or parse `bun.lock` at all.

## Fixes

1. **Cache mount + env on every stage.** `job_builder` previously gated `/cache` and cache env vars on IMPLEMENT/REVISE. Audit/review routinely run `bun install` / `npm test` / test-plan shell commands against the live repo, so the gate meant those stages cold-started every filesystem cache on every retry. Now mounted on all five stages — read-only on review/audit (read existing entries without clobber), read-write on implement/test/revise.
2. **Bun + pnpm in agent-base.** `bun@1.1.43` from official release, verified via the release's own `SHASUMS256.txt` (no hardcoded per-arch digests that drift). `pnpm` / `yarn` via corepack so repo `packageManager` pins work at runtime.
3. **Per-loop `[cache.env]` override**, same pattern as v0.7.12 `[timeouts]`:
   - Migration `20260424000003` adds `cache_env_overrides JSONB` on `loops`.
   - CLI parses `[cache.env]`, sends as `cache_env` in `/start` body.
   - Driver's `job_build_config_for(record)` merges per-loop onto cluster default at dispatch time; per-loop wins on collisions, unrelated defaults survive.
4. **Expanded server-side defaults.** `sccache_defaults` → `common_defaults` covers Rust + JS toolchain (sccache, Bun, npm, pnpm, yarn, turbo, vitest, playwright) — operators with empty `nemo.toml` still get a warm cache on the common monorepo shapes.

## End-to-end smoke (local k3d)

Submitted a loop with `cache_env: { BUN_INSTALL_CACHE_DIR: /cache/bun-loop-smoke, NPM_CONFIG_CACHE: /cache/npm-loop-smoke }`:

- `LoopRecord.cache_env_overrides` persisted exactly as sent (JSONB).
- Audit Job `nautiloop-*-audit-r1-t3`: `/cache` mount present, `readOnly=true`, and 11 cache env vars on the agent container — the two per-loop keys overriding cluster defaults, plus nine untouched defaults (sccache/pnpm/yarn/turbo/vitest/playwright).

Agent-base image: `docker run ... bun --version` → `1.1.43`; `pnpm --version` → `10.33.2`.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib --bins` (477 unit tests; new regression guards listed in the commit message).
- [x] Local `docker buildx build --platform=linux/arm64` on both `images/base/Dockerfile` and `images/control-plane/Dockerfile`.
- [x] k3d smoke for the full `/start` → `LoopRecord` → audit Job chain.
- [ ] Operator smoke test after release images ship, against a real Bun monorepo.

## Out of scope, filed as next ask

Auth preflight — the reason these bugs hurt so much. Operators today submit a loop with stale creds, the control plane happily starts the Job, opencode spins for the full stage budget getting 401s, stage deadline kills the pod, then retries on the same dead creds for 30+ more minutes. Three places to fix it (client-side preflight before `/start`, server-side preflight on submit, fail-fast on first 401 in the stage); will land as its own PR after this.