### PR TITLE
fix(api): surface sidecar and agent_image tags in /health to detect deploy skew

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,6 +6,13 @@
 - **Auto-commit on success**: After completing a task (tests pass, build succeeds), commit automatically without waiting to be asked (see `.claude/rules/auto-commit-on-success.md`).
 - **Conventional commits required**: All commits must follow conventional commits format - enforced by hook (see `.claude/rules/conventional-commits.md`).
 
+## Release skew (high priority)
+
+- **`/health` `version` is the control-plane binary only.** The Nautiloop stack ships three independently-tagged images (control-plane, sidecar, agent-base). They MUST be deployed at the same tag. A control plane at vN paired with a sidecar at vN-1 silently misses fixes — this is what caused the v0.7.13/.14/.15 audit failures with `Unsupported parameter: max_tokens`: the sidecar's `max_tokens → max_output_tokens` rewrite (commit 108c426) was already in source but the running sidecar pod was older.
+- **Always check `sidecar_image` and `agent_image` from `/health`.** Since v0.7.16, `GET /health` returns those fields. If any of the three differs from what you expect, halt the operation and resolve the skew before continuing — do not run `nemo harden`/`start` against a skewed cluster.
+- **Release process must update all three together.** When cutting a release, bump the workspace `Cargo.toml` version AND every `terraform/**/variables.tf` default tag (control_plane_image, sidecar_image, agent_base_image) AND `docs/deploy.md`'s example `terraform apply` snippet. The `/release` skill does this automatically; if you do it by hand, miss any one of those five and you ship skew.
+- **For local k3d dev, `dev/build.sh` builds and imports all three from the same checkout** — it cannot produce skew. The trap is remote/prod deploys where someone updates one image without the others. Check `/health` after every prod deploy.
+
 ## Rust development (high priority)
 
 - **Workspace layout**: Cargo workspace with two crates: `control-plane/` (library + binary) and `cli/` (binary).

--- a/control-plane/src/api/mod.rs
+++ b/control-plane/src/api/mod.rs
@@ -73,24 +73,50 @@ pub fn build_router(state: AppState) -> Router {
 }
 
 /// Health check that verifies Postgres connectivity.
-/// Returns 200 with `{"status":"ok","version":"...","build_info":"..."}` if the store is reachable,
-/// 503 with `{"status":"degraded","version":"...","build_info":"..."}` otherwise.
+///
+/// Response body always includes:
+///   - `version` — the control-plane crate version (`CARGO_PKG_VERSION`).
+///   - `build_info` — the control-plane git SHA at build time.
+///   - `sidecar_image` — the sidecar image tag the control plane will stamp
+///     onto every new agent Job. Configured via `cluster.sidecar_image`.
+///   - `agent_image` — same, for the agent-base image.
+///
+/// `version` reflects only the control-plane binary. `sidecar_image` and
+/// `agent_image` are required to detect deploy skew: a control plane at
+/// 0.7.16 paired with a sidecar at 0.7.13 silently misses the api-key
+/// `max_tokens → max_output_tokens` rewrite (commit 108c426) and audit
+/// stages fail with `Unsupported parameter: max_tokens`. Operators and
+/// release tooling MUST verify all three tags match before trusting that
+/// a fix is actually deployed. (See `.claude/CLAUDE.md` "Release skew".)
+///
+/// Returns 200 with `{"status":"ok",...}` if the store is reachable,
+/// 503 with `{"status":"degraded",...}` otherwise.
 /// K8s liveness/readiness probes use this to detect a dead control plane.
 async fn health(State(state): State<AppState>) -> impl IntoResponse {
     let version = env!("CARGO_PKG_VERSION");
     let build_info = option_env!("BUILD_SHA").unwrap_or("unknown");
+    let sidecar_image = state.config.cluster.sidecar_image.as_str();
+    let agent_image = state.config.cluster.agent_image.as_str();
     match state.store.health_check().await {
         Ok(()) => (
             StatusCode::OK,
-            axum::Json(
-                serde_json::json!({"status": "ok", "version": version, "build_info": build_info}),
-            ),
+            axum::Json(serde_json::json!({
+                "status": "ok",
+                "version": version,
+                "build_info": build_info,
+                "sidecar_image": sidecar_image,
+                "agent_image": agent_image,
+            })),
         ),
         Err(_) => (
             StatusCode::SERVICE_UNAVAILABLE,
-            axum::Json(
-                serde_json::json!({"status": "degraded", "version": version, "build_info": build_info}),
-            ),
+            axum::Json(serde_json::json!({
+                "status": "degraded",
+                "version": version,
+                "build_info": build_info,
+                "sidecar_image": sidecar_image,
+                "agent_image": agent_image,
+            })),
         ),
     }
 }
@@ -358,6 +384,20 @@ mod tests {
             .as_str()
             .expect("build_info should be a string");
         assert!(!build_info.is_empty(), "build_info should not be empty");
+        // Skew-detection fields: sidecar and agent-base image tags the
+        // control plane will stamp onto new Jobs. Operators read these to
+        // confirm all three deployed images match before trusting a fix.
+        let sidecar_image = json["sidecar_image"]
+            .as_str()
+            .expect("sidecar_image should be a string");
+        assert!(
+            !sidecar_image.is_empty(),
+            "sidecar_image should not be empty"
+        );
+        let agent_image = json["agent_image"]
+            .as_str()
+            .expect("agent_image should be a string");
+        assert!(!agent_image.is_empty(), "agent_image should not be empty");
     }
 
     #[tokio::test]
@@ -408,5 +448,18 @@ mod tests {
             .as_str()
             .expect("build_info should be a string");
         assert!(!build_info.is_empty(), "build_info should not be empty");
+        // Skew fields surface even on degraded so operators can still
+        // diagnose during partial outages.
+        let sidecar_image = json["sidecar_image"]
+            .as_str()
+            .expect("sidecar_image should be a string");
+        assert!(
+            !sidecar_image.is_empty(),
+            "sidecar_image should not be empty"
+        );
+        let agent_image = json["agent_image"]
+            .as_str()
+            .expect("agent_image should be a string");
+        assert!(!agent_image.is_empty(), "agent_image should not be empty");
     }
 }


### PR DESCRIPTION
## Summary

P0 hotfix. `/health` returned only the control-plane `CARGO_PKG_VERSION`, hiding the sidecar/agent-base tags. A control plane at v0.7.15 paired with a v0.7.13 sidecar passed every probe — and silently dropped commit `108c426`'s `max_tokens → max_output_tokens` rewrite, surfacing as audit failures: `Bad Request: {"detail":"Unsupported parameter: max_tokens"}`.

Add `sidecar_image` and `agent_image` to the `/health` body (both 200 and 503 paths) so the three deployed tags are visible at a glance. Add CLAUDE.md "Release skew" section so future runs check this before invoking `nemo harden`/`start` against a skewed cluster.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib --bins` (131 passed)
- [x] `api::tests::test_health_returns_json_ok` and `..._degraded_on_db_failure` updated to assert non-empty `sidecar_image` and `agent_image`
- [ ] Post-merge: cut v0.7.16 via `/release`, redeploy, confirm `/health` shows v0.7.16 for control-plane, sidecar, and agent_image