### PR TITLE
chore: release 0.7.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-control-plane"
-version = "0.7.20"
+version = "0.7.21"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "nautiloop-sidecar"
-version = "0.7.20"
+version = "0.7.21"
 dependencies = [
  "bytes",
  "chrono",
@@ -2692,7 +2692,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-cli"
-version = "0.7.20"
+version = "0.7.21"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["control-plane", "cli", "sidecar"]
 
 [workspace.package]
-version = "0.7.20"
+version = "0.7.21"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -65,9 +65,9 @@ module "nautiloop" {
   acme_email = "me@mydomain.com"     # required if domain is set
 
   # Optional: images (defaults to latest public GHCR)
-  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.20"
-  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.20"
-  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.20"
+  control_plane_image = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.21"
+  agent_base_image    = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.21"
+  sidecar_image       = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.21"
 }
 ```
 
@@ -83,9 +83,9 @@ module "nautiloop" {
 | `repo_ssh_private_key` | no | auto-generated | SSH deploy key. If null, generates ED25519 |
 | `domain` | no | `null` | Domain for TLS. null = HTTP on raw IP:8080 |
 | `acme_email` | no | `null` | Let's Encrypt email. Required if domain is set |
-| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.20` | Control plane image |
-| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.20` | Agent base image |
-| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.20` | Auth sidecar image |
+| `control_plane_image` | no | `ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.21` | Control plane image |
+| `agent_base_image` | no | `ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.21` | Agent base image |
+| `sidecar_image` | no | `ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.21` | Auth sidecar image |
 | `k3s_version` | no | `v1.32.13+k3s1` | k3s version (v1.32+ required) |
 | `postgres_password` | no | auto-generated | Postgres password |
 | `postgres_volume_size` | no | `20` | Postgres volume size (Gi) |
@@ -233,9 +233,9 @@ nemo auth                    # pushes credentials (Claude, OpenAI, SSH) to clust
 ```bash
 ./build-images.sh --tag 0.2.0
 terraform apply \
-  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.20" \
-  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.20" \
-  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.20"
+  -var="control_plane_image=ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.21" \
+  -var="agent_base_image=ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.21" \
+  -var="sidecar_image=ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.21"
 ```
 
 All three images must be updated together to avoid version skew.

--- a/terraform/examples/existing-server/variables.tf
+++ b/terraform/examples/existing-server/variables.tf
@@ -50,17 +50,17 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.20"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.21"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.20"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.21"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.20"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.21"
 }

--- a/terraform/examples/hetzner/variables.tf
+++ b/terraform/examples/hetzner/variables.tf
@@ -77,19 +77,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.20"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.21"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.20"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.21"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.20"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.21"
 }
 
 variable "k3s_version" {

--- a/terraform/modules/nautiloop/variables.tf
+++ b/terraform/modules/nautiloop/variables.tf
@@ -79,19 +79,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.20"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.21"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.20"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.21"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.20"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.21"
 }
 
 # --- Optional: tuning ---

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -71,19 +71,19 @@ variable "acme_email" {
 variable "control_plane_image" {
   description = "Control plane container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.20"
+  default     = "ghcr.io/tinkrtailor/nautiloop-control-plane:0.7.21"
 }
 
 variable "agent_base_image" {
   description = "Agent base container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.20"
+  default     = "ghcr.io/tinkrtailor/nautiloop-agent-base:0.7.21"
 }
 
 variable "sidecar_image" {
   description = "Auth sidecar container image"
   type        = string
-  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.20"
+  default     = "ghcr.io/tinkrtailor/nautiloop-sidecar:0.7.21"
 }
 
 variable "k3s_version" {


### PR DESCRIPTION
## Summary

Terraform-only fix release. Closes the last latent gap that surfaced once v0.7.20 unblocked the audit pipeline: server-side \`gh pr create\` in the \`converge_harden_clean()\` path had no \`GH_TOKEN\` on terraform-deployed clusters, so harden loops with a clean audit verdict wedged forever in \`HARDENING/RUNNING\` with no PR opened. The dev manifest fix ([commit 9520014](https://github.com/tinkrtailor/nautiloop/commit/9520014), Apr 15) had not propagated into the terraform module.

Operators **must \`terraform apply\`** with this module version to pick up the new env var. The Rust binaries are unchanged from v0.7.20; the version bump exists so a deploy at v0.7.21 cleanly signals "this includes the GH_TOKEN fix" without hidden skew.

- fix(terraform): wire GH_TOKEN into control-plane deployments (#226)

## Test plan
- [x] Module syntax validates
- [ ] Operator: \`terraform apply\` against the remote, verify both \`nautiloop-api-server\` and \`nautiloop-loop-engine\` pods now show \`GH_TOKEN\` in env, then re-run the failing harden — should reach HARDENED with the spec PR opened.