### PR TITLE
feat(cli): repo-level profile pin via [profile] name in nemo.toml

### DIFF
--- a/cli/src/commands/config.rs
+++ b/cli/src/commands/config.rs
@@ -93,8 +93,12 @@ fn handle_get(
     // Special: current_profile
     if key == "current_profile" {
         // Report the resolved effective profile (FR-6g).
-        // --profile flag is ignored for this key per spec; only NAUTILOOP_PROFILE > current_profile.
-        match config.resolve_profile_name(None) {
+        // --profile flag is ignored for this key per spec; the chain is
+        // NAUTILOOP_PROFILE > repo pin (./nemo.toml [profile] name) >
+        // current_profile.
+        match config
+            .resolve_profile_name(None, crate::project_config::current_repo_pin().as_deref())
+        {
             Ok(name) => {
                 println!("{name}");
                 Ok(())
@@ -105,7 +109,10 @@ fn handle_get(
             }
         }
     } else if is_profile_key(key) {
-        let profile_name = config.resolve_profile_name(profile_flag)?;
+        let profile_name = config.resolve_profile_name(
+            profile_flag,
+            crate::project_config::current_repo_pin().as_deref(),
+        )?;
         let profile = &config.profiles[&profile_name];
 
         let value = match key {
@@ -169,7 +176,10 @@ fn handle_set(config: &mut NemoConfig, kv: &str, profile_flag: Option<&str>) -> 
     }
 
     if is_profile_key(key) {
-        let profile_name = config.resolve_profile_name(profile_flag)?;
+        let profile_name = config.resolve_profile_name(
+            profile_flag,
+            crate::project_config::current_repo_pin().as_deref(),
+        )?;
         let profile = config.profiles.get_mut(&profile_name).unwrap();
 
         match key {
@@ -252,8 +262,13 @@ fn handle_set(config: &mut NemoConfig, kv: &str, profile_flag: Option<&str>) -> 
 }
 
 fn display_config(config: &NemoConfig, profile_flag: Option<&str>, unmask: bool) -> Result<()> {
-    // Try to resolve active profile
-    let active_name = config.resolve_profile_name(profile_flag).ok();
+    // Try to resolve active profile (respecting repo pin from ./nemo.toml).
+    let active_name = config
+        .resolve_profile_name(
+            profile_flag,
+            crate::project_config::current_repo_pin().as_deref(),
+        )
+        .ok();
 
     if let Some(ref name) = active_name {
         println!("Active profile: {name}");

--- a/cli/src/commands/profile.rs
+++ b/cli/src/commands/profile.rs
@@ -56,7 +56,10 @@ pub fn run_show(
             }
             n.to_string()
         }
-        None => config.resolve_profile_name(profile_flag)?,
+        None => config.resolve_profile_name(
+            profile_flag,
+            crate::project_config::current_repo_pin().as_deref(),
+        )?,
     };
 
     let profile = &config.profiles[&profile_name];

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -84,9 +84,19 @@ pub struct NemoConfig {
 
 impl NemoConfig {
     /// Resolve the active profile name from the precedence chain:
-    /// `--profile` flag > `NAUTILOOP_PROFILE` env > `current_profile`.
-    /// Returns the resolved name or an error.
-    pub fn resolve_profile_name(&self, flag: Option<&str>) -> Result<String> {
+    /// `--profile` flag > `NAUTILOOP_PROFILE` env > repo-pinned
+    /// `[profile] name` from `./nemo.toml` > `current_profile`.
+    ///
+    /// `repo_pin` is the pin loaded from the nearest `nemo.toml` walking
+    /// up from `$PWD` (see `project_config::load_project_profile_pin`).
+    /// Pass `None` if you don't want repo-level pinning to participate.
+    /// Empty / whitespace strings are filtered to `None` upstream, so
+    /// this function treats `Some("")` as "no pin" defensively too.
+    pub fn resolve_profile_name(
+        &self,
+        flag: Option<&str>,
+        repo_pin: Option<&str>,
+    ) -> Result<String> {
         // 1. --profile flag
         if let Some(name) = flag {
             if !self.profiles.contains_key(name) {
@@ -108,7 +118,24 @@ impl NemoConfig {
             }
         }
 
-        // 3. current_profile from config
+        // 3. Repo-pinned [profile] name from ./nemo.toml. Slotted above
+        // current_profile so a checked-in repo can dictate "this repo
+        // talks to the dev cluster" without every engineer remembering
+        // to switch their global current_profile when they `cd` here.
+        if let Some(pin) = repo_pin {
+            let pin = pin.trim();
+            if !pin.is_empty() {
+                if !self.profiles.contains_key(pin) {
+                    let available = self.profile_names_sorted().join(", ");
+                    anyhow::bail!(
+                        "Repo-pinned profile '{pin}' (from nemo.toml [profile] name) not found. Available: {available}."
+                    );
+                }
+                return Ok(pin.to_string());
+            }
+        }
+
+        // 4. current_profile from config
         match &self.current_profile {
             Some(name) if !name.is_empty() => {
                 if !self.profiles.contains_key(name) {
@@ -132,9 +159,15 @@ impl NemoConfig {
         }
     }
 
-    /// Get the active profile (after precedence resolution).
-    pub fn active_profile(&self, profile_flag: Option<&str>) -> Result<(&str, &ProfileConfig)> {
-        let name = self.resolve_profile_name(profile_flag)?;
+    /// Get the active profile (after precedence resolution). `repo_pin`
+    /// is forwarded to `resolve_profile_name`; see that doc for the
+    /// full chain.
+    pub fn active_profile(
+        &self,
+        profile_flag: Option<&str>,
+        repo_pin: Option<&str>,
+    ) -> Result<(&str, &ProfileConfig)> {
+        let name = self.resolve_profile_name(profile_flag, repo_pin)?;
         let profile = self.profiles.get(&name).unwrap(); // safe: resolve_profile_name checks existence
         Ok((
             // Return a reference to the key in the map (stable lifetime)
@@ -482,48 +515,44 @@ desktop_notifications = true
         assert_eq!(redact_api_key("exactly12ch"), "****");
     }
 
+    fn make_profile(server: &str) -> ProfileConfig {
+        ProfileConfig {
+            server_url: server.to_string(),
+            api_key: None,
+            engineer: "a".to_string(),
+            name: None,
+            email: None,
+        }
+    }
+
     #[test]
     fn resolve_profile_flag_wins() {
         let mut config = NemoConfig {
             current_profile: Some("default".to_string()),
             ..Default::default()
         };
-        config.profiles.insert(
-            "default".to_string(),
-            ProfileConfig {
-                server_url: "http://default".to_string(),
-                api_key: None,
-                engineer: "a".to_string(),
-                name: None,
-                email: None,
-            },
-        );
-        config.profiles.insert(
-            "work".to_string(),
-            ProfileConfig {
-                server_url: "http://work".to_string(),
-                api_key: None,
-                engineer: "b".to_string(),
-                name: None,
-                email: None,
-            },
-        );
+        config
+            .profiles
+            .insert("default".to_string(), make_profile("http://default"));
+        config
+            .profiles
+            .insert("work".to_string(), make_profile("http://work"));
 
-        let name = config.resolve_profile_name(Some("work")).unwrap();
+        let name = config.resolve_profile_name(Some("work"), None).unwrap();
         assert_eq!(name, "work");
     }
 
     #[test]
     fn resolve_profile_missing_errors() {
         let config = NemoConfig::default();
-        let err = config.resolve_profile_name(Some("nope")).unwrap_err();
+        let err = config.resolve_profile_name(Some("nope"), None).unwrap_err();
         assert!(err.to_string().contains("not found"));
     }
 
     #[test]
     fn resolve_profile_cold_start() {
         let config = NemoConfig::default();
-        let err = config.resolve_profile_name(None).unwrap_err();
+        let err = config.resolve_profile_name(None, None).unwrap_err();
         assert!(err.to_string().contains("No profiles configured"));
     }
 
@@ -533,17 +562,92 @@ desktop_notifications = true
             current_profile: Some("gone".to_string()),
             ..Default::default()
         };
-        config.profiles.insert(
-            "remaining".to_string(),
-            ProfileConfig {
-                server_url: "http://x".to_string(),
-                api_key: None,
-                engineer: "a".to_string(),
-                name: None,
-                email: None,
-            },
-        );
-        let err = config.resolve_profile_name(None).unwrap_err();
+        config
+            .profiles
+            .insert("remaining".to_string(), make_profile("http://x"));
+        let err = config.resolve_profile_name(None, None).unwrap_err();
         assert!(err.to_string().contains("Active profile 'gone' not found"));
+    }
+
+    #[test]
+    fn resolve_profile_repo_pin_overrides_current_profile() {
+        // Repo pin sits above current_profile, so a checked-in nemo.toml
+        // saying [profile] name = "dev" wins over a global current_profile
+        // that points elsewhere. This is the headline behavior for an
+        // engineer working across two nautiloop projects on one workstation.
+        let mut config = NemoConfig {
+            current_profile: Some("personal".to_string()),
+            ..Default::default()
+        };
+        config
+            .profiles
+            .insert("personal".to_string(), make_profile("http://personal"));
+        config
+            .profiles
+            .insert("dev".to_string(), make_profile("http://localhost:18080"));
+
+        let name = config.resolve_profile_name(None, Some("dev")).unwrap();
+        assert_eq!(name, "dev");
+    }
+
+    #[test]
+    fn resolve_profile_flag_beats_repo_pin() {
+        // Operators override per-invocation with --profile; the flag
+        // must trump the repo's pin so a one-off `nemo --profile prod
+        // status` still works inside a dev-pinned repo.
+        let mut config = NemoConfig {
+            current_profile: Some("personal".to_string()),
+            ..Default::default()
+        };
+        config
+            .profiles
+            .insert("dev".to_string(), make_profile("http://dev"));
+        config
+            .profiles
+            .insert("prod".to_string(), make_profile("http://prod"));
+        config
+            .profiles
+            .insert("personal".to_string(), make_profile("http://personal"));
+
+        let name = config
+            .resolve_profile_name(Some("prod"), Some("dev"))
+            .unwrap();
+        assert_eq!(name, "prod");
+    }
+
+    #[test]
+    fn resolve_profile_repo_pin_unknown_errors() {
+        // A repo pin that names a profile the engineer has never set up
+        // is a hard error with a clear message, not a silent fallthrough
+        // to current_profile — silent fallthrough would mask typos in a
+        // checked-in nemo.toml.
+        let mut config = NemoConfig {
+            current_profile: Some("personal".to_string()),
+            ..Default::default()
+        };
+        config
+            .profiles
+            .insert("personal".to_string(), make_profile("http://personal"));
+
+        let err = config.resolve_profile_name(None, Some("dev")).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("Repo-pinned profile 'dev'"), "got: {msg}");
+        assert!(msg.contains("nemo.toml"), "got: {msg}");
+    }
+
+    #[test]
+    fn resolve_profile_empty_repo_pin_falls_through() {
+        // Defensive: caller may pass Some("") or Some("   ") if the TOML
+        // had `name = ""`. Treat as unset, fall through to current_profile.
+        let mut config = NemoConfig {
+            current_profile: Some("personal".to_string()),
+            ..Default::default()
+        };
+        config
+            .profiles
+            .insert("personal".to_string(), make_profile("http://personal"));
+
+        let name = config.resolve_profile_name(None, Some("   ")).unwrap();
+        assert_eq!(name, "personal");
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1067,7 +1067,14 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
 
     let nemo_config = config::load_config()?;
     let profile_flag = cli.profile.as_deref();
-    let (profile_name, active_profile) = nemo_config.active_profile(profile_flag)?;
+    // Repo-level [profile] name pin: walks up from $PWD looking for
+    // nemo.toml, same way [models] / [timeouts] / [cache.env] do. Slots
+    // between NAUTILOOP_PROFILE and current_profile so a checked-in
+    // dev-cluster pin wins over the engineer's global "current" without
+    // overriding an explicit --profile or env override.
+    let repo_pin = project_config::current_repo_pin();
+    let (profile_name, active_profile) =
+        nemo_config.active_profile(profile_flag, repo_pin.as_deref())?;
 
     let server_url = cli
         .server

--- a/cli/src/project_config.rs
+++ b/cli/src/project_config.rs
@@ -86,6 +86,22 @@ impl CacheSection {
     }
 }
 
+/// `[profile]` block from repo-level `nemo.toml`. The `name` field
+/// pins which `~/.nemo/config.toml` profile this repo's `nemo`
+/// invocations should use, so an engineer working across two
+/// nautiloop projects on the same workstation doesn't have to remember
+/// `--profile dev` vs `--profile prod` on every command.
+///
+/// Slotted into `resolve_profile_name` between the `NAUTILOOP_PROFILE`
+/// env var and the global `current_profile` — explicit `--profile` and
+/// env still win, but the repo pin overrides whatever the engineer's
+/// global "current" happens to be.
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+pub struct ProfileSection {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
 #[derive(Debug, Default, Deserialize)]
 struct ProjectTomlShape {
     #[serde(default)]
@@ -94,6 +110,8 @@ struct ProjectTomlShape {
     timeouts: TimeoutsSection,
     #[serde(default)]
     cache: CacheSection,
+    #[serde(default)]
+    profile: ProfileSection,
 }
 
 /// Walk up from `start` looking for `nemo.toml`. Returns its directory
@@ -157,6 +175,40 @@ pub fn load_project_cache_env(start: &Path) -> Result<CacheSection> {
     let contents = std::fs::read_to_string(&path)?;
     let parsed: ProjectTomlShape = toml::from_str(&contents)?;
     Ok(parsed.cache)
+}
+
+/// Load `[profile] name` from the nearest `./nemo.toml`, walking up
+/// from `start`. Returns the pinned profile name if set, `None`
+/// otherwise. Empty strings and whitespace-only values are treated
+/// as unset to match the env-var semantics in `resolve_profile_name`.
+///
+/// Errors only on a malformed nemo.toml — a missing file or a missing
+/// `[profile]` block both return `Ok(None)`. Callers slot this between
+/// the `NAUTILOOP_PROFILE` env var and the global `current_profile`.
+pub fn load_project_profile_pin(start: &Path) -> Result<Option<String>> {
+    let Some(path) = find_project_toml(start) else {
+        return Ok(None);
+    };
+    let contents = std::fs::read_to_string(&path)?;
+    let parsed: ProjectTomlShape = toml::from_str(&contents)?;
+    Ok(parsed
+        .profile
+        .name
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty()))
+}
+
+/// Convenience wrapper around `load_project_profile_pin` that walks up
+/// from `$PWD` and silently returns `None` on any I/O / parse error.
+///
+/// Used by every CLI command site that resolves a profile, so a broken
+/// `nemo.toml` doesn't take down `nemo profile show` / `nemo config
+/// --get`. The strict Result variant is reserved for the active-profile
+/// path in `main.rs` where we want a malformed file to surface as an
+/// error rather than silently degrade to `current_profile`.
+pub fn current_repo_pin() -> Option<String> {
+    let cwd = std::env::current_dir().ok()?;
+    load_project_profile_pin(&cwd).ok().flatten()
 }
 
 /// Resolve the effective (implementor, reviewer) model pair using the
@@ -254,6 +306,55 @@ mod tests {
         let m = load_project_models(td.path()).unwrap();
         assert!(m.implementor.is_none());
         assert!(m.reviewer.is_none());
+    }
+
+    #[test]
+    fn load_profile_pin_returns_name_when_set() {
+        let td = tmpdir();
+        fs::write(td.path().join("nemo.toml"), "[profile]\nname = \"dev\"\n").unwrap();
+        let pin = load_project_profile_pin(td.path()).unwrap();
+        assert_eq!(pin.as_deref(), Some("dev"));
+    }
+
+    #[test]
+    fn load_profile_pin_walks_up() {
+        let td = tmpdir();
+        fs::write(td.path().join("nemo.toml"), "[profile]\nname = \"dev\"\n").unwrap();
+        let nested = td.path().join("a").join("b");
+        fs::create_dir_all(&nested).unwrap();
+        let pin = load_project_profile_pin(&nested).unwrap();
+        assert_eq!(pin.as_deref(), Some("dev"));
+    }
+
+    #[test]
+    fn load_profile_pin_none_when_no_file() {
+        let td = tmpdir();
+        let pin = load_project_profile_pin(td.path()).unwrap();
+        assert!(pin.is_none());
+    }
+
+    #[test]
+    fn load_profile_pin_none_when_section_absent() {
+        let td = tmpdir();
+        fs::write(td.path().join("nemo.toml"), "[models]\n").unwrap();
+        let pin = load_project_profile_pin(td.path()).unwrap();
+        assert!(pin.is_none());
+    }
+
+    #[test]
+    fn load_profile_pin_filters_empty_and_whitespace() {
+        // `name = ""` and `name = "   "` are both treated as unset so a
+        // half-edited nemo.toml doesn't surface a confusing pin error.
+        for value in ["\"\"", "\"   \""] {
+            let td = tmpdir();
+            fs::write(
+                td.path().join("nemo.toml"),
+                format!("[profile]\nname = {value}\n"),
+            )
+            .unwrap();
+            let pin = load_project_profile_pin(td.path()).unwrap();
+            assert!(pin.is_none(), "value {value} should be filtered to None");
+        }
     }
 
     // resolve_models touches $PWD + env, which are process-global.

--- a/nemo.toml
+++ b/nemo.toml
@@ -1,0 +1,15 @@
+# Per-repo nemo configuration. Walks up from $PWD like .git, so any
+# `nemo` invocation inside this checkout reads from this file.
+
+# Pin the profile this repo's loops dispatch to. The CLI resolves
+# the active profile in this order:
+#   1. --profile flag
+#   2. NAUTILOOP_PROFILE env var
+#   3. [profile] name below       <- this entry
+#   4. current_profile in ~/.nemo/config.toml
+#
+# `dev` matches the profile name `dev/setup.sh` writes after a fresh
+# k3d setup. To dispatch a one-off loop against a different cluster,
+# pass --profile <name> on the invocation.
+[profile]
+name = "dev"


### PR DESCRIPTION
## Summary

Closes the gap operators kept hitting after the v0.7.4 profile rollout: nemo had no way to pin a profile in the repo, so engineers across two nautiloop projects on one workstation had to remember `--profile dev` vs `--profile prod` on every command, or `nemo use-profile` flip the global \`current_profile\` when \`cd\`'ing between repos. Forgetting was silent — loops dispatched to the wrong cluster with zero warning.

`[profile] name = "..."` in repo-level \`nemo.toml\` (walks up from \$PWD, same lookup as \`[models]\`, \`[timeouts]\`, \`[cache.env]\`). Slots into \`resolve_profile_name\` between \`NAUTILOOP_PROFILE\` env and \`current_profile\`.

Resolution chain:
1. \`--profile\` flag
2. \`NAUTILOOP_PROFILE\` env var
3. \`[profile] name\` from \`./nemo.toml\` ← **new**
4. \`current_profile\` in \`~/.nemo/config.toml\`

A repo pin naming an unknown profile is a hard error — silent fallthrough would mask typos in a checked-in file. Empty / whitespace values filter to \`None\` to match env-var semantics.

\`nemo.toml\` committed at the repo root pins this checkout to \`dev\` (matches the profile \`dev/setup.sh\` creates after a fresh k3d setup).

## Files

- \`cli/src/project_config.rs\` — \`ProfileSection\`, \`load_project_profile_pin\`, \`current_repo_pin()\` helper
- \`cli/src/config.rs\` — \`resolve_profile_name\` and \`active_profile\` gain \`repo_pin\` parameter
- \`cli/src/main.rs\` + \`cli/src/commands/{config,profile}.rs\` — pass \`current_repo_pin()\` through every call site
- \`nemo.toml\` (new) — pins this repo to the \`dev\` profile

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --workspace --lib --bins\` (140 passed; +9 new tests covering loader paths and resolver precedence)
- [x] Manual: \`nemo use-profile personal\` then \`nemo config --get current_profile\` from this repo returns \`dev\` (the pin), and \`nemo profile show\` shows the dev cluster — confirming the pin overrides the global active without disturbing it.
- [ ] Post-merge: cut v0.7.17 via \`/release\`