### PR TITLE
fix(sidecar): strip token-limit fields on chatgpt-codex /responses route

### DIFF
--- a/sidecar/src/model_proxy.rs
+++ b/sidecar/src/model_proxy.rs
@@ -1119,31 +1119,40 @@ const DEFAULT_INSTRUCTIONS: &str = "Follow the instructions provided in the inpu
 ///
 /// Always: inject `"instructions"` if absent.
 ///
-/// Token-limit field: `max_output_tokens` for both upstreams.
+/// Token-limit field handling depends on the upstream:
 ///
-/// **History.** v0.5.x (commit 9711e86) added a CodexOauth-specific
-/// inverted rename — `max_output_tokens → max_tokens` — under the
-/// belief that `chatgpt.com/backend-api/codex/responses` required the
-/// legacy `max_tokens` name. That was true at the time. OpenAI has
-/// since unified the wire format across `api.openai.com/v1/responses`
-/// and the chatgpt-codex endpoint; both now require
-/// `max_output_tokens` and reject `max_tokens` with `Bad Request:
-/// {"detail":"Unsupported parameter: max_tokens"}`. The previously
-/// "necessary" inverted rename became the regression.
+/// - **api.openai.com/v1/responses** (api-key path): expects
+///   `max_output_tokens`. We rename `max_tokens → max_output_tokens`
+///   so opencode/codex clients that emit either name reach the
+///   upstream with the modern field.
 ///
-/// We now rewrite `max_tokens → max_output_tokens` regardless of
-/// credential type. Clients (opencode ≤1.3.17) emit either name and
-/// can't tell which upstream the sidecar routes to; the sidecar
-/// normalizes once before forwarding so neither client nor server has
-/// to care.
+/// - **chatgpt.com/backend-api/codex/responses** (CodexOauth path):
+///   does not accept any token-limit field on the request. Verified
+///   two ways:
+///     1. Direct probe (curl through the sidecar) returned 400
+///        `{"detail":"Unsupported parameter: <field>"}` for every
+///        name tried (`max_tokens`, `max_output_tokens`,
+///        `max_completion_tokens`, `max_response_output_tokens`,
+///        `max_response_tokens`, `response_max_tokens`,
+///        `output_tokens`); only the no-field body returned 200.
+///     2. The OpenAI Codex CLI's own bug tracker confirms it —
+///        `openai/codex#4138` reports that `model_max_output_tokens`
+///        in `~/.codex/config.toml` is a no-op because the CLI never
+///        sends a token-limit field on this endpoint.
+///   We strip both `max_tokens` and `max_output_tokens`; the upstream
+///   applies its own default.
 ///
-/// `is_codex_oauth` is retained in the signature because the body
-/// patch may yet need to diverge by upstream (e.g. an
-/// account-id-bearing header) — but as of this fix it's a no-op
-/// distinguisher and both branches do the same thing.
+/// **History.** v0.5.x (commit 9711e86) added an inverted rename
+/// `max_output_tokens → max_tokens` for CodexOauth under the (then
+/// correct) assumption that chatgpt codex required the legacy
+/// `max_tokens` name. v0.7.18 swung the other way and renamed
+/// uniformly to `max_output_tokens`, which moved the symptom from
+/// `Unsupported parameter: max_tokens` to `Unsupported parameter:
+/// max_output_tokens`. v0.7.19 verified via direct probe that
+/// chatgpt codex accepts no field — the right move is to strip.
 ///
 /// Returns the original bytes unchanged if the body is not valid JSON.
-fn patch_responses_body(bytes: Bytes, _is_codex_oauth: bool) -> Bytes {
+fn patch_responses_body(bytes: Bytes, is_codex_oauth: bool) -> Bytes {
     let Ok(mut payload) =
         serde_json::from_slice::<serde_json::Map<String, serde_json::Value>>(&bytes)
     else {
@@ -1157,12 +1166,21 @@ fn patch_responses_body(bytes: Bytes, _is_codex_oauth: bool) -> Bytes {
         );
         modified = true;
     }
-    if let Some(v) = payload.remove("max_tokens") {
-        // `insert` overwrites any pre-existing `max_output_tokens`,
-        // which is the right behavior when both names appear in the
-        // same body (some opencode versions hedge by sending both).
-        // The two values are intended to mean the same thing; an
-        // explicit operator-set max_tokens wins.
+    if is_codex_oauth {
+        // chatgpt codex rejects every token-limit field we know about.
+        // Strip both names — the endpoint applies its own default.
+        if payload.remove("max_tokens").is_some() {
+            modified = true;
+        }
+        if payload.remove("max_output_tokens").is_some() {
+            modified = true;
+        }
+    } else if let Some(v) = payload.remove("max_tokens") {
+        // api.openai.com path: rename to the modern name. `insert`
+        // overwrites any pre-existing `max_output_tokens` so a body
+        // hedging with both names lands with a single canonical
+        // value (the explicit `max_tokens` wins, since the two are
+        // semantically the same).
         payload.insert("max_output_tokens".to_string(), v);
         modified = true;
     }
@@ -1629,27 +1647,41 @@ mod tests {
     }
 
     #[test]
-    fn test_codex_oauth_renames_max_tokens_to_max_output_tokens() {
-        // chatgpt.com/backend-api/codex/responses now uses the same
-        // `max_output_tokens` field name as api.openai.com/v1/responses;
-        // a bare `max_tokens` is rejected. v0.7.18 unified the rewrite
-        // so the CodexOauth path no longer keeps the legacy name.
+    fn test_codex_oauth_strips_max_tokens() {
+        // Verified via direct probe (2026-04): chatgpt.com codex's
+        // /backend-api/codex/responses endpoint rejects max_tokens,
+        // max_output_tokens, max_completion_tokens, and every other
+        // token-limit name we tested. It accepts the request only when
+        // no such field is present. Strip rather than rename.
         let input = br#"{"model":"gpt-5.4","input":"review","max_tokens":4096}"#;
         let result = patch_responses_body(Bytes::from_static(input), true);
         let out: serde_json::Value = serde_json::from_slice(&result).unwrap();
-        assert_eq!(out["max_output_tokens"], 4096);
         assert!(out.get("max_tokens").is_none());
+        assert!(out.get("max_output_tokens").is_none());
     }
 
     #[test]
-    fn test_codex_oauth_preserves_max_output_tokens() {
-        // Already in the modern shape — the patch has nothing to do
-        // for the token field.
+    fn test_codex_oauth_strips_max_output_tokens() {
+        // Same upstream constraint applies in the modern-shape direction.
         let input = br#"{"model":"gpt-5.4","input":"review","max_output_tokens":4096}"#;
         let result = patch_responses_body(Bytes::from_static(input), true);
         let out: serde_json::Value = serde_json::from_slice(&result).unwrap();
-        assert_eq!(out["max_output_tokens"], 4096);
         assert!(out.get("max_tokens").is_none());
+        assert!(out.get("max_output_tokens").is_none());
+    }
+
+    #[test]
+    fn test_codex_oauth_strips_both_when_both_present() {
+        // Hedging body shape — strip both, leave the model and input
+        // alone so the request still validates.
+        let input =
+            br#"{"model":"gpt-5.4","input":"review","max_tokens":4096,"max_output_tokens":2048}"#;
+        let result = patch_responses_body(Bytes::from_static(input), true);
+        let out: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        assert!(out.get("max_tokens").is_none());
+        assert!(out.get("max_output_tokens").is_none());
+        assert_eq!(out["model"], "gpt-5.4");
+        assert_eq!(out["input"], "review");
     }
 
     #[test]
@@ -1674,22 +1706,12 @@ mod tests {
     }
 
     #[test]
-    fn test_both_token_fields_max_tokens_wins() {
-        // Some opencode builds send both names in the same body. The
-        // patch removes max_tokens and inserts max_output_tokens with
-        // its value, overwriting any pre-existing max_output_tokens.
-        // This is the right call: an operator who explicitly set
-        // max_tokens almost certainly meant THAT value, and the two
-        // fields are supposed to mean the same thing.
+    fn test_non_codex_oauth_both_fields_max_tokens_wins() {
+        // Api-key path with both names: keep the modern field name,
+        // use max_tokens' value (semantically the same; explicit wins).
         let input =
             br#"{"model":"gpt-5.4","input":"review","max_tokens":4096,"max_output_tokens":2048}"#;
         let result = patch_responses_body(Bytes::from_static(input), false);
-        let out: serde_json::Value = serde_json::from_slice(&result).unwrap();
-        assert_eq!(out["max_output_tokens"], 4096);
-        assert!(out.get("max_tokens").is_none());
-
-        // Same on the codex-oauth route.
-        let result = patch_responses_body(Bytes::from_static(input), true);
         let out: serde_json::Value = serde_json::from_slice(&result).unwrap();
         assert_eq!(out["max_output_tokens"], 4096);
         assert!(out.get("max_tokens").is_none());

--- a/sidecar/tests/model_proxy_e2e.rs
+++ b/sidecar/tests/model_proxy_e2e.rs
@@ -256,16 +256,18 @@ async fn test_api_key_injects_instructions() {
 
 /// POST /openai/v1/responses with a CodexOauth credential.
 ///
-/// Assert: `instructions` injected, body's token field is
-/// `max_output_tokens` (regardless of whether the client sent
-/// `max_tokens` or `max_output_tokens`), Authorization = Bearer
-/// <access>, chatgpt-account-id header present.
+/// Assert: `instructions` injected, both `max_tokens` and
+/// `max_output_tokens` STRIPPED from the body (chatgpt codex rejects
+/// every token-limit field name; the endpoint accepts the request only
+/// when no such field is present), Authorization = Bearer <access>,
+/// chatgpt-account-id header present.
 ///
-/// v0.7.18 unified the rename: chatgpt.com/backend-api/codex/responses
-/// now requires `max_output_tokens` like api.openai.com does. The old
-/// inverted rename (max_output_tokens → max_tokens for CodexOauth) was
-/// the regression that surfaced as `Bad Request: {"detail":"Unsupported
-/// parameter: max_tokens"}`.
+/// **v0.7.19 corrects v0.7.18.** v0.7.18 thought renaming to
+/// `max_output_tokens` would work; the actual chatgpt-codex endpoint
+/// then returned `Bad Request: {"detail":"Unsupported parameter:
+/// max_output_tokens"}`. Direct probe (curl through the running sidecar
+/// against chatgpt-codex) confirmed every plausible token-limit name
+/// is rejected. Stripping is the only request body that gets accepted.
 #[tokio::test]
 async fn test_codex_oauth_patches_body() {
     let tmp = tempfile::tempdir().expect("tempdir");
@@ -284,8 +286,8 @@ async fn test_codex_oauth_patches_body() {
     })
     .await;
 
-    // Send `max_tokens` — the legacy name. The sidecar must rewrite to
-    // `max_output_tokens` even on the codex-oauth route.
+    // Send `max_tokens` — the legacy name. The sidecar must STRIP it
+    // entirely on the codex-oauth route (not rename).
     let (status, _body) = post(
         proxy_addr,
         "/openai/v1/responses",
@@ -321,21 +323,20 @@ async fn test_codex_oauth_patches_body() {
         );
     }
 
-    // Body: instructions injected, max_tokens rewritten to max_output_tokens.
+    // Body: instructions injected, BOTH token-limit fields stripped.
     let body: serde_json::Value =
         serde_json::from_slice(&req.body).expect("upstream body must be JSON");
     assert!(
         body.get("instructions").is_some(),
         "instructions must be injected: {body}"
     );
-    assert_eq!(
-        body.get("max_output_tokens").and_then(|v| v.as_u64()),
-        Some(4096),
-        "max_output_tokens must be 4096 after rename: {body}"
+    assert!(
+        body.get("max_output_tokens").is_none(),
+        "max_output_tokens must be stripped on codex-oauth route: {body}"
     );
     assert!(
         body.get("max_tokens").is_none(),
-        "max_tokens must be removed: {body}"
+        "max_tokens must be stripped on codex-oauth route: {body}"
     );
 }
 


### PR DESCRIPTION
## Summary

Real fix this time, with sources, not guessing.

v0.7.18 renamed \`max_tokens → max_output_tokens\` for the CodexOauth path. Symptom moved from \`Unsupported parameter: max_tokens\` to \`Unsupported parameter: max_output_tokens\`, same hard 400.

## Verified contract (three sources, all aligned)

**1. OpenAI Codex CLI source — the canonical client for this endpoint.** [`codex-rs/core/src/client.rs#L879-L900`](https://github.com/openai/codex/blob/main/codex-rs/core/src/client.rs#L879). The `ResponsesApiRequest` struct OpenAI's own CLI sends to \`chatgpt.com/backend-api/codex/responses\` has these fields:

\`\`\`
model, instructions, input, tools, tool_choice, parallel_tool_calls,
reasoning, store, stream, include, service_tier, prompt_cache_key,
text, client_metadata
\`\`\`

**No token-limit field of any kind.** OpenAI's own client never sends max_tokens / max_output_tokens / max_completion_tokens on this endpoint.

**2. OpenAI Codex CLI bug tracker** ([openai/codex#4138](https://github.com/openai/codex/issues/4138)): *"When users add the config item \`model_max_output_tokens\` in config.toml, the GPT responses API request should use the config, but there's no field for 'max_output_tokens' in the responses api request body."* The CLI's own config option for it is a no-op for exactly this reason.

**3. Direct probe** through the running sidecar against the live endpoint:

| field | response |
| --- | --- |
| max_tokens | 400 \`Unsupported parameter: max_output_tokens\` (after sidecar's v0.7.18 rename) |
| max_output_tokens | 400 \`Unsupported parameter: max_output_tokens\` |
| max_completion_tokens | 400 \`Unsupported parameter: max_completion_tokens\` |
| max_response_output_tokens | 400 \`Unsupported parameter: max_response_output_tokens\` |
| max_response_tokens | 400 \`Unsupported parameter: max_response_tokens\` |
| response_max_tokens | 400 \`Unsupported parameter: response_max_tokens\` |
| output_tokens | 400 \`Unsupported parameter: output_tokens\` |
| (none) | **200 OK** |

## The fix

When \`is_codex_oauth=true\`, strip both \`max_tokens\` and \`max_output_tokens\` from the request body. Let upstream apply its default. The api-key path (api.openai.com) keeps the existing \`max_tokens → max_output_tokens\` rename — that path's contract uses \`max_output_tokens\` and is correct.

## Test plan
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test -p nautiloop-sidecar --features __test_utils\` (105 unit + 5 e2e, all green)
- [x] New unit tests: \`test_codex_oauth_strips_max_tokens\`, \`test_codex_oauth_strips_max_output_tokens\`, \`test_codex_oauth_strips_both_when_both_present\`
- [x] Updated integration test \`test_codex_oauth_patches_body\` to assert stripping
- [ ] Post-merge: cut v0.7.19, redeploy, repro the user's failed audit and confirm it now reaches the model call.