### PR TITLE
fix(agent): drop opencode -s session resume + guard empty stdout

### DIFF
--- a/images/base/nautiloop-agent-entry
+++ b/images/base/nautiloop-agent-entry
@@ -219,6 +219,38 @@ run_and_emit_result() {
     exit_code=$?
     set -e
 
+    # Guard: a successful exit with empty stdout is a verdict-channel
+    # failure dressed up as success. The downstream jq pipeline's
+    # rawfile fallback would otherwise emit `data:""`, the control
+    # plane would treat that as a malformed verdict, and after
+    # MAX_MALFORMED_VERDICT_RETRIES (driver.rs:1880-1908) the whole
+    # loop terminates as FAILED with no actionable signal in the logs.
+    # Surface it as an explicit error envelope so the operator sees
+    # exactly what happened and the loop engine can react with the
+    # standard failure path.
+    #
+    # Concrete trigger: opencode v1.3.x's `run --format json -s
+    # <ses_...>` resume invocation has been observed to exit 0 with
+    # zero bytes on stdout. The fix for that case is to stop passing
+    # `-s` (see the audit/review branch above), but this guard
+    # catches any future regression of the same shape from any CLI.
+    if [ "$exit_code" -eq 0 ] && [ ! -s "$cli_stdout" ]; then
+        local stderr_tail
+        stderr_tail=$(tail -c 5000 "$cli_stderr" 2>/dev/null || echo "")
+        local result
+        result=$(jq -nc \
+            --arg stage "$stage_name" \
+            --arg cli "$cli_cmd" \
+            --arg stderr "$stderr_tail" \
+            '{stage: $stage, data: {exit_code: 0, error: "CLI exited 0 with empty stdout — no verdict emitted. CLI=\($cli). stderr_tail=\($stderr)"}}')
+        echo "$result" > /output/result.json
+        echo "NAUTILOOP_RESULT:$result"
+        # Exit non-zero so the K8s Job is marked Failed and the loop
+        # engine reads `failed_from_state` cleanly. The verdict is
+        # already in /output/result.json for forensic capture.
+        exit 1
+    fi
+
     if [ "$exit_code" -ne 0 ]; then
         local stderr_tail stdout_tail
         stderr_tail=$(tail -c 5000 "$cli_stderr" 2>/dev/null || echo "")
@@ -525,11 +557,28 @@ case "$STAGE" in
                 esac
 
                 OPENCODE_ARGS=(run --format json -m "$OPENCODE_MODEL")
-                # Only resume an opencode ses_ session, not a Claude UUID.
-                if [ -n "${SESSION_ID:-}" ] && \
-                   printf '%s' "$SESSION_ID" | grep -Eq '^ses_[a-zA-Z0-9]+$'; then
-                    OPENCODE_ARGS+=(-s "$SESSION_ID")
-                fi
+                # NOTE: we deliberately do NOT pass `-s "$SESSION_ID"` here.
+                #
+                # opencode v1.3.x's `run --format json -s <ses_...>` resumed
+                # invocation has been observed to exit successfully with
+                # *zero bytes on stdout* — no events, no result, no error.
+                # The agent entrypoint then falls through to the rawfile
+                # branch and emits `NAUTILOOP_RESULT:{"stage":"audit",
+                # "data":""}`, the control plane fails to parse an
+                # AuditVerdict, malformed-verdict retries kick in, and the
+                # whole harden loop terminates as FAILED on round 2's
+                # audit even though round 1 audited cleanly.
+                #
+                # We don't need opencode's conversational memory across
+                # rounds: revise/rN already writes the updated spec to the
+                # branch worktree, and the next audit/rN+1 reads that
+                # revised spec from disk via the prompt template. Losing
+                # session continuation costs some tokens (no prompt-cache
+                # hit) but is correct and unblocks convergence. If/when
+                # opencode's resumed-stdout bug is fixed upstream we can
+                # revisit. (see PR #223 for the regression and #4138 on
+                # the openai/codex side for an unrelated but adjacent
+                # opencode/codex output-channel quirk.)
                 # Read prompt and truncate if extremely large to avoid ARG_MAX
                 PROMPT_CONTENT=$(cat "$PROMPT_FILE")
                 if [ "${#PROMPT_CONTENT}" -gt 100000 ]; then


### PR DESCRIPTION
## Summary

Two changes that together unblock convergence on any harden loop that goes more than one round.

## What was broken

Live repro on v0.7.19 (loop \`e3ccb544-f298-41a3-8a53-134316618bf3\`):

1. \`audit/r1\` succeeds, stores \`ses_2300f8badffe...\`
2. \`revise/r1\` succeeds (claude path with \`--resume\`, unaffected)
3. \`audit/r2\` invokes \`opencode run --format json -m openai/gpt-5.4 -s ses_2300f8badffe...\` — **the resumed process exits 0 with zero bytes on stdout**
4. The entrypoint falls through to the rawfile fallback and emits \`NAUTILOOP_RESULT:{"stage":"audit","data":""}\`
5. \`extract_nautiloop_result\` returns the empty data envelope; control plane cannot parse an AuditVerdict
6. \`handle_verdict_parse_failure\` (driver.rs:753-755) increments malformed-verdict retries
7. After \`MAX_MALFORMED_VERDICT_RETRIES\` (driver.rs:1880-1908) the loop terminates as FAILED

## Fix 1: drop \`-s "$SESSION_ID"\` for opencode audit/review

We don't actually need opencode's conversational memory across rounds. \`revise/rN\` already writes the updated spec to the branch worktree; the next \`audit/rN+1\` reads that revised spec from disk via the prompt template. Losing session continuation costs some tokens (no prompt-cache hit) but is correct and unblocks every multi-round audit.

The claude \`implement\`/\`revise\` path with \`--resume\` is unaffected — that side has been verified working across rounds.

## Fix 2: empty-stdout guard in \`run_and_emit_result\`

Independent of the opencode-specific fix: any CLI that exits 0 with no stdout is a verdict-channel failure dressed up as success. The guard emits an explicit error envelope and exits 1 so the loop engine reads \`failed_from_state\` cleanly with an actionable error message instead of \`data:""\`. Catches future regressions of the same shape from any CLI.

## Test plan
- [x] \`bash -n images/base/nautiloop-agent-entry\` — syntax OK
- [ ] Operator smoke after release ships: \`nemo harden\` against the same spec, observe audit/r2 either reaches a real verdict or surfaces a real error envelope (no more silent malformed-verdict death).
- [ ] Long-term follow-up: investigate why \`opencode run --format json -s <ses_...>\` exits 0 with empty stdout. Likely opencode v1.3.x bug; worth filing upstream.