### PR TITLE
fix(sidecar): unify max_tokens → max_output_tokens rewrite for /v1/responses

### DIFF
--- a/sidecar/src/model_proxy.rs
+++ b/sidecar/src/model_proxy.rs
@@ -1119,20 +1119,31 @@ const DEFAULT_INSTRUCTIONS: &str = "Follow the instructions provided in the inpu
 ///
 /// Always: inject `"instructions"` if absent.
 ///
-/// Token-limit field name depends on the upstream:
-///   - `chatgpt.com/backend-api/codex/responses` expects the legacy
-///     `max_tokens` and rejects `max_output_tokens`.
-///   - `api.openai.com/v1/responses` expects `max_output_tokens` and
-///     rejects `max_tokens`.
+/// Token-limit field: `max_output_tokens` for both upstreams.
 ///
-/// Clients (opencode ≤1.3.17) can't tell which upstream the sidecar
-/// routes to and emit whichever name their internal routing picks.
-/// We rewrite symmetrically so the body always matches the upstream:
-///   - Codex OAuth path: `max_output_tokens` → `max_tokens`.
-///   - Api-key path: `max_tokens` → `max_output_tokens`.
+/// **History.** v0.5.x (commit 9711e86) added a CodexOauth-specific
+/// inverted rename — `max_output_tokens → max_tokens` — under the
+/// belief that `chatgpt.com/backend-api/codex/responses` required the
+/// legacy `max_tokens` name. That was true at the time. OpenAI has
+/// since unified the wire format across `api.openai.com/v1/responses`
+/// and the chatgpt-codex endpoint; both now require
+/// `max_output_tokens` and reject `max_tokens` with `Bad Request:
+/// {"detail":"Unsupported parameter: max_tokens"}`. The previously
+/// "necessary" inverted rename became the regression.
+///
+/// We now rewrite `max_tokens → max_output_tokens` regardless of
+/// credential type. Clients (opencode ≤1.3.17) emit either name and
+/// can't tell which upstream the sidecar routes to; the sidecar
+/// normalizes once before forwarding so neither client nor server has
+/// to care.
+///
+/// `is_codex_oauth` is retained in the signature because the body
+/// patch may yet need to diverge by upstream (e.g. an
+/// account-id-bearing header) — but as of this fix it's a no-op
+/// distinguisher and both branches do the same thing.
 ///
 /// Returns the original bytes unchanged if the body is not valid JSON.
-fn patch_responses_body(bytes: Bytes, is_codex_oauth: bool) -> Bytes {
+fn patch_responses_body(bytes: Bytes, _is_codex_oauth: bool) -> Bytes {
     let Ok(mut payload) =
         serde_json::from_slice::<serde_json::Map<String, serde_json::Value>>(&bytes)
     else {
@@ -1146,12 +1157,12 @@ fn patch_responses_body(bytes: Bytes, is_codex_oauth: bool) -> Bytes {
         );
         modified = true;
     }
-    if is_codex_oauth {
-        if let Some(v) = payload.remove("max_output_tokens") {
-            payload.insert("max_tokens".to_string(), v);
-            modified = true;
-        }
-    } else if let Some(v) = payload.remove("max_tokens") {
+    if let Some(v) = payload.remove("max_tokens") {
+        // `insert` overwrites any pre-existing `max_output_tokens`,
+        // which is the right behavior when both names appear in the
+        // same body (some opencode versions hedge by sending both).
+        // The two values are intended to mean the same thing; an
+        // explicit operator-set max_tokens wins.
         payload.insert("max_output_tokens".to_string(), v);
         modified = true;
     }
@@ -1618,12 +1629,27 @@ mod tests {
     }
 
     #[test]
-    fn test_codex_oauth_renames_max_output_tokens() {
+    fn test_codex_oauth_renames_max_tokens_to_max_output_tokens() {
+        // chatgpt.com/backend-api/codex/responses now uses the same
+        // `max_output_tokens` field name as api.openai.com/v1/responses;
+        // a bare `max_tokens` is rejected. v0.7.18 unified the rewrite
+        // so the CodexOauth path no longer keeps the legacy name.
+        let input = br#"{"model":"gpt-5.4","input":"review","max_tokens":4096}"#;
+        let result = patch_responses_body(Bytes::from_static(input), true);
+        let out: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        assert_eq!(out["max_output_tokens"], 4096);
+        assert!(out.get("max_tokens").is_none());
+    }
+
+    #[test]
+    fn test_codex_oauth_preserves_max_output_tokens() {
+        // Already in the modern shape — the patch has nothing to do
+        // for the token field.
         let input = br#"{"model":"gpt-5.4","input":"review","max_output_tokens":4096}"#;
         let result = patch_responses_body(Bytes::from_static(input), true);
         let out: serde_json::Value = serde_json::from_slice(&result).unwrap();
-        assert_eq!(out["max_tokens"], 4096);
-        assert!(out.get("max_output_tokens").is_none());
+        assert_eq!(out["max_output_tokens"], 4096);
+        assert!(out.get("max_tokens").is_none());
     }
 
     #[test]
@@ -1642,6 +1668,28 @@ mod tests {
         // rewrites it so api-key callers don't need a version-specific client.
         let input = br#"{"model":"gpt-5.4","input":"review","max_tokens":4096}"#;
         let result = patch_responses_body(Bytes::from_static(input), false);
+        let out: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        assert_eq!(out["max_output_tokens"], 4096);
+        assert!(out.get("max_tokens").is_none());
+    }
+
+    #[test]
+    fn test_both_token_fields_max_tokens_wins() {
+        // Some opencode builds send both names in the same body. The
+        // patch removes max_tokens and inserts max_output_tokens with
+        // its value, overwriting any pre-existing max_output_tokens.
+        // This is the right call: an operator who explicitly set
+        // max_tokens almost certainly meant THAT value, and the two
+        // fields are supposed to mean the same thing.
+        let input =
+            br#"{"model":"gpt-5.4","input":"review","max_tokens":4096,"max_output_tokens":2048}"#;
+        let result = patch_responses_body(Bytes::from_static(input), false);
+        let out: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        assert_eq!(out["max_output_tokens"], 4096);
+        assert!(out.get("max_tokens").is_none());
+
+        // Same on the codex-oauth route.
+        let result = patch_responses_body(Bytes::from_static(input), true);
         let out: serde_json::Value = serde_json::from_slice(&result).unwrap();
         assert_eq!(out["max_output_tokens"], 4096);
         assert!(out.get("max_tokens").is_none());

--- a/sidecar/tests/model_proxy_e2e.rs
+++ b/sidecar/tests/model_proxy_e2e.rs
@@ -256,9 +256,16 @@ async fn test_api_key_injects_instructions() {
 
 /// POST /openai/v1/responses with a CodexOauth credential.
 ///
-/// Assert: `instructions` injected, `max_output_tokens` renamed to
-/// `max_tokens`, Content-Length absent, Authorization = Bearer <access>,
-/// chatgpt-account-id header present.
+/// Assert: `instructions` injected, body's token field is
+/// `max_output_tokens` (regardless of whether the client sent
+/// `max_tokens` or `max_output_tokens`), Authorization = Bearer
+/// <access>, chatgpt-account-id header present.
+///
+/// v0.7.18 unified the rename: chatgpt.com/backend-api/codex/responses
+/// now requires `max_output_tokens` like api.openai.com does. The old
+/// inverted rename (max_output_tokens → max_tokens for CodexOauth) was
+/// the regression that surfaced as `Bad Request: {"detail":"Unsupported
+/// parameter: max_tokens"}`.
 #[tokio::test]
 async fn test_codex_oauth_patches_body() {
     let tmp = tempfile::tempdir().expect("tempdir");
@@ -277,10 +284,12 @@ async fn test_codex_oauth_patches_body() {
     })
     .await;
 
+    // Send `max_tokens` — the legacy name. The sidecar must rewrite to
+    // `max_output_tokens` even on the codex-oauth route.
     let (status, _body) = post(
         proxy_addr,
         "/openai/v1/responses",
-        r#"{"model":"gpt-5.4","input":"review","max_output_tokens":4096}"#,
+        r#"{"model":"gpt-5.4","input":"review","max_tokens":4096}"#,
     )
     .await;
     assert_eq!(status, 200);
@@ -312,7 +321,7 @@ async fn test_codex_oauth_patches_body() {
         );
     }
 
-    // Body: instructions injected, max_tokens renamed, max_output_tokens gone
+    // Body: instructions injected, max_tokens rewritten to max_output_tokens.
     let body: serde_json::Value =
         serde_json::from_slice(&req.body).expect("upstream body must be JSON");
     assert!(
@@ -320,13 +329,13 @@ async fn test_codex_oauth_patches_body() {
         "instructions must be injected: {body}"
     );
     assert_eq!(
-        body.get("max_tokens").and_then(|v| v.as_u64()),
+        body.get("max_output_tokens").and_then(|v| v.as_u64()),
         Some(4096),
-        "max_tokens must be 4096 after rename: {body}"
+        "max_output_tokens must be 4096 after rename: {body}"
     );
     assert!(
-        body.get("max_output_tokens").is_none(),
-        "max_output_tokens must be removed: {body}"
+        body.get("max_tokens").is_none(),
+        "max_tokens must be removed: {body}"
     );
 }
 


### PR DESCRIPTION
## Summary

P0. Real fix this time. v0.7.13/.14/.15/.16/.17 all shipped with this regression for any operator using opencode's ChatGPT OAuth bundle. Every audit stage failed at:

\`\`\`
Bad Request: {"detail":"Unsupported parameter: max_tokens"}
endpoint: http://localhost:9090/openai/v1/responses
\`\`\`

v0.7.16's \`/health\` skew-detection was a useful diagnostic but was not the underlying fix. With v0.7.16 confirmed deployed (all three images at the same tag) the audit still failed — proving the bug lived in code, not in deploy skew.

## Root cause

Commit \`9711e86\` (fix(sidecar): rename max_output_tokens to max_tokens for CodexOauth requests, #121) added an inverted rename under the assumption that \`chatgpt.com/backend-api/codex/responses\` required the legacy \`max_tokens\` field name. That was true at the time. OpenAI has since unified the Responses wire format across both \`api.openai.com/v1/responses\` and \`chatgpt.com/backend-api/codex/responses\`; both now require \`max_output_tokens\` and reject \`max_tokens\` with the error above. The "necessary" inverted rename became the regression.

Operators with an api-key (\`OpenAiCredential::ApiKey\`) were unaffected because the patch correctly renames for that path. Anyone using opencode's ChatGPT OAuth (the default for free-tier inference) hit it on every audit.

## The fix

Drop the CodexOauth-specific inverted rename. Always rewrite \`max_tokens → max_output_tokens\` for \`/v1/responses\`, regardless of credential type.

\`is_codex_oauth\` is retained in the function signature — it may yet need to diverge by upstream (e.g. an account-id-bearing header) — but as of this fix both branches do the same thing.

## Test plan
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --workspace --lib --bins\` (140 CLI + 105 sidecar unit, all green)
- [x] \`cargo test -p nautiloop-sidecar --features __test_utils --test model_proxy_e2e\` (5 e2e tests, including updated \`test_codex_oauth_patches_body\` which posts \`max_tokens\` to \`/openai/v1/responses\` with a CodexOauth credential and asserts the upstream-bound body has \`max_output_tokens\`)
- [x] New unit test \`test_codex_oauth_renames_max_tokens_to_max_output_tokens\` covering the failing case directly
- [x] New unit test \`test_both_token_fields_max_tokens_wins\` documenting both-fields resolution
- [ ] Post-merge: cut v0.7.18, redeploy, repro the user's failed audit and confirm it now reaches at least the model call.