### PR TITLE
feat: heartbeat, gh auth preflight, fail-fast on persistent OAuth failure

### DIFF
--- a/cli/src/api_types.rs
+++ b/cli/src/api_types.rs
@@ -75,6 +75,12 @@ pub struct LoopSummary {
     pub model_reviewer: Option<String>,
     pub created_at: String,
     pub updated_at: String,
+    /// Heartbeat from the reconciler (ISO-8601 string). `None` for
+    /// loops that have never had a pod. Surfaced in `nemo status`
+    /// as a relative "Xm ago" so operators can spot wedged loops
+    /// without exec'ing into the cluster.
+    #[serde(default)]
+    pub last_activity_at: Option<String>,
 }
 
 /// GET /pod-introspect/:loop_id response.

--- a/cli/src/commands/helm/actions.rs
+++ b/cli/src/commands/helm/actions.rs
@@ -87,6 +87,7 @@ mod tests {
             model_reviewer: None,
             created_at: "2026-04-10T10:00:00Z".to_string(),
             updated_at: "2026-04-10T10:00:00Z".to_string(),
+            last_activity_at: None,
         }
     }
 

--- a/cli/src/commands/helm/mod.rs
+++ b/cli/src/commands/helm/mod.rs
@@ -2636,6 +2636,7 @@ mod tests {
             model_reviewer: None,
             created_at: updated_at.to_string(),
             updated_at: updated_at.to_string(),
+            last_activity_at: None,
         }
     }
 

--- a/cli/src/commands/helm/summary.rs
+++ b/cli/src/commands/helm/summary.rs
@@ -177,6 +177,7 @@ mod tests {
             model_reviewer: None,
             created_at: "2026-04-10T10:00:00Z".to_string(),
             updated_at: "2026-04-10T10:00:00Z".to_string(),
+            last_activity_at: None,
         }
     }
 

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -39,12 +39,17 @@ pub async fn run(client: &NemoClient, engineer: &str, team: bool, json: bool) ->
         return Ok(());
     }
 
-    // Table output
+    // Table output. ACTIVITY column shows the relative time since
+    // the reconciler last observed forward progress (new agent log
+    // bytes or fresh dispatch). A loop wedged on dead credentials
+    // grows "Xm ago" while a healthy run resets every reconciler
+    // tick — operators can spot wedges in <30s instead of having
+    // to kubectl-exec into the agent pod.
     println!(
-        "{:<38} {:<12} {:<10} {:<20} {:<40} {:<8}",
-        "LOOP ID", "STATE", "STAGE", "ENGINEER", "SPEC", "ROUND"
+        "{:<38} {:<12} {:<10} {:<20} {:<40} {:<8} {:<10}",
+        "LOOP ID", "STATE", "STAGE", "ENGINEER", "SPEC", "ROUND", "ACTIVITY"
     );
-    println!("{}", "-".repeat(138));
+    println!("{}", "-".repeat(150));
 
     for l in &resp.loops {
         let state_display = match &l.sub_state {
@@ -52,11 +57,75 @@ pub async fn run(client: &NemoClient, engineer: &str, team: bool, json: bool) ->
             None => l.state.clone(),
         };
         let stage_display = l.current_stage.as_deref().unwrap_or("-");
+        let activity_display = format_activity(l.last_activity_at.as_deref());
         println!(
-            "{:<38} {:<12} {:<10} {:<20} {:<40} {:<8}",
-            l.loop_id, state_display, stage_display, l.engineer, l.spec_path, l.round
+            "{:<38} {:<12} {:<10} {:<20} {:<40} {:<8} {:<10}",
+            l.loop_id,
+            state_display,
+            stage_display,
+            l.engineer,
+            l.spec_path,
+            l.round,
+            activity_display
         );
     }
 
     Ok(())
+}
+
+/// Render `last_activity_at` as a compact relative time. `None` /
+/// unparseable timestamps render as `-` so the column always lines up.
+/// Buckets match the existing `nemo ps` age formatter so the two
+/// commands feel consistent.
+fn format_activity(ts: Option<&str>) -> String {
+    let Some(s) = ts else {
+        return "-".to_string();
+    };
+    let Ok(parsed) = chrono::DateTime::parse_from_rfc3339(s) else {
+        return "-".to_string();
+    };
+    let elapsed = chrono::Utc::now().signed_duration_since(parsed.with_timezone(&chrono::Utc));
+    let secs = elapsed.num_seconds().max(0);
+    if secs < 60 {
+        format!("{secs}s")
+    } else if secs < 3600 {
+        format!("{}m", secs / 60)
+    } else if secs < 86_400 {
+        let hours = secs / 3600;
+        let mins = (secs % 3600) / 60;
+        if mins == 0 {
+            format!("{hours}h")
+        } else {
+            format!("{hours}h{mins}m")
+        }
+    } else {
+        format!("{}d", secs / 86_400)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_activity_renders_dash_when_absent_or_unparseable() {
+        assert_eq!(format_activity(None), "-");
+        assert_eq!(format_activity(Some("not a timestamp")), "-");
+    }
+
+    #[test]
+    fn format_activity_buckets_into_seconds_minutes_hours_days() {
+        let now = chrono::Utc::now();
+        let f = |dur: chrono::Duration| {
+            let ts = (now - dur).to_rfc3339();
+            format_activity(Some(&ts))
+        };
+        // Use generous tolerance windows because the test reads its
+        // own `now` after the fixture builds, so the boundary is
+        // approximate. Pick durations safely inside a bucket.
+        assert!(f(chrono::Duration::seconds(5)).ends_with('s'));
+        assert!(f(chrono::Duration::minutes(15)).ends_with('m'));
+        assert!(f(chrono::Duration::hours(5)).contains('h'));
+        assert!(f(chrono::Duration::days(2)).ends_with('d'));
+    }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -3,6 +3,7 @@ mod claude_creds;
 mod client;
 mod commands;
 mod config;
+mod preflight;
 mod project_config;
 
 use clap::{CommandFactory, Parser, Subcommand};
@@ -1107,6 +1108,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                 project_config::load_project_timeouts(&std::env::current_dir()?)?;
             let project_cache_env =
                 project_config::load_project_cache_env(&std::env::current_dir()?)?;
+            preflight::render_and_decide(&preflight::run_all().await?)?;
             claude_creds::ensure_fresh(&http_client, engineer, eng_name, eng_email).await?;
             commands::start::run(
                 &http_client,
@@ -1144,6 +1146,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                 project_config::load_project_timeouts(&std::env::current_dir()?)?;
             let project_cache_env =
                 project_config::load_project_cache_env(&std::env::current_dir()?)?;
+            preflight::render_and_decide(&preflight::run_all().await?)?;
             claude_creds::ensure_fresh(&http_client, engineer, eng_name, eng_email).await?;
             commands::start::run(
                 &http_client,
@@ -1176,6 +1179,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                 project_config::load_project_timeouts(&std::env::current_dir()?)?;
             let project_cache_env =
                 project_config::load_project_cache_env(&std::env::current_dir()?)?;
+            preflight::render_and_decide(&preflight::run_all().await?)?;
             claude_creds::ensure_fresh(&http_client, engineer, eng_name, eng_email).await?;
             commands::start::run(
                 &http_client,

--- a/cli/src/preflight.rs
+++ b/cli/src/preflight.rs
@@ -1,0 +1,164 @@
+//! Client-side preflight checks before submitting a loop.
+//!
+//! The control plane can submit a loop, dispatch a Job, and let the
+//! agent run for the full stage budget before discovering that the
+//! engineer's credentials don't actually work. Concrete failure modes
+//! we've eaten in v0.7.x:
+//!   - GitHub PAT missing: 60-min audit completes cleanly, then PR
+//!     creation fails infinitely with `gh auth login` hint.
+//!   - OAuth refresh token reused: opencode burns the full deadline
+//!     on exponential backoff getting 502s from the sidecar.
+//!
+//! Preflight catches whatever we can on the engineer's laptop in
+//! <500 ms before posting `/start`. A failure prints a precise hint
+//! ("run `gh auth login --hostname github.com`", "run `nemo auth
+//! --openai`") and returns a non-zero exit so the engineer doesn't
+//! lose 60+ minutes of compute to a problem that's a one-line fix.
+//!
+//! v0.7.14 ships only the `gh auth status` check because that's the
+//! one tied to the active production failure (#206 follow-up). The
+//! Anthropic + OpenAI pings come in v0.7.15.
+
+use anyhow::Result;
+use std::process::Stdio;
+
+/// Result of a single preflight check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CheckOutcome {
+    /// The check passed.
+    Ok,
+    /// The check failed; render the message to the operator and
+    /// abort the submit.
+    Fail { hint: String },
+    /// The check could not be performed (tool not installed,
+    /// platform unsupported); proceed with a warning rather than
+    /// blocking. Operators on a clean machine without `gh` installed
+    /// shouldn't be locked out of `nemo harden`.
+    Skip { reason: String },
+}
+
+/// Run all preflight checks and return aggregated outcomes. Caller
+/// renders + decides whether to block. Sequential rather than
+/// concurrent because the per-check cost is tens of milliseconds and
+/// concurrent-with-Tokio adds more setup overhead than it saves.
+pub async fn run_all() -> Result<Vec<(&'static str, CheckOutcome)>> {
+    Ok(vec![("gh auth", check_gh_auth().await)])
+}
+
+/// Verify `gh auth status` succeeds for github.com. The agent pod's
+/// PR-creation path shells out to `gh pr create`, which needs a token
+/// in the engineer's `gh` config. Today the sidecar proxies git+ssh
+/// for clone/push, but `gh` runs inside the agent container with its
+/// own credential lookup — and we don't yet mount one (filed as a
+/// separate v0.7.14 ask). Catching the absent-token case on the
+/// engineer's laptop short-circuits the eventual 60-min-then-fail
+/// failure mode by ~3600x.
+async fn check_gh_auth() -> CheckOutcome {
+    let output = match tokio::process::Command::new("gh")
+        .arg("auth")
+        .arg("status")
+        .arg("--hostname")
+        .arg("github.com")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await
+    {
+        Ok(o) => o,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return CheckOutcome::Skip {
+                reason: "gh CLI not installed on this machine; cannot preflight \
+                         GitHub auth (the agent pod still needs a token at run time)"
+                    .to_string(),
+            };
+        }
+        Err(e) => {
+            return CheckOutcome::Skip {
+                reason: format!("gh auth status invocation failed: {e}"),
+            };
+        }
+    };
+
+    if output.status.success() {
+        CheckOutcome::Ok
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // gh prints its hint to stderr; if the binary returned a
+        // recognisable "not logged in" pattern, surface its own
+        // message verbatim — it's already actionable. Otherwise fall
+        // back to a generic prompt.
+        let hint = if stderr.contains("not logged into") || stderr.contains("gh auth login") {
+            format!(
+                "GitHub auth is not configured for github.com. Run:\n  gh auth login --hostname github.com\n\nFull `gh auth status` output:\n{stderr}"
+            )
+        } else {
+            format!(
+                "GitHub auth check failed (`gh auth status --hostname github.com` exited {}). Run `gh auth login --hostname github.com` and retry. Output:\n{stderr}",
+                output.status
+            )
+        };
+        CheckOutcome::Fail { hint }
+    }
+}
+
+/// Render preflight outcomes and return Err if any check failed.
+/// Skip outcomes print a one-line warning and don't block.
+pub fn render_and_decide(outcomes: &[(&'static str, CheckOutcome)]) -> Result<()> {
+    let mut blocking_failures: Vec<String> = Vec::new();
+    for (name, outcome) in outcomes {
+        match outcome {
+            CheckOutcome::Ok => {}
+            CheckOutcome::Skip { reason } => {
+                eprintln!("preflight {name}: skipped — {reason}");
+            }
+            CheckOutcome::Fail { hint } => {
+                blocking_failures.push(format!("preflight {name} failed:\n{hint}"));
+            }
+        }
+    }
+    if !blocking_failures.is_empty() {
+        anyhow::bail!(
+            "Aborting before submit. {} preflight check(s) failed:\n\n{}",
+            blocking_failures.len(),
+            blocking_failures.join("\n\n")
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_and_decide_passes_when_all_ok() {
+        assert!(render_and_decide(&[("gh auth", CheckOutcome::Ok)]).is_ok());
+    }
+
+    #[test]
+    fn render_and_decide_passes_on_skip_only() {
+        assert!(
+            render_and_decide(&[(
+                "gh auth",
+                CheckOutcome::Skip {
+                    reason: "no gh".to_string()
+                },
+            )])
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn render_and_decide_blocks_on_fail() {
+        let r = render_and_decide(&[(
+            "gh auth",
+            CheckOutcome::Fail {
+                hint: "run gh auth login".to_string(),
+            },
+        )]);
+        let err = r.expect_err("must block on Fail");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("preflight gh auth failed"));
+        assert!(msg.contains("run gh auth login"));
+    }
+}

--- a/control-plane/migrations/20260424000004_add_last_activity_at.sql
+++ b/control-plane/migrations/20260424000004_add_last_activity_at.sql
@@ -1,0 +1,12 @@
+-- Activity heartbeat for `nemo status`. Updated by the reconciler
+-- whenever it observes any signal of forward progress on a loop's
+-- pod (new log bytes, K8s status transition, fresh dispatch, etc.).
+-- NULL = no activity yet (e.g. PENDING loop awaiting first dispatch).
+--
+-- Operators today have to kubectl-exec into the agent pod to tell
+-- "still working" from "wedged on dead credentials" — a 90+ minute
+-- diagnostic gap that compounds every other failure mode. One
+-- timestamp column closes most of that gap without touching the log
+-- stream or tailing the opencode session DB.
+ALTER TABLE loops
+    ADD COLUMN last_activity_at TIMESTAMPTZ;

--- a/control-plane/src/api/dashboard/handlers.rs
+++ b/control-plane/src/api/dashboard/handlers.rs
@@ -1800,6 +1800,7 @@ mod tests {
             audit_timeout_secs: None,
             revise_timeout_secs: None,
             cache_env_overrides: None,
+            last_activity_at: None,
             created_at: now,
             updated_at: now,
         }

--- a/control-plane/src/api/handlers.rs
+++ b/control-plane/src/api/handlers.rs
@@ -268,6 +268,7 @@ pub async fn start(
             .as_ref()
             .filter(|m| !m.is_empty())
             .and_then(|m| serde_json::to_value(m).ok()),
+        last_activity_at: None,
         created_at: now,
         updated_at: now,
     };
@@ -412,6 +413,7 @@ pub async fn status(
             model_reviewer: loop_record.model_reviewer.clone(),
             created_at: loop_record.created_at,
             updated_at: loop_record.updated_at,
+            last_activity_at: loop_record.last_activity_at,
         });
     }
 
@@ -1614,6 +1616,7 @@ mod tests {
             audit_timeout_secs: None,
             revise_timeout_secs: None,
             cache_env_overrides: None,
+            last_activity_at: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
@@ -1683,6 +1686,7 @@ mod tests {
             audit_timeout_secs: None,
             revise_timeout_secs: None,
             cache_env_overrides: None,
+            last_activity_at: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
@@ -1746,6 +1750,7 @@ mod tests {
             audit_timeout_secs: None,
             revise_timeout_secs: None,
             cache_env_overrides: None,
+            last_activity_at: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
@@ -2617,6 +2622,7 @@ mod tests {
             audit_timeout_secs: None,
             revise_timeout_secs: None,
             cache_env_overrides: None,
+            last_activity_at: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };

--- a/control-plane/src/api/introspect.rs
+++ b/control-plane/src/api/introspect.rs
@@ -669,6 +669,7 @@ mod tests {
             audit_timeout_secs: None,
             revise_timeout_secs: None,
             cache_env_overrides: None,
+            last_activity_at: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         }

--- a/control-plane/src/api/mod.rs
+++ b/control-plane/src/api/mod.rs
@@ -226,6 +226,9 @@ mod tests {
         async fn set_current_sha(&self, _: Uuid, _: &str) -> crate::error::Result<()> {
             unimplemented!()
         }
+        async fn touch_last_activity(&self, _: Uuid) -> crate::error::Result<()> {
+            unimplemented!()
+        }
         async fn has_active_loop_for_branch(&self, _: &str) -> crate::error::Result<bool> {
             unimplemented!()
         }

--- a/control-plane/src/loop_engine/driver.rs
+++ b/control-plane/src/loop_engine/driver.rs
@@ -593,6 +593,7 @@ impl ConvergentLoopDriver {
             .unwrap_or(0);
 
         let base_timestamp = chrono::Utc::now();
+        let mut appended = 0usize;
         for (offset, line) in new_lines.into_iter().skip(overlap).enumerate() {
             self.store
                 .append_log(&LogEvent {
@@ -604,6 +605,24 @@ impl ConvergentLoopDriver {
                     line,
                 })
                 .await?;
+            appended += 1;
+        }
+
+        // Heartbeat: any new log bytes from the agent pod count as
+        // forward progress. Surfaced in `nemo status` so an operator
+        // can distinguish "still working" from "wedged on dead
+        // credentials" without kubectl-exec'ing to read /proc.
+        // Best-effort — a heartbeat write failure should never tank
+        // a tick (the rest of the reconciler doesn't depend on this
+        // column).
+        if appended > 0
+            && let Err(e) = self.store.touch_last_activity(loop_id).await
+        {
+            tracing::debug!(
+                loop_id = %loop_id,
+                error = %e,
+                "Heartbeat write failed; status will show stale last_activity_at"
+            );
         }
 
         Ok(())
@@ -2480,7 +2499,17 @@ impl ConvergentLoopDriver {
 
         // Now create the K8s Job
         match self.dispatcher.create_job(job).await {
-            Ok(name) => Ok(name),
+            Ok(name) => {
+                // Heartbeat: the dispatch itself is a forward-progress
+                // signal — the loop has a live pod (or will momentarily).
+                // Without this initial bump, a new loop sits with
+                // last_activity_at=NULL until the agent emits its
+                // first log line, which on a slow image pull can be a
+                // few minutes and looks indistinguishable from "stuck"
+                // in `nemo status`.
+                let _ = self.store.touch_last_activity(record.id).await;
+                Ok(name)
+            }
             Err(e) => {
                 // K8s creation failed: clear job name so next tick can retry
                 record.active_job_name = None;
@@ -2822,6 +2851,7 @@ mod tests {
                 audit_timeout_secs: None,
                 revise_timeout_secs: None,
                 cache_env_overrides: None,
+                last_activity_at: None,
                 created_at: Utc::now(),
                 updated_at: Utc::now(),
             }
@@ -2916,6 +2946,7 @@ mod tests {
             audit_timeout_secs: None,
             revise_timeout_secs: None,
             cache_env_overrides: None,
+            last_activity_at: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         }

--- a/control-plane/src/loop_engine/reconciler.rs
+++ b/control-plane/src/loop_engine/reconciler.rs
@@ -261,6 +261,7 @@ mod tests {
             audit_timeout_secs: None,
             revise_timeout_secs: None,
             cache_env_overrides: None,
+            last_activity_at: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };

--- a/control-plane/src/state/mod.rs
+++ b/control-plane/src/state/mod.rs
@@ -83,6 +83,14 @@ pub trait StateStore: Send + Sync + 'static {
     /// Set current_sha on a loop (narrow update, no full record overwrite).
     async fn set_current_sha(&self, id: Uuid, sha: &str) -> Result<()>;
 
+    /// Bump `last_activity_at` to NOW() for the given loop. Narrow
+    /// update so the heartbeat path stays cheap and doesn't race with
+    /// `update_loop` overwrites that the reconciler may be doing in
+    /// parallel for the same record. Best-effort: errors are
+    /// downgraded to debug logs by callers — a failed heartbeat
+    /// write should never tank a tick.
+    async fn touch_last_activity(&self, id: Uuid) -> Result<()>;
+
     /// Check if there is an active loop for the given branch.
     async fn has_active_loop_for_branch(&self, branch: &str) -> Result<bool>;
 
@@ -449,6 +457,14 @@ pub mod memory {
             if let Some(record) = loops.get_mut(&id) {
                 record.current_sha = Some(sha.to_string());
                 record.updated_at = chrono::Utc::now();
+            }
+            Ok(())
+        }
+
+        async fn touch_last_activity(&self, id: Uuid) -> Result<()> {
+            let mut loops = self.loops.write().await;
+            if let Some(record) = loops.get_mut(&id) {
+                record.last_activity_at = Some(chrono::Utc::now());
             }
             Ok(())
         }

--- a/control-plane/src/state/postgres.rs
+++ b/control-plane/src/state/postgres.rs
@@ -174,6 +174,10 @@ fn row_to_loop_record(row: &PgRow) -> Result<LoopRecord> {
             .try_get::<Option<serde_json::Value>, _>("cache_env_overrides")
             .ok()
             .flatten(),
+        last_activity_at: row
+            .try_get::<Option<chrono::DateTime<chrono::Utc>>, _>("last_activity_at")
+            .ok()
+            .flatten(),
         created_at: row.get("created_at"),
         updated_at: row.get("updated_at"),
     })
@@ -353,6 +357,7 @@ impl StateStore for PgStateStore {
                 implement_timeout_secs, test_timeout_secs, review_timeout_secs,
                 audit_timeout_secs, revise_timeout_secs,
                 cache_env_overrides,
+                last_activity_at,
                 created_at, updated_at
             ) VALUES (
                 $1, $2, $3, $4, $5, $6::loop_kind,
@@ -366,7 +371,8 @@ impl StateStore for PgStateStore {
                 $34, $35, $36,
                 $37, $38,
                 $39,
-                $40, $41
+                $40,
+                $41, $42
             )
             RETURNING *
             "#,
@@ -410,6 +416,7 @@ impl StateStore for PgStateStore {
         .bind(record.audit_timeout_secs)
         .bind(record.revise_timeout_secs)
         .bind(&record.cache_env_overrides)
+        .bind(record.last_activity_at)
         .bind(record.created_at)
         .bind(record.updated_at)
         .fetch_one(&self.pool)
@@ -712,6 +719,19 @@ impl StateStore for PgStateStore {
         sqlx::query("UPDATE loops SET current_sha = $2, updated_at = NOW() WHERE id = $1")
             .bind(id)
             .bind(sha)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    async fn touch_last_activity(&self, id: Uuid) -> Result<()> {
+        // Narrow update by design — does NOT bump `updated_at` so
+        // unrelated reconciler decisions that hinge on
+        // `updated_at >= X` (resume races, replacement-loop checks)
+        // aren't perturbed by a heartbeat write. The heartbeat is a
+        // separate signal from "the row was edited".
+        sqlx::query("UPDATE loops SET last_activity_at = NOW() WHERE id = $1")
+            .bind(id)
             .execute(&self.pool)
             .await?;
         Ok(())
@@ -1164,6 +1184,7 @@ mod tests {
             audit_timeout_secs: None,
             revise_timeout_secs: None,
             cache_env_overrides: None,
+            last_activity_at: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         }

--- a/control-plane/src/types/api.rs
+++ b/control-plane/src/types/api.rs
@@ -113,6 +113,13 @@ pub struct LoopSummary {
     pub model_reviewer: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    /// Heartbeat: most recent moment the reconciler observed forward
+    /// progress (new log bytes from the agent pod, or initial dispatch).
+    /// `None` for loops that have never had a pod (e.g. PENDING). The
+    /// CLI renders this as a relative "Xm ago" so operators can spot
+    /// wedged loops without exec'ing into the cluster.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_activity_at: Option<DateTime<Utc>>,
 }
 
 /// GET /status query parameters.

--- a/control-plane/src/types/mod.rs
+++ b/control-plane/src/types/mod.rs
@@ -314,6 +314,13 @@ pub struct LoopRecord {
     /// on collisions. `None` means no override (use cluster default
     /// verbatim). Shape: `{"BUN_INSTALL_CACHE_DIR": "/cache/bun", ...}`.
     pub cache_env_overrides: Option<serde_json::Value>,
+    /// Wall-clock heartbeat: the most recent moment the reconciler
+    /// observed any signal of forward progress on this loop's pod
+    /// (new log bytes, K8s status transition, fresh dispatch). `None`
+    /// when the loop has never had an active pod. Surfaced in
+    /// `nemo status` so operators can distinguish "still working"
+    /// from "wedged on dead credentials" without kubectl-exec.
+    pub last_activity_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }

--- a/control-plane/tests/dashboard_integration.rs
+++ b/control-plane/tests/dashboard_integration.rs
@@ -83,6 +83,7 @@ fn make_loop(engineer: &str, state: LoopState) -> LoopRecord {
         audit_timeout_secs: None,
         revise_timeout_secs: None,
         cache_env_overrides: None,
+        last_activity_at: None,
         created_at: now,
         updated_at: now,
     }

--- a/control-plane/tests/judge_integration.rs
+++ b/control-plane/tests/judge_integration.rs
@@ -137,6 +137,7 @@ fn make_reviewing_loop(round: i32) -> LoopRecord {
         audit_timeout_secs: None,
         revise_timeout_secs: None,
         cache_env_overrides: None,
+        last_activity_at: None,
         created_at: Utc::now(),
         updated_at: Utc::now(),
     }
@@ -184,6 +185,7 @@ fn make_hardening_loop(round: i32) -> LoopRecord {
         audit_timeout_secs: None,
         revise_timeout_secs: None,
         cache_env_overrides: None,
+        last_activity_at: None,
         created_at: Utc::now(),
         updated_at: Utc::now(),
     }

--- a/images/base/nautiloop-agent-entry
+++ b/images/base/nautiloop-agent-entry
@@ -17,6 +17,54 @@ while [ ! -f "$READY_FILE" ]; do
     sleep 0.1
 done
 
+# --- Auth-degraded watchdog ---
+#
+# The sidecar's model proxy writes /tmp/shared/auth-degraded after N
+# consecutive OAuth refresh failures (see sidecar/src/model_proxy.rs
+# AUTH_DEGRADED_THRESHOLD). When that file appears we abort the
+# stage with the "auth expired" exit code so the control plane maps
+# the failure to AWAITING_REAUTH instead of burning the rest of the
+# stage budget on opencode's exponential retry of 502s.
+#
+# Background-poll every 5s. On detection: emit a NAUTILOOP_RESULT
+# error envelope so `nemo logs` shows the cause, then SIGTERM the
+# main entrypoint PID. tini (PID 1) propagates the signal to the
+# whole pod and the K8s Job picks up exit 42 → AuthExpired.
+AUTH_DEGRADED_FLAG="/tmp/shared/auth-degraded"
+MAIN_PID=$$
+(
+    while true; do
+        if [ -f "$AUTH_DEGRADED_FLAG" ]; then
+            reason=$(cat "$AUTH_DEGRADED_FLAG" 2>/dev/null || echo "unknown")
+            echo "NAUTILOOP_ERROR: sidecar reported auth-degraded; aborting stage" >&2
+            # Best-effort jq — if absent we still emit a parseable line.
+            if command -v jq >/dev/null 2>&1; then
+                jq -nc \
+                    --arg stage "${STAGE:-unknown}" \
+                    --arg reason "$reason" \
+                    '{stage: $stage, data: {exit_code: 42, error: ("Auth expired: " + $reason)}}' \
+                    | sed 's/^/NAUTILOOP_RESULT:/'
+            else
+                printf 'NAUTILOOP_RESULT:{"stage":"%s","data":{"exit_code":42,"error":"Auth expired"}}\n' \
+                    "${STAGE:-unknown}"
+            fi
+            # Signal the entrypoint. set -e on the main script will
+            # propagate; we don't use kill -KILL so cleanup traps
+            # (if any) get a chance to run.
+            kill -TERM "$MAIN_PID" 2>/dev/null || true
+            sleep 5
+            kill -KILL "$MAIN_PID" 2>/dev/null || true
+            exit 42
+        fi
+        sleep 5
+    done
+) &
+AUTH_WATCHDOG_PID=$!
+trap 'kill "$AUTH_WATCHDOG_PID" 2>/dev/null || true' EXIT
+# Map SIGTERM (from the watchdog above) to the agent-expired exit code
+# so the K8s Job carries the right signal up to the control plane.
+trap 'exit 42' TERM
+
 # --- Validate required environment variables (Edge Case: Template variable not set) ---
 required_vars="STAGE SPEC_PATH BRANCH SHA ROUND LOOP_ID"
 missing=""

--- a/sidecar/src/model_proxy.rs
+++ b/sidecar/src/model_proxy.rs
@@ -84,7 +84,28 @@ const FORBIDDEN_BODY: &[u8] =
 pub(crate) struct OauthCacheState {
     credential: Option<CodexOauthCredential>,
     last_failure: Option<OauthRefreshFailure>,
+    /// Consecutive refresh failures since the last success. Once
+    /// this passes `AUTH_DEGRADED_THRESHOLD`, the sidecar writes the
+    /// `/tmp/shared/auth-degraded` flag so the agent entrypoint can
+    /// abort the stage with exit 42 (auth-expired) instead of
+    /// burning the full deadline on opencode's exponential retry of
+    /// 502s. Reset to 0 on every successful refresh.
+    consecutive_failures: u32,
 }
+
+/// Number of consecutive refresh failures before we declare auth
+/// "degraded" and signal the agent to bail. With the 60s cooldown
+/// from earlier, this gives the upstream ~5 minutes to recover from
+/// transient outages before we give up — long enough to absorb a
+/// brief network blip, short enough that an actually-stale refresh
+/// token doesn't burn the rest of the stage budget.
+const AUTH_DEGRADED_THRESHOLD: u32 = 5;
+
+/// Path to the flag file the sidecar writes on persistent auth
+/// degradation. Lives on the `/tmp/shared` emptyDir mount that's
+/// already shared between sidecar and agent containers (used today
+/// for the sidecar's startup-probe handshake).
+const AUTH_DEGRADED_FLAG_PATH: &str = "/tmp/shared/auth-degraded";
 
 #[derive(Debug, Clone)]
 struct OauthRefreshFailure {
@@ -856,20 +877,48 @@ where
             // Clear the backoff window on success so the next legitimate
             // failure gets a fresh timer rather than an already-aged one.
             guard.last_failure = None;
+            guard.consecutive_failures = 0;
+            // Best-effort: a successful refresh implies any prior
+            // "auth-degraded" state cleared. Removing the flag lets
+            // the agent's watcher reset if it was about to abort.
+            let _ = std::fs::remove_file(AUTH_DEGRADED_FLAG_PATH);
             Ok(OpenAiCredential::CodexOauth(refreshed))
         }
         Err(e) => {
-            let mut guard = openai_oauth_cache.lock().await;
-            let first_failure = guard.last_failure.is_none();
-            guard.last_failure = Some(OauthRefreshFailure {
-                at_ms: now_ms,
-                message: e.clone(),
-            });
+            let (first_failure, failures_now) = {
+                let mut guard = openai_oauth_cache.lock().await;
+                let first = guard.last_failure.is_none();
+                guard.last_failure = Some(OauthRefreshFailure {
+                    at_ms: now_ms,
+                    message: e.clone(),
+                });
+                guard.consecutive_failures = guard.consecutive_failures.saturating_add(1);
+                (first, guard.consecutive_failures)
+            };
             if first_failure {
                 logging::warn(&format!(
                     "OpenAI OAuth refresh failed; backing off for {}s before retrying: {e}",
                     OPENAI_OAUTH_REFRESH_COOLDOWN_MS / 1000,
                 ));
+            }
+            // After N consecutive failures across the cooldown window,
+            // the refresh token is almost certainly dead and waiting
+            // longer just burns the stage budget. Drop a flag the
+            // agent entrypoint polls; on detection it kills the CLI
+            // and exits with the auth-expired exit code, which the
+            // control plane maps to AWAITING_REAUTH instead of a
+            // generic stage failure.
+            if failures_now == AUTH_DEGRADED_THRESHOLD {
+                logging::warn(&format!(
+                    "OpenAI OAuth refresh failed {failures_now} times in a row; \
+                     signalling auth-degraded so the agent can abort the stage early",
+                ));
+                let payload = format!("openai_oauth: {e}\n");
+                if let Err(write_err) = std::fs::write(AUTH_DEGRADED_FLAG_PATH, payload) {
+                    logging::warn(&format!(
+                        "failed to write auth-degraded flag at {AUTH_DEGRADED_FLAG_PATH}: {write_err}"
+                    ));
+                }
             }
             Err(e)
         }


### PR DESCRIPTION
## Summary

Three operator-facing UX/reliability fixes that close the diagnostic gap between "loop running" and "loop wedged for 97 minutes on dead credentials". First batch from the deferred-items list shipped in v0.7.13.

### 1. `last_activity_at` heartbeat

Single TIMESTAMPTZ column on `loops` (migration `20260424000004`). Bumped by the reconciler whenever it observes forward progress on a pod — currently the dispatch handshake completing and any new log bytes ingested. Surfaced in `nemo status` as an `ACTIVITY` column formatted `Xs / Xm / XhYm / Xd`. `None` renders as `-` for loops that never had a pod.

Operators can now spot a wedged loop in <30s instead of `kubectl exec`'ing into the agent pod and reading `/proc`.

### 2. `gh auth status` preflight on `nemo harden / start / ship`

The agent pod's PR-creation path shells out to `gh pr create`, whose credential lookup the sidecar's git+ssh proxy doesn't cover. Today an absent token only surfaces after a successful 60-min audit, then loops infinitely on the PR step. Preflight catches it on the engineer's laptop in <500ms with a clear `gh auth login --hostname github.com` hint.

New `cli/src/preflight.rs` is the home for the rest of the suite (Anthropic + OpenAI pings come in v0.7.15). Skip-on-no-gh so a clean machine doesn't get locked out.

### 3. Fail-fast on persistent OAuth refresh failure

The sidecar's model proxy tracks consecutive refresh failures; after `AUTH_DEGRADED_THRESHOLD` (5, ≈5 min with the existing 60s cooldown), it drops `/tmp/shared/auth-degraded` with the last upstream error.

The agent entrypoint runs a background watchdog on that flag; on detection it emits a `NAUTILOOP_RESULT` envelope with `exit_code: 42` (auth-expired convention) and `SIGTERM`s the main script. The K8s Job picks up exit 42, the loop engine maps it to `AwaitingReauth` via the existing FR-10 path, and the operator sees a single clear terminal state instead of "HARDENING/RUNNING for 97 min".

A successful refresh removes the flag and resets the counter — transient outages that recover don't permanently signal degraded.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib --bins` (483 unit tests, including new `format_activity_*` and `render_and_decide_*` regression guards).
- [x] k3d smoke: `/start` dispatched, `last_activity_at` populated within one reconciler tick; visible in psql with NOW()-based age (`00:01:01.943055`).
- [ ] Operator smoke against the failure modes that motivated each fix:
  - dispatch a loop with `gh auth logout` first → CLI should refuse with hint, not submit.
  - revoke OAuth refresh token mid-stage → sidecar writes flag → agent exits 42 → loop transitions to `AWAITING_REAUTH` instead of burning the deadline.

## Out of scope (v0.7.15+)

- Anthropic / OpenAI preflight pings.
- `gh` token mount in agent pod (separate ask — preflight catches the *engineer-side* missing token; the agent-side is a credential-mount problem we haven't solved yet).
- Event stream from agent (opencode log/DB tailing).
- Token/cost ticker in `nemo status` / `nemo watch`.