### PR TITLE
fix(terraform): wire GH_TOKEN into control-plane deployments

### DIFF
--- a/terraform/modules/nautiloop/control-plane.tf
+++ b/terraform/modules/nautiloop/control-plane.tf
@@ -194,6 +194,20 @@ spec:
                 secretKeyRef:
                   name: nautiloop-git-host-token
                   key: GIT_HOST_TOKEN
+            # gh CLI requires GH_TOKEN (or GITHUB_TOKEN) for non-interactive
+            # auth — it does NOT read GIT_HOST_TOKEN. Without this, the
+            # converge_harden_clean() path's server-side `gh pr create`
+            # shellout (control-plane/src/git/mod.rs::create_pr) fails with
+            # "gh auth login required" and the harden loop wedges on
+            # repeated transient-tick retries after audit returns clean.
+            # Source the same cluster PAT the secret already holds.
+            # Mirrors dev/k8s/05-control-plane.yaml since commit 9520014;
+            # that fix never propagated into the terraform module until now.
+            - name: GH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: nautiloop-git-host-token
+                  key: GIT_HOST_TOKEN
             - name: BARE_REPO_PATH
               value: /bare-repo
             # The api-server shells out to `git fetch` against the upstream
@@ -344,6 +358,15 @@ spec:
                   name: nautiloop-postgres-credentials
                   key: DATABASE_URL
             - name: GIT_HOST_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: nautiloop-git-host-token
+                  key: GIT_HOST_TOKEN
+            # The loop engine is the one that invokes converge_harden_clean
+            # (control-plane/src/loop_engine/driver.rs:1249) and from there
+            # the server-side `gh pr create`. Same auth requirement as the
+            # api-server above. See that block for the full reasoning.
+            - name: GH_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: nautiloop-git-host-token


### PR DESCRIPTION
## Summary

Mirrors the Apr 15 dev-only fix ([commit 9520014](https://github.com/tinkrtailor/nautiloop/commit/9520014)) into the terraform module. \`dev/k8s/05-control-plane.yaml\` has had \`GH_TOKEN\` since Apr 15; the terraform module never got the same env var, so any cluster deployed via \`terraform/modules/nautiloop\` fails at server-side \`gh pr create\` once the harden audit returns clean.

## Symptom (live repro on remote v0.7.20, loop \`cab651e4-fc6c-4368-8f6a-363e19a6cb05\`)

\`\`\`
audit/r1   → success
revise/r1  → success
audit/r2   → verdict { clean: true, summary: "implementation-ready" }
converge_harden_clean() → gh pr create
  → "To get started with GitHub CLI, please run: gh auth login"
loop engine: "Transient tick error, will retry"  (forever)
\`\`\`

The harden loop wedges in HARDENING/RUNNING. No PR opened, no terminal state reached.

## Why \`GIT_HOST_TOKEN\` isn't enough

The control-plane pod has \`GIT_HOST_TOKEN\` (used for \`git push\` over SSH-via-PAT) but \`gh\` CLI does **not** read \`GIT_HOST_TOKEN\`. It requires \`GH_TOKEN\` or \`GITHUB_TOKEN\` in env (or \`gh auth login\` state, which doesn't exist on a containerized pod).

Source the same secret value (\`nautiloop-git-host-token.GIT_HOST_TOKEN\`) into a second env name so both consumers are happy.

## Applied to both deployments

- \`api-server\`: shells out to \`gh pr view\` for PR-existence checks
- \`loop-engine\`: shells out to \`gh pr create\` from \`converge_harden_clean()\` (driver.rs:1249) — this is the one that was actually wedging

## Test plan
- [x] \`terraform validate\` (module syntax)
- [ ] Operator: \`terraform apply\` against the remote cluster, then re-run the failing harden — should now reach HARDENED with the spec PR opened.