### PR TITLE
feat: gh auth in agent + token ticker + opencode event stream

### DIFF
--- a/cli/src/api_types.rs
+++ b/cli/src/api_types.rs
@@ -81,6 +81,14 @@ pub struct LoopSummary {
     /// without exec'ing into the cluster.
     #[serde(default)]
     pub last_activity_at: Option<String>,
+    /// Cumulative input tokens across all completed rounds. Defaults
+    /// to 0 when the server is older than v0.7.15 or the loop has
+    /// no rounds yet.
+    #[serde(default)]
+    pub tokens_input: u64,
+    /// Cumulative output tokens. Same source as `tokens_input`.
+    #[serde(default)]
+    pub tokens_output: u64,
 }
 
 /// GET /pod-introspect/:loop_id response.

--- a/cli/src/commands/auth.rs
+++ b/cli/src/commands/auth.rs
@@ -35,6 +35,7 @@ pub async fn run(
     claude: bool,
     openai: bool,
     ssh: bool,
+    github: bool,
     json: bool,
 ) -> Result<()> {
     if engineer.is_empty() {
@@ -51,9 +52,12 @@ pub async fn run(
     if ssh {
         providers.push("ssh");
     }
-    // Default: all three if none specified
+    if github {
+        providers.push("github");
+    }
+    // Default: all four if none specified
     if providers.is_empty() {
-        providers = vec!["claude", "openai", "ssh"];
+        providers = vec!["claude", "openai", "ssh", "github"];
     }
 
     let mut any_registered = false;
@@ -100,7 +104,88 @@ pub async fn run(
                 let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
                 format!("{home}/.ssh/id_ed25519")
             }
+            "github" => {
+                // Sentinel — there is no "credential file" for GitHub.
+                // We extract the PAT via `gh auth token` further down,
+                // which is the gh CLI's documented way to surface
+                // whatever auth backend (PAT, device flow, secrets
+                // manager) the engineer has configured. Using a
+                // non-path string here lets the existence check below
+                // (`std::path::Path::new(&cred_path).exists()`) fall
+                // through to our explicit github branch.
+                "<gh-auth-token>".to_string()
+            }
             _ => continue,
+        };
+
+        // Provider-specific override: for `github`, run `gh auth token`
+        // to extract the PAT from the engineer's gh config. This is
+        // what `gh` itself uses for `gh pr create`, so we get exactly
+        // the same auth path the agent pod will use at run time.
+        let github_token: Option<String> = if *provider == "github" {
+            match std::process::Command::new("gh")
+                .arg("auth")
+                .arg("token")
+                .arg("--hostname")
+                .arg("github.com")
+                .output()
+            {
+                Ok(out) if out.status.success() => {
+                    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+                    if s.is_empty() {
+                        let msg =
+                            "gh auth token returned empty output; run `gh auth login --hostname github.com` first".to_string();
+                        if !json {
+                            eprintln!("Error: {msg}");
+                        }
+                        messages.push(msg);
+                        json_results.push(AuthProviderResult {
+                            provider: provider.to_string(),
+                            status: "error".to_string(),
+                            messages,
+                        });
+                        any_error = true;
+                        continue;
+                    }
+                    Some(s)
+                }
+                Ok(out) => {
+                    let stderr = String::from_utf8_lossy(&out.stderr);
+                    let msg = format!(
+                        "gh auth token failed (exit {}): {stderr}. Run `gh auth login --hostname github.com`.",
+                        out.status,
+                    );
+                    if !json {
+                        eprintln!("Error: {msg}");
+                    }
+                    messages.push(msg);
+                    json_results.push(AuthProviderResult {
+                        provider: provider.to_string(),
+                        status: "error".to_string(),
+                        messages,
+                    });
+                    any_error = true;
+                    continue;
+                }
+                Err(e) => {
+                    let msg = format!(
+                        "could not invoke gh CLI: {e}. Install gh and run `gh auth login --hostname github.com`."
+                    );
+                    if !json {
+                        eprintln!("Error: {msg}");
+                    }
+                    messages.push(msg);
+                    json_results.push(AuthProviderResult {
+                        provider: provider.to_string(),
+                        status: "error".to_string(),
+                        messages,
+                    });
+                    any_error = true;
+                    continue;
+                }
+            }
+        } else {
+            None
         };
 
         // For claude on macOS: if the disk file is missing but the keychain has a
@@ -122,7 +207,10 @@ pub async fn run(
                 None
             };
 
-        if !std::path::Path::new(&cred_path).exists() && claude_keychain_fallback.is_none() {
+        if *provider != "github"
+            && !std::path::Path::new(&cred_path).exists()
+            && claude_keychain_fallback.is_none()
+        {
             if !json {
                 eprintln!("No {provider} credentials found at {cred_path}");
                 match *provider {
@@ -141,15 +229,18 @@ pub async fn run(
                 messages,
             });
             // If the provider was explicitly requested (not default "all"), treat as error
-            if claude || openai || ssh {
+            if claude || openai || ssh || github {
                 any_error = true;
             }
             continue;
         }
 
         // Read the credential file. For Claude on macOS, prefer a fresh
-        // keychain entry over a stale disk file.
-        let content = {
+        // keychain entry over a stale disk file. For GitHub, the
+        // token came from `gh auth token` above, not a file.
+        let content = if let Some(token) = github_token.clone() {
+            token
+        } else {
             let file_content = std::fs::read_to_string(&cred_path);
             if *provider == "claude" {
                 let now = crate::claude_creds::now_ms();

--- a/cli/src/commands/helm/actions.rs
+++ b/cli/src/commands/helm/actions.rs
@@ -88,6 +88,8 @@ mod tests {
             created_at: "2026-04-10T10:00:00Z".to_string(),
             updated_at: "2026-04-10T10:00:00Z".to_string(),
             last_activity_at: None,
+            tokens_input: 0,
+            tokens_output: 0,
         }
     }
 

--- a/cli/src/commands/helm/mod.rs
+++ b/cli/src/commands/helm/mod.rs
@@ -2637,6 +2637,8 @@ mod tests {
             created_at: updated_at.to_string(),
             updated_at: updated_at.to_string(),
             last_activity_at: None,
+            tokens_input: 0,
+            tokens_output: 0,
         }
     }
 

--- a/cli/src/commands/helm/summary.rs
+++ b/cli/src/commands/helm/summary.rs
@@ -178,6 +178,8 @@ mod tests {
             created_at: "2026-04-10T10:00:00Z".to_string(),
             updated_at: "2026-04-10T10:00:00Z".to_string(),
             last_activity_at: None,
+            tokens_input: 0,
+            tokens_output: 0,
         }
     }
 

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -39,17 +39,18 @@ pub async fn run(client: &NemoClient, engineer: &str, team: bool, json: bool) ->
         return Ok(());
     }
 
-    // Table output. ACTIVITY column shows the relative time since
-    // the reconciler last observed forward progress (new agent log
-    // bytes or fresh dispatch). A loop wedged on dead credentials
-    // grows "Xm ago" while a healthy run resets every reconciler
-    // tick — operators can spot wedges in <30s instead of having
-    // to kubectl-exec into the agent pod.
+    // Table output. ACTIVITY shows the relative time since the
+    // reconciler last observed forward progress (new agent log bytes
+    // or fresh dispatch); TOKENS shows cumulative LLM token usage
+    // across completed rounds as `<input>/<output>`. A loop wedged
+    // on dead credentials grows "Xm ago" while TOKENS stays flat;
+    // a healthy active loop resets ACTIVITY each tick and ticks
+    // TOKENS up after each round.
     println!(
-        "{:<38} {:<12} {:<10} {:<20} {:<40} {:<8} {:<10}",
-        "LOOP ID", "STATE", "STAGE", "ENGINEER", "SPEC", "ROUND", "ACTIVITY"
+        "{:<38} {:<12} {:<10} {:<20} {:<40} {:<8} {:<10} {:<14}",
+        "LOOP ID", "STATE", "STAGE", "ENGINEER", "SPEC", "ROUND", "ACTIVITY", "TOKENS (in/out)"
     );
-    println!("{}", "-".repeat(150));
+    println!("{}", "-".repeat(165));
 
     for l in &resp.loops {
         let state_display = match &l.sub_state {
@@ -58,19 +59,38 @@ pub async fn run(client: &NemoClient, engineer: &str, team: bool, json: bool) ->
         };
         let stage_display = l.current_stage.as_deref().unwrap_or("-");
         let activity_display = format_activity(l.last_activity_at.as_deref());
+        let tokens_display = format!(
+            "{}/{}",
+            format_tokens(l.tokens_input),
+            format_tokens(l.tokens_output)
+        );
         println!(
-            "{:<38} {:<12} {:<10} {:<20} {:<40} {:<8} {:<10}",
+            "{:<38} {:<12} {:<10} {:<20} {:<40} {:<8} {:<10} {:<14}",
             l.loop_id,
             state_display,
             stage_display,
             l.engineer,
             l.spec_path,
             l.round,
-            activity_display
+            activity_display,
+            tokens_display
         );
     }
 
     Ok(())
+}
+
+/// Format a token count with k/m suffixes for readability. Mirrors
+/// the existing helm cost formatter so `nemo status` and `nemo
+/// helm` show consistent units.
+fn format_tokens(n: u64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}m", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{}k", n / 1_000)
+    } else {
+        n.to_string()
+    }
 }
 
 /// Render `last_activity_at` as a compact relative time. `None` /
@@ -111,6 +131,15 @@ mod tests {
     fn format_activity_renders_dash_when_absent_or_unparseable() {
         assert_eq!(format_activity(None), "-");
         assert_eq!(format_activity(Some("not a timestamp")), "-");
+    }
+
+    #[test]
+    fn format_tokens_compacts_with_k_and_m_suffixes() {
+        assert_eq!(format_tokens(0), "0");
+        assert_eq!(format_tokens(999), "999");
+        assert_eq!(format_tokens(1_500), "1k");
+        assert_eq!(format_tokens(120_000), "120k");
+        assert_eq!(format_tokens(2_400_000), "2.4m");
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -434,6 +434,14 @@ enum Commands {
         #[arg(long)]
         ssh: bool,
 
+        /// Push GitHub PAT only. Extracted via `gh auth token` so the
+        /// engineer's existing `gh auth login` setup is the source of
+        /// truth. Stored in the engineer's K8s secret under the
+        /// `github` key and mounted as `GH_TOKEN` in agent pods so
+        /// `gh pr create` works without re-prompting.
+        #[arg(long)]
+        github: bool,
+
         /// Output as JSON
         #[arg(long)]
         json: bool,
@@ -1298,6 +1306,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
             claude,
             openai,
             ssh,
+            github,
             json,
         } => {
             commands::auth::run(
@@ -1308,6 +1317,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                 claude,
                 openai,
                 ssh,
+                github,
                 json,
             )
             .await?;

--- a/control-plane/src/api/handlers.rs
+++ b/control-plane/src/api/handlers.rs
@@ -388,10 +388,24 @@ pub async fn status(
         )
         .await?;
 
+    // Batch-fetch rounds for every loop in one query so the token
+    // aggregation doesn't N+1-query the DB. Empty when there are no
+    // active loops.
+    let loop_ids: Vec<uuid::Uuid> = loops.iter().map(|l| l.id).collect();
+    let rounds_by_loop = if loop_ids.is_empty() {
+        std::collections::HashMap::new()
+    } else {
+        state.store.get_rounds_for_loops(&loop_ids).await?
+    };
+
     let mut summaries = Vec::with_capacity(loops.len());
     for loop_record in loops {
         let current_stage = current_stage_for_loop(&state, &loop_record).await?;
         let active_job_name = loop_record.active_job_name.clone();
+        let (tokens_input, tokens_output) = rounds_by_loop
+            .get(&loop_record.id)
+            .map(|rounds| sum_round_tokens(rounds))
+            .unwrap_or((0, 0));
         summaries.push(LoopSummary {
             loop_id: loop_record.id,
             engineer: loop_record.engineer.clone(),
@@ -414,10 +428,35 @@ pub async fn status(
             created_at: loop_record.created_at,
             updated_at: loop_record.updated_at,
             last_activity_at: loop_record.last_activity_at,
+            tokens_input,
+            tokens_output,
         });
     }
 
     Ok(Json(StatusResponse { loops: summaries }))
+}
+
+/// Sum input/output tokens across every round whose `output` JSON
+/// carries a `token_usage` block. Rounds without one contribute 0
+/// (still in-flight, or non-LLM stages like `test`). Tolerant of
+/// missing or wrong-typed fields — best-effort surfacing.
+fn sum_round_tokens(rounds: &[crate::types::RoundRecord]) -> (u64, u64) {
+    let mut input: u64 = 0;
+    let mut output: u64 = 0;
+    for r in rounds {
+        let Some(out) = r.output.as_ref() else {
+            continue;
+        };
+        let usage = out.get("token_usage").or_else(|| {
+            // Some envelopes nest the verdict under `data`.
+            out.get("data").and_then(|d| d.get("token_usage"))
+        });
+        if let Some(u) = usage {
+            input = input.saturating_add(u.get("input").and_then(|v| v.as_u64()).unwrap_or(0));
+            output = output.saturating_add(u.get("output").and_then(|v| v.as_u64()).unwrap_or(0));
+        }
+    }
+    (input, output)
 }
 
 fn current_stage_source_state(record: &LoopRecord) -> Option<LoopState> {

--- a/control-plane/src/k8s/job_builder.rs
+++ b/control-plane/src/k8s/job_builder.rs
@@ -377,6 +377,39 @@ fn build_agent_env_vars(
         "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 9091 localhost",
     ));
 
+    // GH_TOKEN for `gh pr create` from the agent. Pulled from the
+    // engineer's `nautiloop-creds-{engineer}` secret under the
+    // `github` key (populated by `nemo auth --github` from the
+    // engineer's local `gh auth token`). Marked optional so pods
+    // whose engineer hasn't run `nemo auth --github` still start —
+    // the eventual `gh pr create` will fail with the upstream
+    // "not authenticated" message, which is the same situation we
+    // had pre-v0.7.15 and is at least an obvious failure rather
+    // than a startup crash. Once the engineer runs `nemo auth
+    // --github` and re-dispatches, the env appears.
+    //
+    // This is a deliberate exception to the "secrets never touch
+    // the agent" rule (CLAUDE.md): GitHub PR creation is genuinely
+    // an agent-side operation and proxying gh CLI through a sidecar
+    // route would require either re-implementing the GitHub REST
+    // API or forking gh — both of which are larger surface area
+    // than the existing sidecar's git+ssh path. The token is scoped
+    // to the engineer's PAT (already limited by their gh login)
+    // and lives only in the pod's env, not on disk.
+    let safe_engineer: String = ctx.engineer.to_lowercase().replace('_', "-");
+    env.push(EnvVar {
+        name: "GH_TOKEN".to_string(),
+        value_from: Some(k8s_openapi::api::core::v1::EnvVarSource {
+            secret_key_ref: Some(k8s_openapi::api::core::v1::SecretKeySelector {
+                name: format!("nautiloop-creds-{safe_engineer}"),
+                key: "github".to_string(),
+                optional: Some(true),
+            }),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+
     // FR-7: Session ID for round > 1
     if let Some(ref session_id) = ctx.session_id {
         env.push(env_var("SESSION_ID", session_id));
@@ -1105,6 +1138,44 @@ mod tests {
         assert_eq!(
             git_url.value.as_deref(),
             Some("git@github.com:test-org/test-repo.git")
+        );
+    }
+
+    #[test]
+    fn test_build_job_gh_token_env_from_engineer_secret() {
+        // v0.7.15: GH_TOKEN injected as an env var pulled from the
+        // engineer's secret under the `github` key, marked optional
+        // so pods don't fail to start when an engineer hasn't yet
+        // run `nemo auth --github`. Locked by this test because
+        // dropping the optional flag silently breaks every loop
+        // submitted before the operator has set up their PAT.
+        let ctx = test_ctx();
+        let stage = test_stage();
+        let cfg = test_cfg();
+        let job = build_job(&ctx, &stage, &cfg);
+        let agent = &job.spec.unwrap().template.spec.unwrap().containers[0];
+        let env = agent.env.as_ref().unwrap();
+        let gh_token = env
+            .iter()
+            .find(|e| e.name == "GH_TOKEN")
+            .expect("GH_TOKEN env var must be set on the agent container");
+        let value_from = gh_token
+            .value_from
+            .as_ref()
+            .expect("GH_TOKEN must use valueFrom, not a literal value");
+        let secret_ref = value_from
+            .secret_key_ref
+            .as_ref()
+            .expect("GH_TOKEN valueFrom must be a secretKeyRef");
+        // Engineer slug (alice in the test fixture) is lowercased
+        // and underscore-replaced to match the existing
+        // `nautiloop-creds-{engineer}` convention.
+        assert_eq!(secret_ref.name, "nautiloop-creds-alice");
+        assert_eq!(secret_ref.key, "github");
+        assert_eq!(
+            secret_ref.optional,
+            Some(true),
+            "the github key must be optional so pods start before nemo auth --github"
         );
     }
 

--- a/control-plane/src/types/api.rs
+++ b/control-plane/src/types/api.rs
@@ -120,6 +120,19 @@ pub struct LoopSummary {
     /// wedged loops without exec'ing into the cluster.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_activity_at: Option<DateTime<Utc>>,
+    /// Cumulative input tokens across every completed round on this
+    /// loop. Aggregated from each round's `output.token_usage.input`
+    /// JSON; rounds without a parsable token_usage block contribute 0.
+    /// Defaulted to 0 so a loop in PENDING with no rounds yet still
+    /// renders cleanly in `nemo status`. Operators paying per-token
+    /// can read these without standing up dashboard queries or
+    /// running ad-hoc psql.
+    #[serde(default)]
+    pub tokens_input: u64,
+    /// Cumulative output tokens. Same aggregation source as
+    /// `tokens_input`.
+    #[serde(default)]
+    pub tokens_output: u64,
 }
 
 /// GET /status query parameters.

--- a/images/base/nautiloop-agent-entry
+++ b/images/base/nautiloop-agent-entry
@@ -60,7 +60,49 @@ MAIN_PID=$$
     done
 ) &
 AUTH_WATCHDOG_PID=$!
-trap 'kill "$AUTH_WATCHDOG_PID" 2>/dev/null || true' EXIT
+
+# --- Opencode event-stream tailer ---
+#
+# `opencode run --format json` doesn't stream anything human-useful
+# to stdout — operators watching `nemo logs --tail` see nothing for
+# the full stage budget. opencode DOES write a structured log file
+# to ~/.local/share/opencode/log/*.log with INFO/WARN/ERROR per
+# tool call and per LLM round-trip, so we tail that file in the
+# background and forward filtered lines to pod stdout. They land
+# in the K8s pod logs, the reconciler's sync_current_stage_logs
+# ingests them on every tick, and `nemo logs --tail --follow`
+# shows them live.
+#
+# Best-effort: if opencode never runs (e.g. on a claude-only
+# stage), the tailer waits for a file that never appears and exits
+# cleanly when the trap fires.
+OPENCODE_LOG_DIR="${HOME:-/home/agent}/.local/share/opencode/log"
+mkdir -p "$OPENCODE_LOG_DIR"
+(
+    # Wait up to 10 minutes for opencode to create its log file. If it
+    # never does (claude-only stages), exit clean.
+    waited=0
+    while [ -z "$(ls -A "$OPENCODE_LOG_DIR" 2>/dev/null)" ]; do
+        sleep 2
+        waited=$((waited + 2))
+        if [ "$waited" -ge 600 ]; then
+            exit 0
+        fi
+    done
+    # tail -F follows rotations; --line-buffered grep prevents
+    # multi-second buffering of bursty events.
+    tail -F "$OPENCODE_LOG_DIR"/*.log 2>/dev/null \
+        | grep --line-buffered -E 'INFO|WARN|ERROR|tool|llm|model' \
+        | while IFS= read -r line; do
+            # Prefix with stage/round so multiple rounds in one pod
+            # remain disambiguable. Keep terse — these go straight
+            # into the logs table and bloat the pod log volume.
+            printf 'NEMO_EVENT: [%s/r%s] %s\n' "${STAGE:-?}" "${ROUND:-?}" "$line"
+        done
+) &
+OPENCODE_TAILER_PID=$!
+
+trap 'kill "$AUTH_WATCHDOG_PID" "$OPENCODE_TAILER_PID" 2>/dev/null || true' EXIT
 # Map SIGTERM (from the watchdog above) to the agent-expired exit code
 # so the K8s Job carries the right signal up to the control plane.
 trap 'exit 42' TERM


### PR DESCRIPTION
## Summary

Three more deferred items from the v0.7.13 follow-up list. All small, all separable, all close diagnostic gaps that compound the next bug.

### gh auth in agent pod

- `nemo auth --github` extracts the engineer's PAT via `gh auth token --hostname github.com` and pushes to control plane under the `github` provider. Plain `nemo auth` (no flags) now does claude + openai + ssh + github in one shot.
- Server stores it in `nautiloop-creds-{engineer}` under the `github` key (existing endpoint accepted arbitrary providers).
- Agent containers gain `GH_TOKEN` env via `secretKeyRef` with `optional: true` so pods of engineers who haven't run `nemo auth --github` still start. Locked by `test_build_job_gh_token_env_from_engineer_secret`.
- Deliberate exception to "agent gets no secrets" — proxying gh through a sidecar route would mean re-implementing GitHub REST or forking gh; both bigger surface than the existing git+ssh proxy.

### Token ticker in `nemo status`

- Server batches `get_rounds_for_loops` (no N+1) and aggregates `output.token_usage.{input,output}` across every round per loop into new `tokens_input` / `tokens_output` `LoopSummary` fields.
- CLI renders as a `TOKENS (in/out)` column formatted with k/m suffixes (`120k/8k`, `2.4m/35k`). Matches the existing helm cost formatter.
- Tolerant of envelope nesting under `data` and missing/wrong-typed fields.

### Opencode event stream

- Agent entrypoint background-tails `~/.local/share/opencode/log/*.log`, filters `INFO|WARN|ERROR|tool|llm|model` lines, forwards them to pod stdout prefixed `NEMO_EVENT: [stage/rN] <line>`.
- Goes through the existing kubelet log capture + `sync_current_stage_logs` ingestion path — zero server changes.
- Operators see `audit/r1] tool.read apps/foo/bar.ts` or `audit/r1] ERROR AI_APICallError 401` live in `nemo logs --tail --follow` instead of nothing for the full stage.
- Best-effort: claude-only stages and the 10-min waitless-of-opencode-startup case both exit clean.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib --bins` (485 unit tests, new regressions: `test_build_job_gh_token_env_from_engineer_secret`, `format_tokens_compacts_with_k_and_m_suffixes`).
- [x] `bash -n` syntax check on modified entrypoint.
- [ ] Operator smoke after release ships:
  - `nemo auth --github`, dispatch a loop that produces a PR — expect successful creation.
  - `nemo status` against an active loop — expect TOKENS column populated.
  - `nemo logs --tail --follow` on an opencode audit — expect `NEMO_EVENT` lines as opencode does tool calls.