### PR TITLE
chore: release 0.7.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-control-plane"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-sidecar"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "bytes",
  "chrono",
@@ -2692,7 +2692,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-cli"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["control-plane", "cli", "sidecar"]
 
 [workspace.package]
-version = "0.7.13"
+version = "0.7.14"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -65,9 +65,9 @@ module "nautiloop" {
   acme_email = "me@mydomain.com"     # required if domain is set
 
   # Optional: images (defaults to latest public GHCR)
-  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.13"
-  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.13"
-  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.13"
+  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.14"
+  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.14"
+  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.14"
 }
 ```
 
@@ -83,9 +83,9 @@ module "nautiloop" {
 | `repo_ssh_private_key` | no | auto-generated | SSH deploy key. If null, generates ED25519 |
 | `domain` | no | `null` | Domain for TLS. null = HTTP on raw IP:8080 |
 | `acme_email` | no | `null` | Let's Encrypt email. Required if domain is set |
-| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.13` | Control plane image |
-| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.13` | Agent base image |
-| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.13` | Auth sidecar image |
+| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.14` | Control plane image |
+| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.14` | Agent base image |
+| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.14` | Auth sidecar image |
 | `k3s_version` | no | `v1.32.13+k3s1` | k3s version (v1.32+ required) |
 | `postgres_password` | no | auto-generated | Postgres password |
 | `postgres_volume_size` | no | `20` | Postgres volume size (Gi) |
@@ -233,9 +233,9 @@ nemo auth                    # pushes credentials (Claude, OpenAI, SSH) to clust
 ```bash
 ./build-images.sh --tag 0.2.0
 terraform apply \
-  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.13" \
-  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.13" \
-  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.13"
+  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.14" \
+  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.14" \
+  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.14"
 ```
 
 All three images must be updated together to avoid version skew.

--- a/terraform/examples/existing-server/variables.tf
+++ b/terraform/examples/existing-server/variables.tf
@@ -50,17 +50,17 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.13"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.14"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.13"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.14"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.13"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.14"
 }

--- a/terraform/examples/hetzner/variables.tf
+++ b/terraform/examples/hetzner/variables.tf
@@ -77,19 +77,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.13"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.14"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.13"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.14"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.13"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.14"
 }
 
 variable "k3s_version" {

--- a/terraform/modules/nautiloop/variables.tf
+++ b/terraform/modules/nautiloop/variables.tf
@@ -79,19 +79,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.13"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.14"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.13"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.14"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.13"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.14"
 }
 
 # --- Optional: tuning ---

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -71,19 +71,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.13"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.14"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.13"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.14"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.13"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.14"
 }
 
 variable "k3s_version" {


### PR DESCRIPTION
## Summary
Patch release: ship the operator-feedback-loop fixes from #211 — heartbeat column, `gh auth` preflight, and fail-fast on persistent OAuth refresh failure. The 90+ minute "is this loop wedged or working?" diagnostic gap closes in this release.

- feat: `last_activity_at` heartbeat on every loop, surfaced in `nemo status` as an ACTIVITY column. Bumped on dispatch and on every new agent log line. (#211)
- feat: `gh auth status` preflight on `nemo harden / start / ship`. Fails in <500ms with a `gh auth login` hint when the engineer's token is missing — instead of after a successful 60-min audit fails on `gh pr create`. (#211)
- feat: fail-fast on dead OAuth refresh tokens. Sidecar drops `/tmp/shared/auth-degraded` after 5 consecutive refresh failures (≈5 min). Agent entrypoint exits 42 on the flag, the K8s Job fails with the auth-expired exit code, and the loop transitions to AWAITING_REAUTH instead of burning the rest of the deadline on opencode's exponential 502 retry. (#211)

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib --bins` (483 unit tests).
- [x] `bash -n` syntax check on the modified agent entrypoint.
- [x] k3d smoke: `last_activity_at` populated within one reconciler tick of dispatch.
- [ ] Operator smoke: `gh auth logout` then `nemo harden` — expect refusal with hint.
- [ ] Operator smoke: revoke OAuth refresh token mid-stage — expect AWAITING_REAUTH within ≈5 min.