### PR TITLE
chore: release 0.7.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-control-plane"
-version = "0.7.17"
+version = "0.7.18"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-sidecar"
-version = "0.7.17"
+version = "0.7.18"
 dependencies = [
  "bytes",
  "chrono",
@@ -2692,7 +2692,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-cli"
-version = "0.7.17"
+version = "0.7.18"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["control-plane", "cli", "sidecar"]
 
 [workspace.package]
-version = "0.7.17"
+version = "0.7.18"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -65,9 +65,9 @@ module "nautiloop" {
   acme_email = "me@mydomain.com"     # required if domain is set
 
   # Optional: images (defaults to latest public GHCR)
-  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.17"
-  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.17"
-  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.17"
+  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.18"
+  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.18"
+  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.18"
 }
 ```
 
@@ -83,9 +83,9 @@ module "nautiloop" {
 | `repo_ssh_private_key` | no | auto-generated | SSH deploy key. If null, generates ED25519 |
 | `domain` | no | `null` | Domain for TLS. null = HTTP on raw IP:8080 |
 | `acme_email` | no | `null` | Let's Encrypt email. Required if domain is set |
-| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.17` | Control plane image |
-| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.17` | Agent base image |
-| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.17` | Auth sidecar image |
+| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.18` | Control plane image |
+| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.18` | Agent base image |
+| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.18` | Auth sidecar image |
 | `k3s_version` | no | `v1.32.13+k3s1` | k3s version (v1.32+ required) |
 | `postgres_password` | no | auto-generated | Postgres password |
 | `postgres_volume_size` | no | `20` | Postgres volume size (Gi) |
@@ -233,9 +233,9 @@ nemo auth                    # pushes credentials (Claude, OpenAI, SSH) to clust
 ```bash
 ./build-images.sh --tag 0.2.0
 terraform apply \
-  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.17" \
-  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.17" \
-  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.17"
+  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.18" \
+  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.18" \
+  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.18"
 ```
 
 All three images must be updated together to avoid version skew.

--- a/terraform/examples/existing-server/variables.tf
+++ b/terraform/examples/existing-server/variables.tf
@@ -50,17 +50,17 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.17"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.18"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.17"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.18"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.17"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.18"
 }

--- a/terraform/examples/hetzner/variables.tf
+++ b/terraform/examples/hetzner/variables.tf
@@ -77,19 +77,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.17"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.18"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.17"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.18"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.17"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.18"
 }
 
 variable "k3s_version" {

--- a/terraform/modules/nautiloop/variables.tf
+++ b/terraform/modules/nautiloop/variables.tf
@@ -79,19 +79,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.17"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.18"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.17"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.18"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.17"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.18"
 }
 
 # --- Optional: tuning ---

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -71,19 +71,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.17"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.18"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.17"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.18"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.17"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.18"
 }
 
 variable "k3s_version" {


### PR DESCRIPTION
## Summary

P0 fix release. The actual fix for the audit-stage failure that v0.7.13/.14/.15/.16/.17 all silently shipped: \`chatgpt.com/backend-api/codex/responses\` now requires \`max_output_tokens\` like \`api.openai.com/v1/responses\` does, but the sidecar was still doing the old inverted rename to \`max_tokens\` for CodexOauth credentials. Every operator using opencode's ChatGPT OAuth bundle hit it on every audit.

v0.7.16 surfaced image-tag visibility on \`/health\` to rule out deploy skew, but the underlying bug lived in code, not in deployment. With v0.7.16 confirmed deployed (all three images at the same tag) the audit still failed — exposing the real regression.

- fix(sidecar): unify \`max_tokens → max_output_tokens\` rewrite for \`/v1/responses\`, regardless of credential type. Drops the inverted rename added in #121 that's now wrong. (#219)

## Test plan
- [x] \`cargo fmt --all --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --workspace --lib --bins\` (140 CLI + 105 sidecar unit, all green)
- [x] \`cargo test -p nautiloop-sidecar --features __test_utils\` (5 e2e tests, including updated \`test_codex_oauth_patches_body\` covering the failing case)
- [ ] Operator smoke after release ships: redeploy, repro the failed audit, confirm it now reaches the model call.