### PR TITLE
chore: release 0.7.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-control-plane"
-version = "0.7.19"
+version = "0.7.20"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-sidecar"
-version = "0.7.19"
+version = "0.7.20"
 dependencies = [
  "bytes",
  "chrono",
@@ -2692,7 +2692,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-cli"
-version = "0.7.19"
+version = "0.7.20"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["control-plane", "cli", "sidecar"]
 
 [workspace.package]
-version = "0.7.19"
+version = "0.7.20"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -65,9 +65,9 @@ module "nautiloop" {
   acme_email = "me@mydomain.com"     # required if domain is set
 
   # Optional: images (defaults to latest public GHCR)
-  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.19"
-  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.19"
-  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.19"
+  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.20"
+  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.20"
+  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.20"
 }
 ```
 
@@ -83,9 +83,9 @@ module "nautiloop" {
 | `repo_ssh_private_key` | no | auto-generated | SSH deploy key. If null, generates ED25519 |
 | `domain` | no | `null` | Domain for TLS. null = HTTP on raw IP:8080 |
 | `acme_email` | no | `null` | Let's Encrypt email. Required if domain is set |
-| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.19` | Control plane image |
-| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.19` | Agent base image |
-| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.19` | Auth sidecar image |
+| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.20` | Control plane image |
+| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.20` | Agent base image |
+| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.20` | Auth sidecar image |
 | `k3s_version` | no | `v1.32.13+k3s1` | k3s version (v1.32+ required) |
 | `postgres_password` | no | auto-generated | Postgres password |
 | `postgres_volume_size` | no | `20` | Postgres volume size (Gi) |
@@ -233,9 +233,9 @@ nemo auth                    # pushes credentials (Claude, OpenAI, SSH) to clust
 ```bash
 ./build-images.sh --tag 0.2.0
 terraform apply \
-  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.19" \
-  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.19" \
-  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.19"
+  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.20" \
+  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.20" \
+  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.20"
 ```
 
 All three images must be updated together to avoid version skew.

--- a/terraform/examples/existing-server/variables.tf
+++ b/terraform/examples/existing-server/variables.tf
@@ -50,17 +50,17 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.19"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.20"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.19"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.20"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.19"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.20"
 }

--- a/terraform/examples/hetzner/variables.tf
+++ b/terraform/examples/hetzner/variables.tf
@@ -77,19 +77,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.19"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.20"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.19"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.20"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.19"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.20"
 }
 
 variable "k3s_version" {

--- a/terraform/modules/nautiloop/variables.tf
+++ b/terraform/modules/nautiloop/variables.tf
@@ -79,19 +79,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.19"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.20"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.19"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.20"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.19"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.20"
 }
 
 # --- Optional: tuning ---

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -71,19 +71,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.19"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.20"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.19"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.20"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.19"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.20"
 }
 
 variable "k3s_version" {


### PR DESCRIPTION
## Summary

Convergence fix. Harden loops with more than one audit round were terminating as FAILED on round 2 even when round 1 audited cleanly.

Root cause was the agent entrypoint passing \`-s <ses_...>\` to opencode on resume; opencode v1.3.x's resumed \`run --format json\` invocation exited 0 with zero bytes on stdout, the entrypoint emitted \`NAUTILOOP_RESULT:{stage:audit,data:""}\`, and the control plane's malformed-verdict retry path eventually killed the loop instead of surfacing the channel break.

- fix(agent): drop \`-s "$SESSION_ID"\` for opencode audit/review and add an empty-stdout guard so any future zero-byte verdict surfaces as an explicit error envelope instead of silent malformed-verdict death. (#223)

## Test plan
- [x] \`bash -n images/base/nautiloop-agent-entry\` (syntax OK)
- [ ] Operator smoke: \`nemo harden\` against the same spec that failed on v0.7.19, observe audit/r2 either reaches a real verdict or surfaces a real error envelope (no more silent malformed-verdict death).