### PR TITLE
chore: release 0.7.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-control-plane"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-sidecar"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "bytes",
  "chrono",
@@ -2692,7 +2692,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-cli"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["control-plane", "cli", "sidecar"]
 
 [workspace.package]
-version = "0.7.14"
+version = "0.7.15"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -65,9 +65,9 @@ module "nautiloop" {
   acme_email = "me@mydomain.com"     # required if domain is set
 
   # Optional: images (defaults to latest public GHCR)
-  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.14"
-  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.14"
-  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.14"
+  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.15"
+  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.15"
+  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.15"
 }
 ```
 
@@ -83,9 +83,9 @@ module "nautiloop" {
 | `repo_ssh_private_key` | no | auto-generated | SSH deploy key. If null, generates ED25519 |
 | `domain` | no | `null` | Domain for TLS. null = HTTP on raw IP:8080 |
 | `acme_email` | no | `null` | Let's Encrypt email. Required if domain is set |
-| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.14` | Control plane image |
-| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.14` | Agent base image |
-| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.14` | Auth sidecar image |
+| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.15` | Control plane image |
+| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.15` | Agent base image |
+| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.15` | Auth sidecar image |
 | `k3s_version` | no | `v1.32.13+k3s1` | k3s version (v1.32+ required) |
 | `postgres_password` | no | auto-generated | Postgres password |
 | `postgres_volume_size` | no | `20` | Postgres volume size (Gi) |
@@ -233,9 +233,9 @@ nemo auth                    # pushes credentials (Claude, OpenAI, SSH) to clust
 ```bash
 ./build-images.sh --tag 0.2.0
 terraform apply \
-  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.14" \
-  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.14" \
-  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.14"
+  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.15" \
+  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.15" \
+  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.15"
 ```
 
 All three images must be updated together to avoid version skew.

--- a/terraform/examples/existing-server/variables.tf
+++ b/terraform/examples/existing-server/variables.tf
@@ -50,17 +50,17 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.14"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.15"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.14"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.15"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.14"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.15"
 }

--- a/terraform/examples/hetzner/variables.tf
+++ b/terraform/examples/hetzner/variables.tf
@@ -77,19 +77,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.14"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.15"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.14"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.15"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.14"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.15"
 }
 
 variable "k3s_version" {

--- a/terraform/modules/nautiloop/variables.tf
+++ b/terraform/modules/nautiloop/variables.tf
@@ -79,19 +79,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.14"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.15"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.14"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.15"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.14"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.15"
 }
 
 # --- Optional: tuning ---

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -71,19 +71,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.14"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.15"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.14"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.15"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.14"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.15"
 }
 
 variable "k3s_version" {


### PR DESCRIPTION
## Summary
Patch release bundling #213's three operator-feedback follow-ups on top of v0.7.14: agent pods can finally create PRs, `nemo status` shows token usage, and `nemo logs --tail` actually streams events for opencode runs.

- feat(cli,api,k8s): `nemo auth --github` extracts the engineer's PAT via `gh auth token` and pushes to the control plane under the `github` provider. Agent pods gain `GH_TOKEN` env via secretKeyRef (optional) so `gh pr create` works. (#213)
- feat(api,cli): cumulative input/output token totals on every `LoopSummary`, surfaced in `nemo status` as a `TOKENS (in/out)` column with k/m suffixes. (#213)
- feat(images): agent entrypoint background-tails opencode's log file and forwards filtered events to pod stdout as `NEMO_EVENT: [stage/rN] ...`. Goes through the existing log ingestion path. Operators see tool calls and LLM round-trips live in `nemo logs --tail --follow` instead of nothing for the full stage. (#213)

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib --bins` (485 unit tests).
- [x] `bash -n` on the modified agent entrypoint.
- [ ] Operator smoke after release ships.