### PR TITLE
chore: release 0.7.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-control-plane"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-sidecar"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "bytes",
  "chrono",
@@ -2692,7 +2692,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-cli"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["control-plane", "cli", "sidecar"]
 
 [workspace.package]
-version = "0.7.15"
+version = "0.7.16"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -65,9 +65,9 @@ module "nautiloop" {
   acme_email = "me@mydomain.com"     # required if domain is set
 
   # Optional: images (defaults to latest public GHCR)
-  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.15"
-  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.15"
-  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.15"
+  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.16"
+  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.16"
+  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.16"
 }
 ```
 
@@ -83,9 +83,9 @@ module "nautiloop" {
 | `repo_ssh_private_key` | no | auto-generated | SSH deploy key. If null, generates ED25519 |
 | `domain` | no | `null` | Domain for TLS. null = HTTP on raw IP:8080 |
 | `acme_email` | no | `null` | Let's Encrypt email. Required if domain is set |
-| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.15` | Control plane image |
-| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.15` | Agent base image |
-| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.15` | Auth sidecar image |
+| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.16` | Control plane image |
+| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.16` | Agent base image |
+| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.16` | Auth sidecar image |
 | `k3s_version` | no | `v1.32.13+k3s1` | k3s version (v1.32+ required) |
 | `postgres_password` | no | auto-generated | Postgres password |
 | `postgres_volume_size` | no | `20` | Postgres volume size (Gi) |
@@ -233,9 +233,9 @@ nemo auth                    # pushes credentials (Claude, OpenAI, SSH) to clust
 ```bash
 ./build-images.sh --tag 0.2.0
 terraform apply \
-  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.15" \
-  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.15" \
-  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.15"
+  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.16" \
+  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.16" \
+  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.16"
 ```
 
 All three images must be updated together to avoid version skew.

--- a/terraform/examples/existing-server/variables.tf
+++ b/terraform/examples/existing-server/variables.tf
@@ -50,17 +50,17 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.15"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.16"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.15"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.16"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.15"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.16"
 }

--- a/terraform/examples/hetzner/variables.tf
+++ b/terraform/examples/hetzner/variables.tf
@@ -77,19 +77,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.15"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.16"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.15"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.16"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.15"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.16"
 }
 
 variable "k3s_version" {

--- a/terraform/modules/nautiloop/variables.tf
+++ b/terraform/modules/nautiloop/variables.tf
@@ -79,19 +79,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.15"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.16"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.15"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.16"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.15"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.16"
 }
 
 # --- Optional: tuning ---

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -71,19 +71,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.15"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.16"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.15"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.16"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.15"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.16"
 }
 
 variable "k3s_version" {


### PR DESCRIPTION
## Summary

P0 hotfix release. `/health` now surfaces `sidecar_image` and `agent_image` tags so operators can detect deploy skew at a glance — the silent miscompare that masked the v0.7.13/.14/.15 sidecar in production and caused audit failures with `Bad Request: {"detail":"Unsupported parameter: max_tokens"}` even though the rewrite (commit `108c426`) was on main. The control-plane `/health` previously reported only `version` (its own crate version), so a stack with sidecar at vN-1 and control plane at vN passed every probe and silently dropped the api-key Responses fix.

- fix(api): surface sidecar and agent_image tags in /health to detect deploy skew (#215)
- docs(claude): "Release skew" section in `.claude/CLAUDE.md` codifying the rule (always verify all three tags from `/health` before trusting a fix is deployed) so future agent runs catch this without operator intervention.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib --bins` (131 control-plane lib tests; full workspace clean)
- [x] `/health` tests assert non-empty `sidecar_image` and `agent_image` on both 200 ok and 503 degraded
- [ ] Post-merge: `terraform apply` against an existing cluster with all three image tags at 0.7.16; `curl /health` shows all three tags match