### PR TITLE
chore: release 0.7.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-control-plane"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-sidecar"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "bytes",
  "chrono",
@@ -2692,7 +2692,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-cli"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["control-plane", "cli", "sidecar"]
 
 [workspace.package]
-version = "0.7.12"
+version = "0.7.13"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -65,9 +65,9 @@ module "nautiloop" {
   acme_email = "me@mydomain.com"     # required if domain is set
 
   # Optional: images (defaults to latest public GHCR)
-  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.12"
-  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.12"
-  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.12"
+  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.13"
+  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.13"
+  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.13"
 }
 ```
 
@@ -83,9 +83,9 @@ module "nautiloop" {
 | `repo_ssh_private_key` | no | auto-generated | SSH deploy key. If null, generates ED25519 |
 | `domain` | no | `null` | Domain for TLS. null = HTTP on raw IP:8080 |
 | `acme_email` | no | `null` | Let's Encrypt email. Required if domain is set |
-| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.12` | Control plane image |
-| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.12` | Agent base image |
-| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.12` | Auth sidecar image |
+| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.13` | Control plane image |
+| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.13` | Agent base image |
+| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.13` | Auth sidecar image |
 | `k3s_version` | no | `v1.32.13+k3s1` | k3s version (v1.32+ required) |
 | `postgres_password` | no | auto-generated | Postgres password |
 | `postgres_volume_size` | no | `20` | Postgres volume size (Gi) |
@@ -233,9 +233,9 @@ nemo auth                    # pushes credentials (Claude, OpenAI, SSH) to clust
 ```bash
 ./build-images.sh --tag 0.2.0
 terraform apply \
-  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.12" \
-  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.12" \
-  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.12"
+  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.13" \
+  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.13" \
+  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.13"
 ```
 
 All three images must be updated together to avoid version skew.

--- a/terraform/examples/existing-server/variables.tf
+++ b/terraform/examples/existing-server/variables.tf
@@ -50,17 +50,17 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.12"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.13"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.12"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.13"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.12"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.13"
 }

--- a/terraform/examples/hetzner/variables.tf
+++ b/terraform/examples/hetzner/variables.tf
@@ -77,19 +77,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.12"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.13"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.12"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.13"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.12"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.13"
 }
 
 variable "k3s_version" {

--- a/terraform/modules/nautiloop/variables.tf
+++ b/terraform/modules/nautiloop/variables.tf
@@ -79,19 +79,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.12"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.13"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.12"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.13"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.12"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.13"
 }
 
 # --- Optional: tuning ---

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -71,19 +71,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.12"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.13"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.12"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.13"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.12"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.13"
 }
 
 variable "k3s_version" {


### PR DESCRIPTION
## Summary
Patch release bundling #208 (cache + bun + `[cache.env]` plumbing) and #209 (Claude session ID routing + bun baseline amd64 + test flake fix). Operators running JS monorepos — especially anything on Bun, or any stage whose verdict was being emitted by Claude — see the biggest change.

- fix(k8s): mount `/cache` on every stage and ship cache env vars on audit/review/test/implement/revise. Review/audit read-only; the rest read-write (#208).
- feat(cli,api): plumb `[cache.env]` from repo-level `nemo.toml` via a per-loop `cache_env_overrides` JSONB column; merged with cluster default at dispatch time (#208).
- feat(config): expand server-side default cache env to cover Rust sccache + Bun + pnpm + yarn + turbo + vitest + playwright (#208).
- feat(images): install `bun@1.1.43` and enable corepack for `pnpm` / `yarn` in `nautiloop-agent-base` (#208, baseline amd64 variant for QEMU compatibility in #209).
- fix(loop_engine): route session IDs to their typed column by FORMAT (`ses_*` vs UUID), not by stage name. Claude-generated verdicts on audit/review are now persisted (#209).
- fix(sidecar): pre-existing env-var test flake now deterministic via a test-local Mutex (#209).

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib --bins` (478 unit tests).
- [x] Local `docker buildx build --platform=linux/arm64` and `--platform=linux/amd64` on both `images/base/Dockerfile` and `images/control-plane/Dockerfile`.
- [x] k3d end-to-end smoke for `/cache` + `cache_env` path.
- [ ] Operator smoke against a real Bun monorepo after release images ship.