### PR TITLE
chore: release 0.7.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-control-plane"
-version = "0.7.18"
+version = "0.7.19"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-sidecar"
-version = "0.7.18"
+version = "0.7.19"
 dependencies = [
  "bytes",
  "chrono",
@@ -2692,7 +2692,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-cli"
-version = "0.7.18"
+version = "0.7.19"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["control-plane", "cli", "sidecar"]
 
 [workspace.package]
-version = "0.7.18"
+version = "0.7.19"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -65,9 +65,9 @@ module "nautiloop" {
   acme_email = "me@mydomain.com"     # required if domain is set
 
   # Optional: images (defaults to latest public GHCR)
-  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.18"
-  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.18"
-  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.18"
+  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.19"
+  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.19"
+  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.19"
 }
 ```
 
@@ -83,9 +83,9 @@ module "nautiloop" {
 | `repo_ssh_private_key` | no | auto-generated | SSH deploy key. If null, generates ED25519 |
 | `domain` | no | `null` | Domain for TLS. null = HTTP on raw IP:8080 |
 | `acme_email` | no | `null` | Let's Encrypt email. Required if domain is set |
-| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.18` | Control plane image |
-| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.18` | Agent base image |
-| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.18` | Auth sidecar image |
+| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.19` | Control plane image |
+| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.19` | Agent base image |
+| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.19` | Auth sidecar image |
 | `k3s_version` | no | `v1.32.13+k3s1` | k3s version (v1.32+ required) |
 | `postgres_password` | no | auto-generated | Postgres password |
 | `postgres_volume_size` | no | `20` | Postgres volume size (Gi) |
@@ -233,9 +233,9 @@ nemo auth                    # pushes credentials (Claude, OpenAI, SSH) to clust
 ```bash
 ./build-images.sh --tag 0.2.0
 terraform apply \
-  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.18" \
-  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.18" \
-  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.18"
+  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.19" \
+  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.19" \
+  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.19"
 ```
 
 All three images must be updated together to avoid version skew.

--- a/terraform/examples/existing-server/variables.tf
+++ b/terraform/examples/existing-server/variables.tf
@@ -50,17 +50,17 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.18"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.19"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.18"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.19"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.18"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.19"
 }

--- a/terraform/examples/hetzner/variables.tf
+++ b/terraform/examples/hetzner/variables.tf
@@ -77,19 +77,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.18"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.19"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.18"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.19"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.18"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.19"
 }
 
 variable "k3s_version" {

--- a/terraform/modules/nautiloop/variables.tf
+++ b/terraform/modules/nautiloop/variables.tf
@@ -79,19 +79,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.18"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.19"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.18"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.19"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.18"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.19"
 }
 
 # --- Optional: tuning ---

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -71,19 +71,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.18"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.19"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.18"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.19"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.18"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.19"
 }
 
 variable "k3s_version" {


### PR DESCRIPTION
## Summary

Verified-against-source fix for the audit-stage failure that v0.7.13 through v0.7.18 silently shipped: \`chatgpt.com/backend-api/codex/responses\` accepts no token-limit field, period.

v0.7.18 thought the right move was renaming \`max_tokens → max_output_tokens\`; the symptom moved from \`Unsupported parameter: max_tokens\` to \`Unsupported parameter: max_output_tokens\`. This release verifies the actual contract three independent ways before changing behavior:

1. **[OpenAI Codex CLI source](https://github.com/openai/codex/blob/main/codex-rs/core/src/client.rs#L879)** — the \`ResponsesApiRequest\` struct OpenAI's own client sends has no token-limit field at all.
2. **[openai/codex#4138](https://github.com/openai/codex/issues/4138)** — confirms the \`model_max_output_tokens\` config knob is parsed but never sent (a known no-op).
3. **Direct probe** through the running sidecar — every plausible field name returns 400 \`Unsupported parameter\`; only no-field returns 200.

Strip both \`max_tokens\` and \`max_output_tokens\` on the CodexOauth path. The api-key path (api.openai.com) keeps the existing \`max_tokens → max_output_tokens\` rename, which is correct there.

- fix(sidecar): strip token-limit fields on chatgpt-codex /responses route (#221)

## Test plan
- [x] \`cargo fmt --all --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test -p nautiloop-sidecar --features __test_utils\` (105 unit + 5 e2e, all green)
- [x] Three independent verification sources documented above
- [ ] Operator smoke after release ships: redeploy, repro the failed audit, confirm it now reaches the model call.